### PR TITLE
Add client activation API support

### DIFF
--- a/java/src/main/java/org/mifos/community/ai/mcp/MifosXServer.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/MifosXServer.java
@@ -116,6 +116,31 @@ public class MifosXServer {
         return mifosXClient.createClient(jsonClient);
     }
 
+    @Tool(description = "Activate a client account using his client account. " +
+            "Optionally provide an activation date. If omitted, today's date will be used.")
+    JsonNode activateClient(@ToolArg(description = "Client Id (e.g. 1)") Integer clientId,
+                            @ToolArg(description = "Activation Date (e.g. 22 April 2025)") String activationDate)
+            throws JsonProcessingException {
+        ClientActivation clientActivation = new ClientActivation();
+
+        if (activationDate != null)
+        {
+            clientActivation.setActivationDate(activationDate);
+        }
+        else {
+            LocalDate currentDate = LocalDate.now();
+            DateTimeFormatter dtf = DateTimeFormatter.ofPattern("dd MMMM yyyy");
+            String formattedDate = currentDate.format(dtf);
+            clientActivation.setActivationDate(formattedDate);
+        }
+        clientActivation.setDateFormat("dd MMMM yyyy");
+        clientActivation.setLocale("en");
+
+        ObjectMapper ow = new ObjectMapper();
+        String jsonActiveClient = ow.writeValueAsString(clientActivation);
+        return mifosXClient.activateClient(clientId, jsonActiveClient);
+    }
+
     @Tool(description = "Add an address to a client by his account number. Required fields: address type, address line 1, address line 2, address line 3, " +
             "city, country, postal code, state province")
     JsonNode addAddress(@ToolArg(description = "Client Id (e.g. 1)") Integer clientId,

--- a/java/src/main/java/org/mifos/community/ai/mcp/client/MifosXClient.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/client/MifosXClient.java
@@ -64,6 +64,12 @@ public interface MifosXClient {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @Path("/fineract-provider/api/v1/clients/{clientId}?command=activate")
+    JsonNode activateClient(Integer clientId,String activateClient);
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("/fineract-provider/api/v2/clients/search")
     JsonNode listClients(String searchText);
 

--- a/java/src/main/java/org/mifos/community/ai/mcp/dto/ClientActivation.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/dto/ClientActivation.java
@@ -1,0 +1,12 @@
+package org.mifos.community.ai.mcp.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ClientActivation {
+    String activationDate;
+    String dateFormat;
+    String locale;
+}


### PR DESCRIPTION
Introduce functionality to activate a client account via API, including the ability to specify an activation date or default to the current date. Added `ClientActivation` DTO for handling activation details and updated `MifosXClient` and `MifosXServer` to process activation requests.