### PR TITLE
fix: replace deprecated mcp sse transport with http and update quarkus platform

### DIFF
--- a/java/userrecommendation/pom.xml
+++ b/java/userrecommendation/pom.xml
@@ -12,7 +12,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.30.4</quarkus.platform.version>
+        <quarkus.platform.version>3.30.5</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.4</surefire-plugin.version>
     </properties>
@@ -42,12 +42,13 @@
             <groupId>io.quarkiverse.mcp</groupId>
             <artifactId>quarkus-mcp-server-stdio</artifactId>
             <version>1.8.1</version>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>io.quarkiverse.mcp</groupId>
-            <artifactId>quarkus-mcp-server-sse</artifactId>
+            <artifactId>quarkus-mcp-server-http</artifactId>
             <version>1.8.1</version>
         </dependency>
+
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>


### PR DESCRIPTION
This PR addresses Renovate dependency dashboard issue #4.

Changes:
- Replaced deprecated `quarkus-mcp-server-sse` with `quarkus-mcp-server-http`
- Upgraded Quarkus platform from 3.30.4 to 3.30.5

Reason:
- SSE transport is deprecated in the MCP Quarkiverse
- HTTP is the recommended and supported transport
- Patch-level Quarkus upgrade ensures better compatibility and stability

Build:
- mvn clean verify
