### PR TITLE
Fix: Add zsh quoting tip for pip install with extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ This starts a local web UI to connect to your MCP server via STDIO or SSE.
    ```bash
    pip install mcp[cli] uv flask
    ```
+
+   > **Note for zsh users**: If you're using zsh, be sure to quote extras to avoid shell expansion errors:
+   >
+   > ```bash
+   > pip install 'mcp[cli]' uv flask
+   > ```
 2. Run the server:
    ```bash
    mcp dev app.py


### PR DESCRIPTION
Here’s a polished PR description you can use for your contribution to the README:

✅ Pull Request: Add zsh quoting note for pip install mcp[cli]
📌 Summary
This PR improves the installation instructions for users running zsh by clarifying the need to quote extras when using pip install mcp[cli].

🧠 Motivation
In zsh, square brackets are interpreted as glob patterns. Running:

```
pip install mcp[cli]
```
produces:

>zsh: no matches found: mcp[cli]


To avoid this, the extras section must be quoted:

```
pip install 'mcp[cli]'
```
✨ What I Changed
Added the following to the Python (Flask) installation section:


> **Note for zsh users**: Square brackets require quoting. Run:
>
> ```bash
> pip install 'mcp[cli]'
> ```
✅ Benefits
Prevents confusion during setup

Improves developer onboarding

Consistent with best practices for package installation

📎 Related Issue
(None formally filed – this is a small fix based on observed behavior)