### PR TITLE
Add ChargeOption DTO and update related references

### DIFF
--- a/java/src/main/java/org/mifos/community/ai/mcp/MifosXServer.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/MifosXServer.java
@@ -598,7 +598,7 @@ public class MifosXServer {
             "Optionally, include the disbursement amount, external ID, note, and payment-related details.")
     JsonNode disburseLoanAccount(
             @ToolArg(description = "Loan account number (e.g. 1)") Integer loanAccountNumber,
-            @ToolArg(description = "Disbursement amount (e.g. 10000)", required = false) Double transactionAmount,
+            @ToolArg(description = "Disbursement amount (e.g. 10000). If omitted, the system uses the default approved amount.", required = false) Double transactionAmount,
             @ToolArg(description = "External identifier for the transaction (e.g. LDT01)", required = false) String externalId,
             @ToolArg(description = "Name of the payment type (e.g. Money Transfer)") String paymentType,
             @ToolArg(description = "Optional note related to the disbursement (e.g. FYI)", required = false) String note,

--- a/java/src/main/java/org/mifos/community/ai/mcp/dto/ChargeOption.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/dto/ChargeOption.java
@@ -1,0 +1,24 @@
+package org.mifos.community.ai.mcp.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ChargeOption {
+    Integer id;
+    String name;
+    String active;
+    String penalty;
+    String freeWithdrawal;
+    String isPaymentType;
+    Integer freeWithdrawalChargeFrequency;
+    Integer restartFrequency;
+    Integer restartFrequencyEnum;
+    Currency currency;
+    Double amount;
+    Types chargeTimeType;
+    Types chargeAppliesTo;
+    Types chargeCalculationType;
+    Types chargePaymentMode;
+}

--- a/java/src/main/java/org/mifos/community/ai/mcp/dto/LoanProductApplicationTemplate.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/dto/LoanProductApplicationTemplate.java
@@ -51,7 +51,7 @@ public class LoanProductApplicationTemplate {
     List<Types> interestTypeOptions;
     List<Types> interestCalculationPeriodTypeOptions;
     List<Options> transactionProcessingStrategyOptions;
-    List<Charge> chargeOptions;
+    List<ChargeOption> chargeOptions;
     List<Object> loanCollateralOptions;
     List<Types> loanScheduleTypeOptions;
     List<Types> loanScheduleProcessingTypeOptions;


### PR DESCRIPTION
Introduce the `ChargeOption` DTO to enhance charge options management. Replaced `Charge` with `ChargeOption` in `LoanProductApplicationTemplate` for improved clarity and extensibility. Updated `MifosXServer` to include more descriptive details for the `transactionAmount` parameter.