### PR TITLE
Added logging to inspect loanProduct payload before backend submission

### DIFF
--- a/java/src/main/java/org/mifos/community/ai/mcp/MifosXServer.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/MifosXServer.java
@@ -364,8 +364,11 @@ public class MifosXServer {
         loanProduct.setCharges(charges);
 
 
-        String jsonDefaultLoanProduct = ow.writeValueAsString(loanProduct);
         //jsonDefaultLoanProduct = jsonDefaultLoanProduct.replace(":null", ":\"\"");
+        ObjectWriter owf = new ObjectMapper().writer().withDefaultPrettyPrinter();
+        String jsonDefaultLoanProduct = ow.writeValueAsString(loanProduct);
+
+        log.info("******** Contenido de loanProduct enviado al backend ********\n" + jsonDefaultLoanProduct);
 
         return mifosXClient.createDefaultLoanProduct(jsonDefaultLoanProduct);
     }


### PR DESCRIPTION
This change adds a single log statement to print the full JSON structure of the loanProduct object before it is sent to the backend. No other logic was modified.