### PR TITLE
Fix typo in ToolArg annotation for 'qualification' parameter

### DIFF
--- a/java/src/main/java/org/mifos/community/ai/mcp/MifosXServer.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/MifosXServer.java
@@ -111,7 +111,7 @@ public class MifosXServer {
             @ToolArg(description = "First Name (e.g. Jhon)") String firstName,
             @ToolArg(description = "Middle Name (e.g. Cena)", required = false) String middleName,
             @ToolArg(description = "Last Name (e.g. Doe)") String lastName,
-            @ToolArg(description = "Qualification (e.g. MBA), required = false") String qualification,
+            @ToolArg(description = "Qualification (e.g. MBA)", required = false) String qualification,
             @ToolArg(description = "Age (e.g. 25)") Integer age,
             @ToolArg(description = "Is Dependent (e.g. true)", required = false) String isDependent,
             @ToolArg(description = "Relationship (e.g. 1)") Integer relationshipId,


### PR DESCRIPTION
Corrected the annotation syntax for the 'qualification' parameter by moving 'required = false' outside the description text. This ensures proper parsing and functionality of the annotation