### PR TITLE
Fix incorrect method call for setting address type

### DIFF
--- a/java/src/main/java/org/mifos/community/ai/mcp/MifosXServer.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/MifosXServer.java
@@ -157,7 +157,7 @@ public class MifosXServer {
                         @ToolArg(description = "Postal Code (e.g. 12345)") String postalCode) throws JsonProcessingException {
         Address address = new Address();
 
-        address.setAddressTypeId(getCodeValueId(address.getAddressTypeCodeValueId(), addressType));
+        address.setAddressType(getCodeValueId(address.getAddressTypeCodeValueId(), addressType));
         address.setAddressLine1(addressLine1);
         address.setAddressLine2(Optional.ofNullable(addressLine2).orElse(""));
         address.setAddressLine3(Optional.ofNullable(addressLine3).orElse(""));


### PR DESCRIPTION
Replaced `setAddressTypeId` with `setAddressType` to correctly map and assign the address type. This ensures that the address initialization logic aligns with the expected method usage and prevents potential misconfigurations.