### PR TITLE
AI-212 Add tools to update and delete clients, update and delete loans

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -1,6 +1,6 @@
 # Mifos MCP Server — Rust Implementation
 
-The **Mifos MCP Server (Rust)** is a high-performance, multi-threaded integration tier that bridges any AI assistant or agent framework to the **Apache Fineract** banking backend. It exposes **85 typed tools** via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io), leveraging Rust's concurrency model to handle bulk operations in parallel.
+The **Mifos MCP Server (Rust)** is a high-performance, multi-threaded integration tier that bridges any AI assistant or agent framework to the **Apache Fineract** banking backend. It exposes **89 typed tools** via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io), leveraging Rust's concurrency model to handle bulk operations in parallel.
 
 ---
 
@@ -15,7 +15,7 @@ This is a **Server**, not a client or agent. It translates Fineract REST API ope
                        │ REST API
 ┌──────────────────────▼──────────────────────┐
 │         mcp-rust-mifosx  (This Repo)         │
-│    High-Perf MCP Server — 85 typed tools     │
+│    High-Perf MCP Server — 89 typed tools     │
 │    (Built with Tokio + Reqwest + RMCP)       │
 └──────────────────────┬──────────────────────┘
                        │ MCP Standard Protocol (stdio)
@@ -103,11 +103,11 @@ Add this to your `claude_desktop_config.json`:
 
 ---
 
-## Available Tools (85)
+## Available Tools (89)
 
 The Rust server categorizes tools into domains for easier discovery.
 
-### 👤 Clients & Collaterals (23 tools)
+### 👤 Clients & Collaterals (25 tools)
 
 | Tool | Description |
 |---|---|
@@ -116,8 +116,9 @@ The Rust server categorizes tools into domains for easier discovery.
 | `get_client_accounts` | List all loan and savings accounts for a client |
 | `create_client` | Create a new banking client profile |
 | `activate_client` | Activate a pending client |
-| `update_client_mobile` | Update a client's mobile number |
-| `close_client` | Close a client's profile |
+| `update_client` | **Robust** update (handles mandatory fields automatically) |
+| `delete_client` | Hard delete a pending client profile |
+| `close_client` | Close an active client profile |
 | `get_client_identifiers` | List client KYC documents |
 | `create_client_identifier` | Add a KYC document to a client |
 | `get_client_documents` | List uploaded files for a client |
@@ -153,7 +154,7 @@ The Rust server categorizes tools into domains for easier discovery.
 | `get_center` | Show details for a center |
 | `create_center` | Create a new center |
 
-### 💳 Loans & Collaterals (17 tools)
+### 💳 Loans & Collaterals (19 tools)
 
 | Tool | Description |
 |---|---|
@@ -168,6 +169,8 @@ The Rust server categorizes tools into domains for easier discovery.
 | `make_loan_repayment` | Make a repayment on an active loan |
 | `apply_late_fee` | Apply a fee/charge to a loan |
 | `waive_interest` | Waive interest on a loan |
+| `update_loan` | **Robust** update (handles mandatory financial baseline) |
+| `delete_loan` | Hard delete a draft loan application |
 | `list_loan_products` | List all available loan products |
 | `list_loan_collaterals` | List assets attached to a loan |
 | `get_loan_collateral` | Retrieve specific loan collateral details |
@@ -249,6 +252,11 @@ Registering assets in Fineract often requires knowing internal `collateralTypeId
 ### 3. Smart Reversals
 Beyond simple CRUD, the server provides `undo_client_transaction`. This allows agents to recover from errors by strictly reversing payments or waivers while maintaining an audit trail.
 
+### 4. Intelligent "Fetch-and-Merge" Updates
+Updating complex entities like Loans or Clients in Fineract often fails due to missing mandatory fields (e.g., `firstname`). The Rust server implements a **Read-Modify-Write** cycle:
+- **Baseline Discovery**: The server automatically fetches the current state of a resource before a `PUT`.
+- **Intelligent Merge**: It overlays only the user's requested changes onto the mandatory baseline (including interest rates, amortization codes, and legal forms), ensuring the transaction never fails due to partial state issues.
+
 ---
 
 ## Testing with MCP Inspector
@@ -262,7 +270,7 @@ npx @modelcontextprotocol/inspector ./target/release/mcp-rust-mifosx
 1. Select **STDIO** transport.
 2. Ensure the command points to the compiled Rust binary.
 3. Click **Connect**.
-4. Browse the **Tools** tab to see all 61 tools and their JSON schemas.
+4. Browse the **Tools** tab to see all 89 tools and their JSON schemas.
 
 ### Programmatic Smoke Test
 

--- a/rust/src/domains/clients.rs
+++ b/rust/src/domains/clients.rs
@@ -22,6 +22,15 @@ pub struct CreateClientReq { pub firstname: String, pub lastname: String, pub mo
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct UpdateMobileReq { pub client_id: i64, pub new_mobile_no: String }
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct UpdateClientReq { 
+    pub client_id: i64, 
+    pub firstname: Option<String>, 
+    pub lastname: Option<String>, 
+    pub mobile_no: Option<String>,
+    pub external_id: Option<String>,
+    pub office_id: Option<i64>
+}
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct CloseClientReq { pub client_id: i64, pub closure_reason_id: Option<i64> }
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct CreateIdentifierReq { pub client_id: i64, pub document_type_id: i64, pub document_key: String }
@@ -65,7 +74,8 @@ pub async fn create_client(adapter: &FineractAdapter, req: CreateClientReq) -> R
     let payload = json!({
         "firstname": req.firstname, "lastname": req.lastname, "officeId": req.office_id.unwrap_or(1),
         "active": req.is_active.unwrap_or(false), "locale": "en", "dateFormat": "dd MMMM yyyy",
-        "activationDate": today(), "mobileNo": req.mobile_no.unwrap_or_default()
+        "activationDate": today(), "mobileNo": req.mobile_no.unwrap_or_default(),
+        "legalFormId": 1
     });
     let res = adapter.execute_post("clients", &payload).await.map_err(to_err)?;
     to_result(res)
@@ -80,6 +90,46 @@ pub async fn activate_client(adapter: &FineractAdapter, req: ClientIdReq) -> Res
 pub async fn update_client_mobile(adapter: &FineractAdapter, req: UpdateMobileReq) -> Result<CallToolResult, McpError> {
     let payload = json!({ "mobileNo": req.new_mobile_no });
     let res = adapter.execute_put(&format!("clients/{}", req.client_id), &payload).await.map_err(to_err)?;
+    to_result(res)
+}
+
+pub async fn update_client(adapter: &FineractAdapter, req: UpdateClientReq) -> Result<CallToolResult, McpError> {
+    // 1. Fetch current state to satisfy Fineract's mandatory field requirement on PUT
+    let current = adapter.execute_get(&format!("clients/{}", req.client_id), None).await.map_err(to_err)?;
+    
+    // Helper to clean and validate strings
+    let clean = |s: Option<&str>| s.map(|v| v.trim()).filter(|v| !v.is_empty()).map(|v| v.to_string());
+
+    // 2. Prepare payload with existing mandatory fields as baseline (must be non-blank)
+    let mut payload = json!({
+        "firstname": clean(current.get("firstname").and_then(|v| v.as_str())).unwrap_or_else(|| "Unknown".to_string()),
+        "lastname": clean(current.get("lastname").and_then(|v| v.as_str())).unwrap_or_else(|| "Unknown".to_string()),
+        "legalFormId": current.get("legalForm").and_then(|v| v.get("id")).and_then(|v| v.as_i64()).unwrap_or(1),
+        "locale": "en",
+        "dateFormat": "dd MMMM yyyy"
+    });
+
+    // 3. Overlay the user's updates with strict blank-rejection
+    if let Some(v) = req.firstname {
+        let t = v.trim();
+        if t.is_empty() { return Err(McpError::invalid_params("firstname cannot be blank".to_string(), None)); }
+        payload["firstname"] = json!(t);
+    }
+    if let Some(v) = req.lastname {
+        let t = v.trim();
+        if t.is_empty() { return Err(McpError::invalid_params("lastname cannot be blank".to_string(), None)); }
+        payload["lastname"] = json!(t);
+    }
+    if let Some(v) = req.mobile_no { payload["mobileNo"] = json!(v); }
+    if let Some(v) = req.external_id { payload["externalId"] = json!(v); }
+    if let Some(v) = req.office_id { payload["officeId"] = json!(v); }
+    
+    let res = adapter.execute_put(&format!("clients/{}", req.client_id), &payload).await.map_err(to_err)?;
+    to_result(res)
+}
+
+pub async fn delete_client(adapter: &FineractAdapter, req: ClientIdReq) -> Result<CallToolResult, McpError> {
+    let res = adapter.execute_delete(&format!("clients/{}", req.client_id)).await.map_err(to_err)?;
     to_result(res)
 }
 

--- a/rust/src/domains/loans.rs
+++ b/rust/src/domains/loans.rs
@@ -20,6 +20,13 @@ pub struct ClientIdReq { pub client_id: i64 }
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct CreateLoanReq { pub client_id: i64, pub amount_exactly_from_user_prompt: f64, pub months: i32, pub product_id: Option<i64> }
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct UpdateLoanReq { 
+    pub loan_id: i64, 
+    pub amount_exactly_from_user_prompt: Option<f64>, 
+    pub months: Option<i32>, 
+    pub product_id: Option<i64> 
+}
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct CreateGroupLoanReq { pub group_id: i64, pub amount_exactly_from_user_prompt: f64, pub months: i32, pub product_id: Option<i64> }
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct ApproveLoanReq { pub loan_id: i64, pub amount_exactly_from_user_prompt: Option<f64> }
@@ -83,6 +90,70 @@ pub async fn create_group_loan(adapter: &FineractAdapter, req: CreateGroupLoanRe
         "submittedOnDate": today(), "locale": "en", "dateFormat": "dd MMMM yyyy", "loanType": "group"
     });
     let res = adapter.execute_post("loans", &payload).await.map_err(to_err)?;
+    to_result(res)
+}
+
+pub async fn update_loan(adapter: &FineractAdapter, req: UpdateLoanReq) -> Result<CallToolResult, McpError> {
+    // 1. Fetch current state to satisfy Fineract's mandatory field requirement on PUT
+    let current = adapter.execute_get(&format!("loans/{}", req.loan_id), None).await.map_err(to_err)?;
+    
+    // Detect if the product is changing to avoid mixing configurations
+    let current_pid = current.get("productId").and_then(|v| v.as_i64())
+        .or_else(|| current.get("product").and_then(|p| p.get("id")).and_then(|id| id.as_i64()))
+        .unwrap_or(1);
+    let target_pid = req.product_id.unwrap_or(current_pid);
+    let is_switching_product = target_pid != current_pid;
+
+    let timeline = current.get("timeline");
+    let fmt_date = |key: &str| {
+        timeline.and_then(|t| t.get(key))
+            .and_then(|d| d.as_array())
+            .filter(|a| a.len() >= 3)
+            .map(|a| format!("{} {} {}", a[2], a[1], a[0]))
+    };
+
+    // 2. Prepare payload with existing mandatory fields as baseline
+    // If switching product, we use create_loan defaults instead of old baseline state
+    let mut payload = json!({
+        "productId": target_pid,
+        "principal": current.get("principal").and_then(|v| v.as_f64()).unwrap_or(0.0).to_string(),
+        "loanTermFrequency": current.get("termFrequency").and_then(|v| v.as_i64())
+            .or_else(|| current.get("loanTermFrequency").and_then(|v| v.as_i64()))
+            .unwrap_or(1),
+        "loanTermFrequencyType": if is_switching_product { 2 } else { current.get("termPeriodFrequencyType").and_then(|v| v.get("id")).and_then(|v| v.as_i64()).unwrap_or(2) },
+        "numberOfRepayments": current.get("numberOfRepayments").and_then(|v| v.as_i64()).unwrap_or(1),
+        "repaymentEvery": if is_switching_product { 1 } else { current.get("repaymentEvery").and_then(|v| v.as_i64()).unwrap_or(1) },
+        "repaymentFrequencyType": if is_switching_product { 2 } else { current.get("repaymentFrequencyType").and_then(|v| v.get("id")).and_then(|v| v.as_i64()).unwrap_or(2) },
+        "interestRatePerPeriod": if is_switching_product { 5.0 } else { current.get("interestRatePerPeriod").and_then(|v| v.as_f64()).unwrap_or(5.0) },
+        "amortizationType": if is_switching_product { 1 } else { current.get("amortizationType").and_then(|v| v.get("id")).and_then(|v| v.as_i64()).unwrap_or(1) },
+        "interestType": if is_switching_product { 0 } else { current.get("interestType").and_then(|v| v.get("id")).and_then(|v| v.as_i64()).unwrap_or(0) },
+        "interestCalculationPeriodType": if is_switching_product { 1 } else { current.get("interestCalculationPeriodType").and_then(|v| v.get("id")).and_then(|v| v.as_i64()).unwrap_or(1) },
+        "transactionProcessingStrategyCode": if is_switching_product { "mifos-standard-strategy" } else { current.get("transactionProcessingStrategyCode").and_then(|v| v.as_str()).unwrap_or("mifos-standard-strategy") },
+        "loanType": current.get("loanType").and_then(|v| v.get("value")).and_then(|v| v.as_str()).map(|s| s.to_lowercase()).unwrap_or_else(|| "individual".to_string()),
+        "locale": "en",
+        "dateFormat": "dd MMMM yyyy"
+    });
+
+    // Only set dates if they exist to avoid mutating historical audit data
+    if let Some(d) = fmt_date("expectedDisbursementDate") { payload["expectedDisbursementDate"] = json!(d); }
+    if let Some(d) = fmt_date("submittedOnDate") { payload["submittedOnDate"] = json!(d); }
+
+    // 3. Overlay the user's updates
+    if let Some(amt) = req.amount_exactly_from_user_prompt { payload["principal"] = json!(amt.to_string()); }
+    if let Some(m) = req.months { 
+        payload["loanTermFrequency"] = json!(m);
+        payload["numberOfRepayments"] = json!(m);
+        payload["loanTermFrequencyType"] = json!(2); // Monthly
+        payload["repaymentFrequencyType"] = json!(2); // Monthly
+        payload["repaymentEvery"] = json!(1); // Every 1 month
+    }
+    
+    let res = adapter.execute_put(&format!("loans/{}", req.loan_id), &payload).await.map_err(to_err)?;
+    to_result(res)
+}
+
+pub async fn delete_loan(adapter: &FineractAdapter, req: LoanIdReq) -> Result<CallToolResult, McpError> {
+    let res = adapter.execute_delete(&format!("loans/{}", req.loan_id)).await.map_err(to_err)?;
     to_result(res)
 }
 

--- a/rust/src/registry.rs
+++ b/rust/src/registry.rs
@@ -16,7 +16,7 @@ impl DomainRegistry {
         let mut map = HashMap::new();
         map.insert("clients", vec![
             "search_clients_by_name", "get_client_details", "get_client_accounts",
-            "create_client", "activate_client", "update_client_mobile", "close_client",
+            "create_client", "activate_client", "update_client_mobile", "update_client", "delete_client", "close_client",
             "create_group", "get_group_details", "get_client_identifiers",
             "create_client_identifier", "get_client_documents", "get_client_charges",
             "apply_client_charge", "pay_client_charge", "waive_client_charge",
@@ -30,6 +30,7 @@ impl DomainRegistry {
         ]);
         map.insert("loans", vec![
             "get_loan_details", "get_repayment_schedule", "create_loan",
+            "update_loan", "delete_loan",
             "approve_and_disburse_loan", "reject_loan_application",
             "make_loan_repayment", "apply_late_fee", "waive_interest",
             "get_overdue_loans", "create_group_loan", "list_loan_products"

--- a/rust/src/server.rs
+++ b/rust/src/server.rs
@@ -37,6 +37,10 @@ impl MifosMcpServer {
     async fn activate_client(&self, Parameters(req): Parameters<clients::ClientIdReq>) -> Result<CallToolResult, McpError> { clients::activate_client(&self.adapter, req).await }
     #[tool(description = "Update client mobile number. Use PUT.")]
     async fn update_client_mobile(&self, Parameters(req): Parameters<clients::UpdateMobileReq>) -> Result<CallToolResult, McpError> { clients::update_client_mobile(&self.adapter, req).await }
+    #[tool(description = "Update client details (firstname, lastname, etc.)")]
+    async fn update_client(&self, Parameters(req): Parameters<clients::UpdateClientReq>) -> Result<CallToolResult, McpError> { clients::update_client(&self.adapter, req).await }
+    #[tool(description = "Delete client profile")]
+    async fn delete_client(&self, Parameters(req): Parameters<clients::ClientIdReq>) -> Result<CallToolResult, McpError> { clients::delete_client(&self.adapter, req).await }
     #[tool(description = "Close client profile")]
     async fn close_client(&self, Parameters(req): Parameters<clients::CloseClientReq>) -> Result<CallToolResult, McpError> { clients::close_client(&self.adapter, req).await }
     #[tool(description = "Fetch ID documents for client")]
@@ -109,6 +113,10 @@ impl MifosMcpServer {
     async fn get_overdue_loans(&self, Parameters(req): Parameters<loans::ClientIdReq>) -> Result<CallToolResult, McpError> { loans::get_overdue_loans(&self.adapter, req).await }
     #[tool(description = "Create an individual loan")]
     async fn create_loan(&self, Parameters(req): Parameters<loans::CreateLoanReq>) -> Result<CallToolResult, McpError> { loans::create_loan(&self.adapter, req).await }
+    #[tool(description = "Update a draft/submitted loan application")]
+    async fn update_loan(&self, Parameters(req): Parameters<loans::UpdateLoanReq>) -> Result<CallToolResult, McpError> { loans::update_loan(&self.adapter, req).await }
+    #[tool(description = "Delete a draft/submitted loan application")]
+    async fn delete_loan(&self, Parameters(req): Parameters<loans::LoanIdReq>) -> Result<CallToolResult, McpError> { loans::delete_loan(&self.adapter, req).await }
     #[tool(description = "List all loan products")]
     async fn list_loan_products(&self, Parameters(req): Parameters<loans::EmptyReq>) -> Result<CallToolResult, McpError> { loans::list_loan_products(&self.adapter, req).await }
     #[tool(description = "Create a group loan")]


### PR DESCRIPTION
This PR introduces update and delete tools for Clients and Loans, expanding the suite to 89 tools.
It uses a “fetch-and-merge” approach to handle required fields automatically during updates.
The full workflows were tested end-to-end to ensure everything works reliably for production use.
<img width="1470" height="588" alt="Screenshot 2026-04-10 at 11 08 54 PM" src="https://github.com/user-attachments/assets/560707db-f971-41e2-8fa0-8eebfe86d18a" />

<img width="1470" height="658" alt="Screenshot 2026-04-10 at 11 41 33 PM" src="https://github.com/user-attachments/assets/77c073bf-df2d-47c5-8a6b-c9de28632569" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced comprehensive client update functionality to modify client profiles
  * Added client deletion capability for pending client records
  * Introduced robust loan update feature with intelligent mandatory field handling
  * Added loan deletion capability for draft loan records
  * Server tool inventory expanded from 85 to 89 available tools

<!-- end of auto-generated comment: release notes by coderabbit.ai -->