### PR TITLE
Refactor: Replace ParsedAmount fields with Double types

### DIFF
--- a/java/src/main/java/org/mifos/community/ai/mcp/MifosXServer.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/MifosXServer.java
@@ -678,7 +678,7 @@ public class MifosXServer {
         }
 
         loanRepayment.setTransactionDate(Optional.ofNullable(transactionDate).orElse(template.getDate()));
-        loanRepayment.setTransactionAmount(Optional.ofNullable(amount).orElse(template.getAmount().getParsedValue()));
+        loanRepayment.setTransactionAmount(Optional.ofNullable(amount).orElse(template.getAmount()));
         loanRepayment.setExternalId(Optional.ofNullable(externalId).orElse(""));
         loanRepayment.setPaymentTypeId(selectedPaymentType.getId());
 

--- a/java/src/main/java/org/mifos/community/ai/mcp/dto/LoanRepaymentTemplate.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/dto/LoanRepaymentTemplate.java
@@ -14,10 +14,10 @@ public class LoanRepaymentTemplate {
     @JsonDeserialize(using = DateArrayDeserializer.class)
     String date;
     Currency currency;
-    ParsedAmount amount;
-    ParsedAmount netDisbursalAmount;
-    ParsedAmount principalPortion;
-    ParsedAmount interestPortion;
+    Double amount;
+    Double netDisbursalAmount;
+    Double principalPortion;
+    Double interestPortion;
     Integer feeChargesPortion;
     Integer penaltyChargesPortion;
     String manuallyReversed;

--- a/java/src/main/java/org/mifos/community/ai/mcp/dto/LoanRepaymentTemplate.java
+++ b/java/src/main/java/org/mifos/community/ai/mcp/dto/LoanRepaymentTemplate.java
@@ -1,7 +1,6 @@
 package org.mifos.community.ai.mcp.dto;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.deser.std.DateDeserializers;
 import lombok.Getter;
 import lombok.Setter;
 


### PR DESCRIPTION
Replaced fields of type ParsedAmount with Double in the LoanRepaymentTemplate class to resolve a deserialization issue.