### PR TITLE
Add support for default savings product creation with DTOs and API integration

### DIFF
--- a/java/src/main/java/org/mifos/community/ai/mcp/MifosXServer.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/MifosXServer.java
@@ -227,9 +227,44 @@ public class MifosXServer {
         return mifosXClient.addFamilyMember(clientId, jsonClient);
     }
 
-    @Tool(description = "")
-    JsonNode createDefaultSavingProduct() throws JsonProcessingException{
-        return null;
+    @Tool(description = "Create a default savings product. " +
+            "Provide only the following inputs: name, short name, description, and currency. " +
+            "All other values will be automatically set with default configuration. " +
+            "Use this to quickly initialize standard savings products.")
+    JsonNode createDefaultSavingProduct(@ToolArg(description = "Saving product name (e.g. WALLET)") String name,
+        @ToolArg(description = "Short name of the savings product (e.g. WL01)") String shortName,
+        @ToolArg(description = "Short description of the savings product (e.g. WALLET PRODUCT)") String description,
+        @ToolArg(description = "Currency for the savings product (e.g. USD)") String currency) throws JsonProcessingException{
+        SavingProduct savingProduct = new SavingProduct();
+
+        savingProduct.setName(name);
+        savingProduct.setShortName(shortName);
+        savingProduct.setDescription(description);
+        savingProduct.setCurrencyCode(currency);
+        savingProduct.setDigitsAfterDecimal(2);
+        savingProduct.setInMultiplesOf(null);
+        savingProduct.setNominalAnnualInterestRate(0);
+        savingProduct.setInterestCompoundingPeriodType(1);
+        savingProduct.setInterestPostingPeriodType(4);
+        savingProduct.setInterestCalculationDaysInYearType(1);
+        savingProduct.setInterestCalculationDaysInYearType(365);
+        savingProduct.setWithdrawalFeeForTransfers("false");
+        savingProduct.setEnforceMinRequiredBalance("false");
+        savingProduct.setAllowOverdraft("false");
+        savingProduct.setWithHoldTax("false");
+        savingProduct.setIsDormancyTrackingActive("false");
+
+        ArrayList<Charge> charges = new ArrayList<>();
+        savingProduct.setCharges(charges);
+
+        savingProduct.setAccountingRule(1);
+        savingProduct.setLocale("en");
+
+        ObjectMapper ow = new ObjectMapper();
+        String jsonClient = ow.writeValueAsString(savingProduct);
+        jsonClient = jsonClient.replace(":null", ":\"\"");
+
+        return mifosXClient.newLoanAccountApplication(jsonClient);
     }
 
     @Tool(description = "Create a new loan account for a client using their account number and a loan product ID. " +

--- a/java/src/main/java/org/mifos/community/ai/mcp/MifosXServer.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/MifosXServer.java
@@ -264,7 +264,7 @@ public class MifosXServer {
         String jsonClient = ow.writeValueAsString(savingProduct);
         jsonClient = jsonClient.replace(":null", ":\"\"");
 
-        return mifosXClient.newLoanAccountApplication(jsonClient);
+        return mifosXClient.createDefaultSavingsProduct(jsonClient);
     }
 
     @Tool(description = "Create a new loan account for a client using their account number and a loan product ID. " +

--- a/java/src/main/java/org/mifos/community/ai/mcp/client/MifosXClient.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/client/MifosXClient.java
@@ -95,6 +95,12 @@ public interface MifosXClient {
     @Path("/fineract-provider/api/v1/loans")
     JsonNode newLoanAccountApplication(String newLoanAccountApplication);
 
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("fineract-provider/api/v1/savingsproducts")
+    JsonNode createDefaultSavingsProduct(String defaultSavingsProduct);
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("fineract-provider/api/v1/codes")

--- a/java/src/main/java/org/mifos/community/ai/mcp/dto/Charge.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/dto/Charge.java
@@ -1,0 +1,19 @@
+package org.mifos.community.ai.mcp.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class Charge {
+    String active;
+    String amount;
+    Integer chargeAppliesTo;
+    Integer chargeCalculationType;
+    Integer chargeTimeType;
+    String currencyCode;
+    String locale;
+    String monthDayFormat;
+    String name;
+    String penalty;
+}

--- a/java/src/main/java/org/mifos/community/ai/mcp/dto/SavingProduct.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/dto/SavingProduct.java
@@ -1,0 +1,37 @@
+package org.mifos.community.ai.mcp.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+
+import java.util.List;
+
+@Setter
+@Getter
+public class SavingProduct {
+    @NonNull
+    String name;
+    @NonNull
+    @Size(min = 4, max = 4)
+    String shortName;
+    String description;
+    @NotNull
+    String currencyCode;
+    Integer digitsAfterDecimal;
+    Integer inMultiplesOf;
+    double nominalAnnualInterestRate;
+    Integer interestCompoundingPeriodType;
+    Integer interestPostingPeriodType;
+    Integer interestCalculationType;
+    Integer interestCalculationDaysInYearType;
+    String withdrawalFeeForTransfers;
+    String enforceMinRequiredBalance;
+    String allowOverdraft;
+    String withHoldTax;
+    String isDormancyTrackingActive;
+    List<Charge> charges;
+    Integer accountingRule;
+    String locale;
+}


### PR DESCRIPTION
Introduced `SavingProduct` and `Charge` DTOs to define the structure and validation for default savings products. 
Added a new API endpoint in `MifosXClient` to support streamlined product creation. 
Updated `createDefaultSavingProduct` in `MifosXServer` to use this endpoint and apply default configurations, requiring minimal input from users. This improves maintainability and enhances the overall savings product management workflow.