### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ This repository is structured to support multiple implementations and client int
 
 ---
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/openmf-mcp-mifosx).
+
 ## Available Tools Summary
 
 The exact number and categorization of tools depend on the core server implementation deployed:


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/openmf-mcp-mifosx).