### PR TITLE
Fix missing break statement in gender switch

### DIFF
--- a/java/src/main/java/org/mifos/community/ai/mcp/MifosXServer.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/MifosXServer.java
@@ -158,6 +158,7 @@ public class MifosXServer {
                 break;
             default:
                 familyMember.setGenderId(29);
+                break;
         }
         switch (maritalStatus.toLowerCase()){
             case "single":


### PR DESCRIPTION
Added a missing break statement in the gender switch to prevent fall-through behavior. This ensures proper execution flow and eliminates any unintended logic errors.