### PR TITLE
Remove @PathParam annotation from addAddress method

### DIFF
--- a/java/src/main/java/org/mifos/community/ai/mcp/client/MifosXClient.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/client/MifosXClient.java
@@ -71,7 +71,7 @@ public interface MifosXClient {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/fineract-provider/api/v1/client/{clientId}/addresses")
-    JsonNode addAddress(@PathParam("clientId") Integer clientId,
+    JsonNode addAddress(Integer clientId,
                         @QueryParam("type") Integer addressTypeId,
                         String address);
 


### PR DESCRIPTION
The @PathParam annotation for clientId was removed to simplify method parameters and better align with API design. This change ensures consistency in the parameter handling for the addAddress method.