### PR TITLE
Refactor addFamilyMember to serialize FamilyMember as JSON

### DIFF
--- a/java/src/main/java/org/mifos/community/ai/mcp/MifosXServer.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/MifosXServer.java
@@ -18,6 +18,7 @@
  */
 package org.mifos.community.ai.mcp;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -144,7 +145,9 @@ public class MifosXServer {
         familyMember.setDateOfBirth(dateOfBirth);
         familyMember.setDateFormat("dd MMMM yyyy");
         familyMember.setLocale("en");
-
-        return mifosXClient.addFamilyMember(clientId, familyMember);
+        ObjectMapper ow = new ObjectMapper();
+        ow.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        String jsonClient = ow.writeValueAsString(familyMember);
+        return mifosXClient.addFamilyMember(clientId, jsonClient);
     }
 }

--- a/java/src/main/java/org/mifos/community/ai/mcp/client/MifosXClient.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/client/MifosXClient.java
@@ -75,5 +75,5 @@ public interface MifosXClient {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/fineract-provider/api/v1/clients/{clientId}/familymembers")
-    JsonNode addFamilyMember(Integer clientId, FamilyMember familyMember);
+    JsonNode addFamilyMember(Integer clientId, String familyMember);
 }


### PR DESCRIPTION
Previously, the addFamilyMember method directly passed a FamilyMember object. This update changes it to serialize the object into a JSON string before sending it to the MifosXClient, ensuring proper handling of non-null fields via Jackson's JsonInclude settings.