### PR TITLE
Rename class to LoanProductApplication

### DIFF
--- a/java/src/main/java/org/mifos/community/ai/mcp/dto/LoanProductApplication.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/dto/LoanProductApplication.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 @Setter
 @Getter
-public class LoanProdctApplications {
+public class LoanProductApplication {
     String allowPartialPeriodInterestCalcualtion;
     Integer amortizationType;
     List<Object> charges;


### PR DESCRIPTION
Corrected the class name from LoanProdctApplications to LoanProductApplication to fix a typo and align with naming conventions. This ensures clarity and consistency across the codebase.