### PR TITLE
[AI-203] Standardize MCP tool input validation

### DIFF
--- a/python/mcp_server.py
+++ b/python/mcp_server.py
@@ -4,6 +4,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import logging
+import functools
+import inspect
 
 from fastmcp import FastMCP
 
@@ -73,9 +75,60 @@ from tools.domains.savings import (
     withdraw_savings,
 )
 from tools.domains.staff import get_office_details, get_staff_details, list_offices, list_staff
+from tools.validation import validate_tool_params
 
 # 3. Initialize the FastMCP Server
 mcp = FastMCP("Mifos-Banking-Agent")
+
+
+def _build_param_map(func, args, kwargs) -> dict:
+    """Map call arguments to parameter names for consistent validation."""
+    try:
+        bound = inspect.signature(func).bind_partial(*args, **kwargs)
+        return dict(bound.arguments)
+    except Exception:
+        # Best-effort fallback if signature binding fails.
+        return {"args": args, "kwargs": kwargs}
+
+
+def _enable_mcp_tool_validation() -> None:
+    """Apply a central validation layer to all @mcp.tool() registrations.
+
+    This keeps individual tool business logic unchanged while ensuring a
+    consistent error structure and early rejection of invalid parameters.
+    """
+    original_tool = mcp.tool
+
+    def validated_tool(*tool_args, **tool_kwargs):
+        decorator = original_tool(*tool_args, **tool_kwargs)
+
+        def apply(func):
+            @functools.wraps(func)
+            def wrapped(*args, **kwargs):
+                params = _build_param_map(func, args, kwargs)
+                validation_error = validate_tool_params(params)
+                if validation_error:
+                    logger.warning(
+                        "MCP_TOOL_VALIDATION_FAILED tool=%s field=%s value=%s",
+                        func.__name__,
+                        validation_error.get("validation", {}).get("field"),
+                        validation_error.get("validation", {}).get("value"),
+                    )
+                    return validation_error
+
+                return func(*args, **kwargs)
+
+            # Preserve original signature for framework introspection.
+            wrapped.__signature__ = inspect.signature(func)
+            return decorator(wrapped)
+
+        return apply
+
+    mcp.tool = validated_tool
+
+
+# Enable centralized tool input validation before registering tools.
+_enable_mcp_tool_validation()
 
 # --- Shared helpers ---
 

--- a/python/tests/test_validation.py
+++ b/python/tests/test_validation.py
@@ -1,0 +1,37 @@
+# Copyright since 2025 Mifos Initiative
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from tools.validation import validate_tool_params
+
+
+def test_validate_tool_params_accepts_valid_inputs():
+    params = {
+        "loanId": 10,
+        "amount": 500.25,
+        "months": 12,
+        "rescheduleFromDate": "15 March 2026",
+    }
+    assert validate_tool_params(params) is None
+
+
+def test_validate_tool_params_rejects_invalid_id():
+    result = validate_tool_params({"loanId": 0})
+    assert result is not None
+    assert result["httpStatusCode"] == 400
+    assert result["validation"]["field"] == "loanId"
+
+
+def test_validate_tool_params_rejects_invalid_amount():
+    result = validate_tool_params({"amount": -1})
+    assert result is not None
+    assert result["httpStatusCode"] == 400
+    assert result["validation"]["field"] == "amount"
+
+
+def test_validate_tool_params_rejects_empty_date_string():
+    result = validate_tool_params({"transactionDate": ""})
+    assert result is not None
+    assert result["httpStatusCode"] == 400
+    assert result["validation"]["field"] == "transactionDate"

--- a/python/tools/validation.py
+++ b/python/tools/validation.py
@@ -1,0 +1,95 @@
+# Copyright since 2025 Mifos Initiative
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def validation_error_response(
+    message: str,
+    field: str,
+    value: Any,
+    expected: str,
+    http_status_code: int = 400,
+) -> dict:
+    """Return a consistent validation error payload for MCP tools."""
+    return {
+        "error": message,
+        "httpStatusCode": http_status_code,
+        "validation": {
+            "field": field,
+            "value": value,
+            "expected": expected,
+        },
+    }
+
+
+def _is_positive_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
+def _is_positive_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and value > 0
+
+
+def validate_tool_params(params: dict[str, Any]) -> dict | None:
+    """Validate common MCP tool parameters and return structured error if invalid.
+
+    Validation rules are intentionally conservative to preserve compatibility:
+    - Any `*Id` / `*_id` parameter must be a positive integer when provided.
+    - Common quantitative fields (amount/principal/months/terms/rates) must be positive.
+    - Date-like fields, when present, must be non-empty strings.
+    """
+    for name, value in params.items():
+        if value is None:
+            continue
+
+        lname = name.lower()
+
+        # Common Fineract/MCP ID fields: clientId, loanId, productId, loan_id, etc.
+        if name.endswith("Id") or lname.endswith("_id") or lname == "id":
+            if not _is_positive_int(value):
+                return validation_error_response(
+                    message=f"Invalid {name}. It must be a positive integer.",
+                    field=name,
+                    value=value,
+                    expected="positive integer",
+                )
+            continue
+
+        # Positive integer counters/period values.
+        if lname in {"months", "extraterms", "graceonprincipal", "numberofrepayments"}:
+            if not _is_positive_int(value):
+                return validation_error_response(
+                    message=f"Invalid {name}. It must be a positive integer.",
+                    field=name,
+                    value=value,
+                    expected="positive integer",
+                )
+            continue
+
+        # Positive monetary/rate values.
+        if any(token in lname for token in ("amount", "principal", "rate")):
+            if not _is_positive_number(value):
+                return validation_error_response(
+                    message=f"Invalid {name}. It must be a positive number.",
+                    field=name,
+                    value=value,
+                    expected="positive number",
+                )
+            continue
+
+        # Date-like strings should not be empty when passed.
+        if "date" in lname:
+            if not isinstance(value, str) or not value.strip():
+                return validation_error_response(
+                    message=f"Invalid {name}. It must be a non-empty date string.",
+                    field=name,
+                    value=value,
+                    expected="non-empty string",
+                )
+
+    return None


### PR DESCRIPTION
Jira: https://mifosforge.jira.com/browse/AI-203

## Summary
- Add reusable python/tools/validation.py for shared MCP input validation
- Wrap all @mcp.tool() registrations in mcp_server.py with centralized pre-validation
- Short-circuit invalid requests before tool business logic / Fineract API calls
- Add focused tests in python/tests/test_validation.py

## Validation Framework
- Validates common ID fields (*Id, *_id, id) as positive integers
- Validates common numeric fields (amount, principal, rate, period counters) as positive numbers
- Validates date-like fields as non-empty strings
- Returns early with consistent error structure on any validation failure

## Error Response Format
```json
{
  "error": "Invalid loan_id. It must be a positive integer.",
  "httpStatusCode": 400,
  "validation": {
    "field": "loan_id",
    "value": "invalid_value",
    "expected": "positive integer"
  }
}
```

## Backward Compatibility
- Preserves all function signatures (no breaking changes)
- Uses conservative common validation rules only
- Existing callers continue to work unchanged

## Verification
- Error checks: clean for all edited files
- Tests pass: 14 passed
- Command: python -m pytest tests/test_validation.py tests/test_loans.py -q

Closes AI-203
