### PR TITLE
Refactor URL path for addAddress API method

### DIFF
--- a/java/src/main/java/org/mifos/community/ai/mcp/client/MifosXClient.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/client/MifosXClient.java
@@ -70,10 +70,8 @@ public interface MifosXClient {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    @Path("/fineract-provider/api/v1/client/{clientId}/addresses")
-    JsonNode addAddress(Integer clientId,
-                        @QueryParam("type") Integer addressTypeId,
-                        String address);
+    @Path("/fineract-provider/api/v1/client/{clientId}/addresses?type={addressTypeId}")
+    JsonNode addAddress(Integer clientId, Integer addressTypeId, String address);
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
Simplified the @Path annotation for the addAddress method by moving the addressTypeId parameter directly into the URL path. This change improves readability and aligns with standard RESTful API conventions.