### PR TITLE
Fix DisburseLoanAccountTemplate:

### DIFF
--- a/java/src/main/java/org/mifos/community/ai/mcp/dto/Currency.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/dto/Currency.java
@@ -1,14 +1,17 @@
 package org.mifos.community.ai.mcp.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 import lombok.Setter;
 
 @Setter
 @Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Currency {
     String code;
     String name;
     Integer decimalPlaces;
+    Integer inMultiplesOf;
     String displaySymbol;
     String nameCode;
     String displayLabel;


### PR DESCRIPTION
Added the inMultiplesOf field and @JsonInclude(Include.NON_NULL) to the Currency class to exclude null fields from serialization. This results in cleaner JSON output and improves API response clarity.