### PR TITLE
Refactor Address DTO and fix method parameter usage.

### DIFF
--- a/java/src/main/java/org/mifos/community/ai/mcp/MifosXServer.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/MifosXServer.java
@@ -177,7 +177,7 @@ public class MifosXServer {
         String jsonAddress = ow.writeValueAsString(address);
         jsonAddress = jsonAddress.replace(":null", ":\"\"");
         log.info("jsonAddress: " + jsonAddress);
-        return mifosXClient.addAddress(clientId,address.getAddressTypeId(),jsonAddress);
+        return mifosXClient.addAddress(clientId,address.getAddressType(),jsonAddress);
     }
 
     @Tool(description = "Add a family member to a client by his account number. Required fields: firstName, lastName, age, relationship, genderId, dateOfBirth," +

--- a/java/src/main/java/org/mifos/community/ai/mcp/dto/Address.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/dto/Address.java
@@ -10,11 +10,11 @@ import lombok.Setter;
 @JsonIgnoreProperties({"addressTypeCodeValueId", "countryCodeValueId", "stateProvinceCodeValueId"})
 public class Address {
     @NotNull
-    Integer addressTypeId;
-    @NotNull
     String  addressLine1;
     String  addressLine2;
     String  addressLine3;
+    @NotNull
+    Integer addressType;
     String  city;
     @NotNull
     Integer countryId;


### PR DESCRIPTION
Replaced `addressTypeId` with `addressType` in both `Address` DTO and `MifosXServer` client method call to ensure proper mapping. Added `@NotNull` annotation to enforce validation for `addressType`. This change ensures consistency and improves data handling.