### PR TITLE
Support for default loan product creation

### DIFF
--- a/java/src/main/java/org/mifos/community/ai/mcp/client/MifosXClient.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/client/MifosXClient.java
@@ -145,6 +145,17 @@ public interface MifosXClient {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
+    @Path("fineract-provider/api/v1/loanproducts/template")
+    JsonNode getLoanProductTemplate();
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("fineract-provider/api/v1/loanproducts")
+    JsonNode createDefaultLoanProduct(String defaultLoanProduct);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("fineract-provider/api/v1/currencies")
     JsonNode getCurrencies();
 

--- a/java/src/main/java/org/mifos/community/ai/mcp/dto/AllowAttributeOverrides.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/dto/AllowAttributeOverrides.java
@@ -1,0 +1,17 @@
+package org.mifos.community.ai.mcp.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AllowAttributeOverrides {
+    String amortizationType = "true";
+    String graceOnArrearsAgeing = "true";
+    String graceOnPrincipalAndInterestPayment = "true";
+    String inArrearsTolerance = "true";
+    String interestCalculationPeriodType = "true";
+    String interestType = "true";
+    String repaymentEvery = "true";
+    String transactionProcessingStrategyCode = "true";
+}

--- a/java/src/main/java/org/mifos/community/ai/mcp/dto/LoanProduct.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/dto/LoanProduct.java
@@ -1,0 +1,70 @@
+package org.mifos.community.ai.mcp.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class LoanProduct {
+    Integer accountingRule = 1;
+    String accountMovesOutOfNPAOnlyOnArrearsCompletion = "false";
+    String allowApprovedDisbursedAmountsOverApplied = "false";
+
+    AllowAttributeOverrides allowAttributeOverrides;
+
+    String allowVariableInstallments = "false";
+    Integer amortizationType = 1;
+    String canDefineInstallmentAmount = "false";
+    String canUseForTopup = "false";
+    List<Charge> charges;
+    @NotNull
+    String currencyCode;
+    String dateFormat = "dd MMMM yyyy";
+    Integer daysInMonthType = 1;
+    Integer daysInYearType = 1;
+    Integer delinquencyBucketId;
+    Integer digitsAfterDecimal = 2;
+    String disallowExpectedDisbursements = "false";
+    Integer dueDaysForRepaymentEvent = 1;
+    String enableDownPayment = "false";
+    String enableInstallmentLevelDelinquency = "false";
+    String externalId;
+    Integer fixedLength;
+    String holdGuaranteeFunds = "false";
+    String includeInBorrowerCycle = "false";
+    Integer inMultiplesOf = 0;
+    Integer interestCalculationPeriodType = 1;
+    @NotNull
+    Integer interestRateFrequencyType = 2;
+    @NotNull
+    double interestRatePerPeriod;
+    List<Object> interestRateVariationsForBorrowerCycle;
+    String interestRecognitionOnDisbursementDate = "false";
+    Integer interestType = 0;
+    String isEqualAmortization = "false";
+    String isInterestRecalculationEnabled = "false";
+    String isLinkedToFloatingInterestRates = "false";
+    String loanScheduleType = "CUMULATIVE";
+    String locale = "en";
+    @NotNull
+    String name;
+    @NotNull
+    Integer numberOfRepayments;
+    List<Object> numberOfRepaymentVariationsForBorrowerCycle;
+    Integer overDueDaysForRepaymentEvent = 1;
+    @NotNull
+    double principal;
+    List<Object> principalVariationsForBorrowerCycle;
+    @NotNull
+    Integer repaymentEvery;
+    @NotNull
+    Integer repaymentFrequencyType;
+    Integer repaymentStartDateType = 1;
+    @NotNull
+    String shortName;
+    String transactionProcessingStrategyCode = "creocore-strategy";
+    String useBorrowerCycle = "false";
+}

--- a/java/src/main/java/org/mifos/community/ai/mcp/dto/Options.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/dto/Options.java
@@ -1,0 +1,13 @@
+package org.mifos.community.ai.mcp.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class Options {
+
+    Integer id;
+    String code;
+    String value;
+}


### PR DESCRIPTION
Added support for quick creation of standard loan products. Only key parameters such as name, principal amount, frequency, and nominal interest rate are required, while default values are automatically set for all other fields. Included necessary classes to handle generated JSON structures and their corresponding data types.