### PR TITLE
Set default MIFOSX_BASE_URL to production environment

### DIFF
--- a/java/src/main/resources/application.properties
+++ b/java/src/main/resources/application.properties
@@ -19,8 +19,8 @@
 
 # The Apache Fineract API behind API Gateway returns 30x redirects, so we need to follow them
 quarkus.rest-client.follow-redirects=true
-#quarkus.rest-client.mifosx.url=${MIFOSX_BASE_URL:https://apis.flexcore.mx/v1.0/mcp}
-quarkus.rest-client.mifosx.url=${MIFOSX_BASE_URL:https://sandbox.mifos.community}
+quarkus.rest-client.mifosx.url=${MIFOSX_BASE_URL:https://apis.flexcore.mx/v1.0/mcp}
+#quarkus.rest-client.mifosx.url=${MIFOSX_BASE_URL:https://sandbox.mifos.community}
 mifos.basic.token=${MIFOSX_BASIC_AUTH_TOKEN:bWlmb3M6cGFzc3dvcmQ=}
 mifos.tenantid=${MIFOS_TENANT_ID:default}
 


### PR DESCRIPTION
Updated the application.properties file to set the default MIFOSX_BASE_URL to the production API endpoint. The sandbox URL was commented out to reflect the change in focus towards the production environment. This ensures proper configuration for live deployments.