### PR TITLE
Refactor relationship field to relationshipId in FamilyMember

### DIFF
--- a/java/src/main/java/org/mifos/community/ai/mcp/MifosXServer.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/MifosXServer.java
@@ -173,16 +173,16 @@ public class MifosXServer {
         }
         switch (relationship.toLowerCase()){
             case "friend":
-                familyMember.setRelationship(17);
+                familyMember.setRelationshipId(17);
                 break;
             case "father":
-                familyMember.setRelationship(25);
+                familyMember.setRelationshipId(25);
                 break;
             case "mother":
-                familyMember.setRelationship(26);
+                familyMember.setRelationshipId(26);
                 break;
             default:
-                familyMember.setRelationship(17);
+                familyMember.setRelationshipId(17);
                 break;
         }
 

--- a/java/src/main/java/org/mifos/community/ai/mcp/dto/FamilyMember.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/dto/FamilyMember.java
@@ -16,7 +16,7 @@ public class FamilyMember {
     String qualification;
     Integer age;
     String isDependent;
-    Integer relationship;
+    Integer relationshipId;
     Integer genderId;
     Integer professionId;
     Integer maritalStatusId;


### PR DESCRIPTION
Renamed the 'relationship' field to 'relationshipId' in the FamilyMember DTO and updated references accordingly in MifosXServer. This improves naming consistency and clarity within the codebase.