### PR TITLE
Remove unnecessary @JsonSerialize annotation

### DIFF
--- a/java/src/main/java/org/mifos/community/ai/mcp/dto/LoanOfficer.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/dto/LoanOfficer.java
@@ -19,6 +19,5 @@ public class LoanOfficer {
     String isLoanOfficer;
     String isActive;
     @JsonDeserialize(using = DateArrayDeserializer.class)
-    @JsonSerialize()
     String joiningDate;
 }


### PR DESCRIPTION
The @JsonSerialize annotation for the joiningDate field was redundant and has been removed. This change ensures cleaner code without affecting functionality or serialization behavior.