### PR TITLE
fix(security): Make SSL/TLS verification configurable via environment…

### DIFF
--- a/go/.env.example
+++ b/go/.env.example
@@ -1,8 +1,8 @@
 # Fineract Backend Configuration
 MIFOSX_BASE_URL=https://localhost:8443/fineract-provider/api/v1
-MIFOSX_TENANT_ID=default
 MIFOSX_USERNAME=<your_username>
 MIFOSX_PASSWORD=<your_password>
+MIFOSX_TENANT_ID=default
 
 # SSL/TLS Verification (set to "true" only for local development with self-signed certs)
 # For production, leave this unset or set to "false"

--- a/go/.env.example
+++ b/go/.env.example
@@ -1,8 +1,12 @@
 # Fineract Backend Configuration
 MIFOSX_BASE_URL=https://localhost:8443/fineract-provider/api/v1
 MIFOSX_TENANT_ID=default
-MIFOSX_USERNAME=mifos
-MIFOSX_PASSWORD=password
+MIFOSX_USERNAME=<your_username>
+MIFOSX_PASSWORD=<your_password>
+
+# SSL/TLS Verification (set to "true" only for local development with self-signed certs)
+# For production, leave this unset or set to "false"
+# MIFOSX_SKIP_TLS_VERIFY=true
 
 # OpenAI Configuration (Optional, for agent.py)
 OPENAI_API_KEY=your_openai_api_key_here

--- a/go/adapter/adapter.go
+++ b/go/adapter/adapter.go
@@ -37,6 +37,7 @@ func New() *FineractClient {
 	tenantID := os.Getenv("MIFOSX_TENANT_ID")
 	username := os.Getenv("MIFOSX_USERNAME")
 	password := os.Getenv("MIFOSX_PASSWORD")
+	skipTLSVerify := os.Getenv("MIFOSX_SKIP_TLS_VERIFY")
 
 	if baseURL == "" {
 		baseURL = "https://localhost:8443/fineract-provider/api/v1"
@@ -48,6 +49,9 @@ func New() *FineractClient {
 		username = "mifos"
 	}
 
+	// Default to false for security, only skip verification if explicitly set
+	insecureSkipVerify := strings.ToLower(skipTLSVerify) == "true"
+
 	return &FineractClient{
 		BaseURL:  strings.TrimRight(baseURL, "/"),
 		TenantID: tenantID,
@@ -56,7 +60,7 @@ func New() *FineractClient {
 		HTTP: &http.Client{
 			Timeout: 45 * time.Second,
 			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify},
 			},
 		},
 	}

--- a/python/.env.example
+++ b/python/.env.example
@@ -5,6 +5,10 @@ MIFOSX_USERNAME=your_username
 MIFOSX_PASSWORD=your_password
 MIFOSX_TENANT_ID=default
 
+# SSL/TLS Verification (set to "true" only for local development with self-signed certs)
+# For production, leave this unset or set to "false"
+# MIFOSX_SKIP_TLS_VERIFY=true
+
 # ── Banking Agent Server ───────────────────────────────────────────────
 APP_HOST=0.0.0.0
 APP_PORT=8000

--- a/python/tools/mcp_adapter.py
+++ b/python/tools/mcp_adapter.py
@@ -23,8 +23,9 @@ class FineractAdapter:
         self.username = os.getenv("MIFOSX_USERNAME")
         self.password = os.getenv("MIFOSX_PASSWORD")
         
-        # Default to True for backward compatibility, but should be False in production
-        self.verify_ssl = os.getenv("MIFOSX_SKIP_TLS_VERIFY", "true").lower() != "true"
+        # Default to False (secure) - SSL verification enabled by default
+        # Set MIFOSX_SKIP_TLS_VERIFY=true only for local dev with self-signed certs
+        self.verify_ssl = os.getenv("MIFOSX_SKIP_TLS_VERIFY", "false").lower() != "true"
 
         # Only suppress SSL warnings if verification is disabled
         if not self.verify_ssl:

--- a/python/tools/mcp_adapter.py
+++ b/python/tools/mcp_adapter.py
@@ -22,11 +22,15 @@ class FineractAdapter:
         self.tenant_id = os.getenv("MIFOSX_TENANT_ID", "default")
         self.username = os.getenv("MIFOSX_USERNAME")
         self.password = os.getenv("MIFOSX_PASSWORD")
+        
+        # Default to True for backward compatibility, but should be False in production
+        self.verify_ssl = os.getenv("MIFOSX_SKIP_TLS_VERIFY", "true").lower() != "true"
 
-        # STOP: Suppress SSL warnings for local self-signed certs (Docker)
-        requests.packages.urllib3.disable_warnings(
-            requests.packages.urllib3.exceptions.InsecureRequestWarning
-        )
+        # Only suppress SSL warnings if verification is disabled
+        if not self.verify_ssl:
+            requests.packages.urllib3.disable_warnings(
+                requests.packages.urllib3.exceptions.InsecureRequestWarning
+            )
 
     def _get_headers(self):
         """Builds the mandatory headers for Fineract."""
@@ -55,7 +59,7 @@ class FineractAdapter:
         try:
             response = requests.get(
                 url, headers=self._get_headers(), auth=(self.username, self.password),
-                params=params, verify=False
+                params=params, verify=self.verify_ssl
             )
             response.raise_for_status()
             return response.json()
@@ -73,7 +77,7 @@ class FineractAdapter:
         try:
             response = requests.post(
                 url, headers=self._get_headers(), auth=(self.username, self.password),
-                json=payload, verify=False
+                json=payload, verify=self.verify_ssl
             )
             response.raise_for_status()
             return response.json()
@@ -89,7 +93,7 @@ class FineractAdapter:
         try:
             response = requests.put(
                 url, headers=self._get_headers(), auth=(self.username, self.password),
-                json=payload, verify=False
+                json=payload, verify=self.verify_ssl
             )
             response.raise_for_status()
             return response.json()
@@ -105,7 +109,7 @@ class FineractAdapter:
         try:
             response = requests.delete(
                 url, headers=self._get_headers(), auth=(self.username, self.password),
-                verify=False
+                verify=self.verify_ssl
             )
             response.raise_for_status()
             return response.json()

--- a/rust/.env.example
+++ b/rust/.env.example
@@ -1,4 +1,8 @@
 MIFOSX_BASE_URL=https://localhost:8443/fineract-provider/api/v1
 MIFOSX_TENANT_ID=default
-MIFOSX_USERNAME=mifos
-MIFOSX_PASSWORD=password
+MIFOSX_USERNAME=<your_username>
+MIFOSX_PASSWORD=<your_password>
+
+# SSL/TLS Verification (set to "true" only for local development with self-signed certs)
+# For production, leave this unset or set to "false"
+# MIFOSX_SKIP_TLS_VERIFY=true

--- a/rust/.env.example
+++ b/rust/.env.example
@@ -1,7 +1,7 @@
 MIFOSX_BASE_URL=https://localhost:8443/fineract-provider/api/v1
-MIFOSX_TENANT_ID=default
 MIFOSX_USERNAME=<your_username>
 MIFOSX_PASSWORD=<your_password>
+MIFOSX_TENANT_ID=default
 
 # SSL/TLS Verification (set to "true" only for local development with self-signed certs)
 # For production, leave this unset or set to "false"

--- a/rust/src/adapter.rs
+++ b/rust/src/adapter.rs
@@ -21,9 +21,14 @@ impl FineractAdapter {
         let tenant_id = env::var("MIFOSX_TENANT_ID").unwrap_or_else(|_| "default".to_string());
         let _username = env::var("MIFOSX_USERNAME").expect("MIFOSX_USERNAME must be set");
         let _password = env::var("MIFOSX_PASSWORD").expect("MIFOSX_PASSWORD must be set");
+        
+        // Default to false for security, only skip verification if explicitly set
+        let skip_tls_verify = env::var("MIFOSX_SKIP_TLS_VERIFY")
+            .map(|v| v.to_lowercase() == "true")
+            .unwrap_or(false);
 
         let client = Client::builder()
-            .danger_accept_invalid_certs(true)
+            .danger_accept_invalid_certs(skip_tls_verify)
             .build()?;
 
         Ok(Self {


### PR DESCRIPTION
# SSL/TLS Verification Security Fix

## 🚨 Issue

All three implementations (Go, Rust, Python) had **SSL/TLS certificate verification hardcoded to disabled**, making production deployments vulnerable to **man-in-the-middle attacks**.

**Before:**
```go
// Go
TLSClientConfig: &tls.Config{InsecureSkipVerify: true}  // ❌ Always disabled
```
```rust
// Rust
.danger_accept_invalid_certs(true)  // ❌ Always disabled
```
```python
# Python
response = requests.get(url, verify=False)  // ❌ Always disabled
```

---

## ✅ Fix

Added `MIFOSX_SKIP_TLS_VERIFY` environment variable. SSL verification is now **ENABLED by default** (secure).

**After:**
```go
// Go
skipTLSVerify := os.Getenv("MIFOSX_SKIP_TLS_VERIFY")
insecureSkipVerify := strings.ToLower(skipTLSVerify) == "true"
TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify}
```
```rust
// Rust
let skip_tls_verify = env::var("MIFOSX_SKIP_TLS_VERIFY")
    .map(|v| v.to_lowercase() == "true")
    .unwrap_or(false);
.danger_accept_invalid_certs(skip_tls_verify)
```
```python
# Python
self.verify_ssl = os.getenv("MIFOSX_SKIP_TLS_VERIFY", "true").lower() != "true"
response = requests.get(url, verify=self.verify_ssl)
```

---

## 📖 Usage

**Production (Secure):**
```env
MIFOSX_BASE_URL=https://your-fineract-instance.com/api/v1
# Don't set MIFOSX_SKIP_TLS_VERIFY - SSL verification ENABLED ✅
```

**Local Dev (Self-signed certs):**
```env
MIFOSX_BASE_URL=https://localhost:8443/fineract-provider/api/v1
MIFOSX_SKIP_TLS_VERIFY=true  # ⚠️ Development only
```

---

## 📝 Files Changed

| File | Change |
|------|--------|
| `go/adapter/adapter.go` | Configurable TLS verification |
| `rust/src/adapter.rs` | Configurable certificate validation |
| `python/tools/mcp_adapter.py` | Configurable SSL verification |
| `*/.env.example` | Added security documentation |

---

## 🔒 Security Impact

- ✅ Prevents man-in-the-middle attacks
- ✅ Secure by default
- ✅ Configurable for development
- ✅ No new dependencies
- ✅ Backward compatible

---

## ⚠️ Note

**Breaking change**: SSL verification is now enabled by default. If using self-signed certificates locally, add `MIFOSX_SKIP_TLS_VERIFY=true` to your `.env` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated environment credential placeholders across all SDK implementations to require explicit user input.
  * Added optional SSL/TLS verification toggle for local development with self-signed certificates.

* **Security**
  * Changed SSL/TLS verification behavior from always disabled to conditionally configurable, with secure defaults for production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->