### PR TITLE
Add functionality to retrieve all clients

### DIFF
--- a/java/src/main/resources/application.properties
+++ b/java/src/main/resources/application.properties
@@ -19,7 +19,8 @@
 
 # The Apache Fineract API behind API Gateway returns 30x redirects, so we need to follow them
 quarkus.rest-client.follow-redirects=true
-quarkus.rest-client.mifosx.url=${MIFOSX_BASE_URL:https://apis.flexcore.mx/v1.0/mcp}
+#quarkus.rest-client.mifosx.url=${MIFOSX_BASE_URL:https://apis.flexcore.mx/v1.0/mcp}
+quarkus.rest-client.mifosx.url=${MIFOSX_BASE_URL:https://sandbox.mifos.community}
 mifos.basic.token=${MIFOSX_BASIC_AUTH_TOKEN:bWlmb3M6cGFzc3dvcmQ=}
 mifos.tenantid=${MIFOS_TENANT_ID:default}
 
@@ -29,7 +30,7 @@ quarkus.package.jar.type=uber-jar
 # Enable logging to a file
 quarkus.log.file.enable=true
 quarkus.log.file.path=mifosx-mcpp.log
-quarkus.tls.tls-disabled.trust-all=true
+#quarkus.tls.tls-disabled.trust-all=true
 ## just for debugging
 #quarkus.log.level=DEBUG
 quarkus.mcp.server.traffic-logging.enabled=true 


### PR DESCRIPTION
Introduced a new method `listClients` in both `MifosXServer` and `MifosXClient` classes. This allows retrieving a list of all clients from the Fineract API for enhanced data access.