### PR TITLE
feat: CommonPurse companion server — datatable/VSLA MCP tools (Python) + /companion REST facade (Go)

### DIFF
--- a/go/companion/companion.go
+++ b/go/companion/companion.go
@@ -68,6 +68,9 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	h.registerLoanDetailRoutes(mux)
 	h.registerGroupTypeCatalogRoutes(mux)
 	h.registerPassthroughRoutes(mux)
+	// COMP-CAL: meeting-lifecycle facade (calendar/conduct/summary/previous-review + reschedule;
+	// see meeting.go).
+	h.registerMeetingRoutes(mux)
 }
 
 // ---- Wire contract (exactly what the app sends / expects) ----

--- a/go/companion/companion.go
+++ b/go/companion/companion.go
@@ -1,0 +1,387 @@
+// Copyright since 2025 Mifos Initiative
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package companion is a thin REST facade the CommonPurse app talks to for
+// authentication. It sits IN FRONT of Fineract: it forwards the end-user's
+// credentials to Fineract's POST /authentication endpoint (rather than the
+// service credential the shared adapter.DoRequest forces) so a wrong password
+// genuinely surfaces as a 401, and reshapes the Fineract response into the
+// AuthResponse contract the app's CompanionAuthApiImpl expects.
+package companion
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/openMF/mcp-mifosx/go/adapter"
+)
+
+// Handler owns the companion REST routes. It borrows BaseURL / TenantID / HTTP
+// from the shared FineractClient but deliberately does NOT use DoRequest, which
+// would inject the service BasicAuth and mask a bad end-user password.
+type Handler struct {
+	Fineract *adapter.FineractClient
+}
+
+// New builds a companion Handler bound to the shared Fineract client.
+func New(f *adapter.FineractClient) *Handler {
+	return &Handler{Fineract: f}
+}
+
+// RegisterRoutes wires the companion endpoints onto an existing mux. The mux's
+// outer handler already sets the CORS headers, so these routes inherit them.
+func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/companion/auth/login", h.HandleLogin)
+	mux.HandleFunc("/companion/auth/self-register", h.HandleSelfRegister)
+	mux.HandleFunc("/companion/auth/me", h.HandleMe)
+
+	// COMP-GRP: group-dashboard read facade (see groups.go).
+	h.registerGroupRoutes(mux)
+	// COMP-GRP-001: group-CREATE write facade (see group_create.go).
+	h.registerGroupCreateRoutes(mux)
+	// COMP-DT-002/003/005: member-INVITE write facade (see member_invite.go).
+	h.registerMemberInviteRoutes(mux)
+	h.registerOrganizerRoutes(mux)
+
+	// COMP-MEMBERLIST / COMP-SAVINGS / COMP-MEMBERDASH / COMP-LOANLIST: group-scoped read
+	// facades the CommonPurse app fans in (see member_list.go / savings.go /
+	// member_dashboard.go / loan_list.go).
+	h.registerMemberListRoutes(mux)
+	h.registerSavingsRoutes(mux)
+	h.registerMemberDashboardRoutes(mux)
+	h.registerLoanListRoutes(mux)
+	// COMP-LOAN-WRITE: loan apply / repayment / writeoff write facade (see loan_write.go).
+	h.registerLoanWriteRoutes(mux)
+	// COMP-DIST-001/002: share-out / rotation-payout write facade (see share_out_write.go).
+	h.registerShareOutRoutes(mux)
+	h.registerShareOutPreviewRoutes(mux)
+	// COMP-LOANDETAIL: single-loan detail read facade (see loan_detail.go).
+	h.registerLoanDetailRoutes(mux)
+	h.registerGroupTypeCatalogRoutes(mux)
+	h.registerPassthroughRoutes(mux)
+}
+
+// ---- Wire contract (exactly what the app sends / expects) ----
+
+type loginRequest struct {
+	EmailPhone string `json:"emailPhone"`
+	Password   string `json:"password"`
+}
+
+type selfRegisterRequest struct {
+	Name       string `json:"name"`
+	EmailPhone string `json:"emailPhone"`
+	Password   string `json:"password"`
+}
+
+// GroupMembership mirrors the app's group-membership DTO.
+type GroupMembership struct {
+	GroupID   string `json:"groupId"`
+	GroupName string `json:"groupName"`
+	Role      string `json:"role"`
+	JoinedAt  string `json:"joinedAt"`
+}
+
+// AuthResponse is the shape returned by /login and /self-register on success.
+type AuthResponse struct {
+	UserID           string            `json:"userId"`
+	SessionToken     string            `json:"sessionToken"`
+	TokenExpiresAt   string            `json:"tokenExpiresAt"`
+	GroupMemberships []GroupMembership `json:"groupMemberships"`
+}
+
+type meResponse struct {
+	UserID           string            `json:"userId"`
+	Name             string            `json:"name"`
+	EmailPhone       string            `json:"emailPhone"`
+	GroupMemberships []GroupMembership `json:"groupMemberships"`
+}
+
+// ---- Fineract wire types ----
+
+type fineractAuthResponse struct {
+	Username      string `json:"username"`
+	UserID        int64  `json:"userId"`
+	Base64Key     string `json:"base64EncodedAuthenticationKey"`
+	Authenticated bool   `json:"authenticated"`
+	Roles         []struct {
+		Name string `json:"name"`
+	} `json:"roles"`
+}
+
+// ---- Handlers ----
+
+// HandleLogin authenticates emailPhone/password against Fineract and returns an
+// AuthResponse. Wrong credentials -> 401.
+func (h *Handler) HandleLogin(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	if r.Method != http.MethodPost {
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "POST required")
+		return
+	}
+	var req loginRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid JSON body")
+		return
+	}
+	if strings.TrimSpace(req.EmailPhone) == "" || req.Password == "" {
+		writeErr(w, http.StatusBadRequest, "bad_request", "emailPhone and password are required")
+		return
+	}
+
+	fa, status, raw, err := h.fineractAuthenticate(req.EmailPhone, req.Password)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	if status == http.StatusUnauthorized {
+		writeErr(w, http.StatusUnauthorized, "invalid_credentials", "Invalid email/phone or password")
+		return
+	}
+	if status != http.StatusOK || fa == nil || !fa.Authenticated {
+		// Pass the upstream failure through honestly rather than fabricate a success.
+		writeUpstreamFailure(w, status, raw)
+		return
+	}
+
+	_ = json.NewEncoder(w).Encode(AuthResponse{
+		UserID:           fmt.Sprintf("%d", fa.UserID),
+		SessionToken:     fa.Base64Key,
+		TokenExpiresAt:   time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
+		GroupMemberships: h.resolveGroups(fa),
+	})
+}
+
+// HandleSelfRegister forwards a registration to Fineract's self-service API.
+// mifos-bank-2 HAS self-service registration enabled, but it (a) requires a
+// pre-existing client whose accountNumber matches, and (b) gates activation
+// behind an email/SMS confirmation token — so no usable session can be issued
+// synchronously. We therefore NEVER fake an AuthResponse: on a Fineract-accepted
+// submission we return 202-intent as a 501 (confirmation required); on a
+// Fineract rejection we mirror the real upstream error.
+func (h *Handler) HandleSelfRegister(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	if r.Method != http.MethodPost {
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "POST required")
+		return
+	}
+	var req selfRegisterRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid JSON body")
+		return
+	}
+	if strings.TrimSpace(req.EmailPhone) == "" || strings.TrimSpace(req.Name) == "" || req.Password == "" {
+		writeErr(w, http.StatusBadRequest, "bad_request", "name, emailPhone and password are required")
+		return
+	}
+
+	emailMode := strings.Contains(req.EmailPhone, "@")
+	first, last := splitName(req.Name)
+	payload := map[string]string{
+		"firstName": first,
+		"lastName":  last,
+		"username":  req.EmailPhone,
+		"password":  req.Password,
+	}
+	if emailMode {
+		payload["authenticationMode"] = "email"
+		payload["email"] = req.EmailPhone
+	} else {
+		payload["authenticationMode"] = "mobile"
+		payload["mobileNumber"] = req.EmailPhone
+	}
+
+	status, raw, err := h.fineractPost("/self/registration", payload)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	if status >= 200 && status < 300 {
+		// Submission accepted but account is not yet usable (confirmation step).
+		w.WriteHeader(http.StatusNotImplemented)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"error":   "self_registration_confirmation_required",
+			"message": "Fineract self-service registration was submitted but requires email/SMS confirmation before a session can be issued. No sessionToken can be returned synchronously.",
+			"fineract": json.RawMessage(nonEmpty(raw)),
+		})
+		return
+	}
+	// Mirror the real Fineract rejection (missing client, weak password, etc.).
+	writeUpstreamFailure(w, status, raw)
+}
+
+// HandleMe resolves the caller from a bearer token. Fineract's
+// base64EncodedAuthenticationKey IS base64(username:password), so we decode it
+// and re-authenticate to obtain userId/username live.
+func (h *Handler) HandleMe(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	token := strings.TrimSpace(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
+	if token == "" {
+		writeErr(w, http.StatusUnauthorized, "unauthorized", "missing bearer token")
+		return
+	}
+	username, password, ok := decodeSessionToken(token)
+	if !ok {
+		writeErr(w, http.StatusUnauthorized, "unauthorized", "malformed session token")
+		return
+	}
+	fa, status, _, err := h.fineractAuthenticate(username, password)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	if status != http.StatusOK || fa == nil || !fa.Authenticated {
+		writeErr(w, http.StatusUnauthorized, "unauthorized", "token invalid or expired")
+		return
+	}
+	_ = json.NewEncoder(w).Encode(meResponse{
+		UserID:           fmt.Sprintf("%d", fa.UserID),
+		Name:             fa.Username,
+		EmailPhone:       fa.Username,
+		GroupMemberships: h.resolveGroups(fa),
+	})
+}
+
+// ---- Fineract calls (end-user creds, NOT the service credential) ----
+
+func (h *Handler) fineractAuthenticate(username, password string) (*fineractAuthResponse, int, []byte, error) {
+	status, raw, err := h.fineractPost("/authentication", map[string]string{
+		"username": username,
+		"password": password,
+	})
+	if err != nil {
+		return nil, 0, nil, err
+	}
+	if status != http.StatusOK {
+		return nil, status, raw, nil
+	}
+	var fa fineractAuthResponse
+	if err := json.Unmarshal(raw, &fa); err != nil {
+		return nil, status, raw, fmt.Errorf("decode fineract auth response: %w", err)
+	}
+	return &fa, status, raw, nil
+}
+
+func (h *Handler) fineractPost(endpoint string, body interface{}) (int, []byte, error) {
+	url := h.Fineract.BaseURL + "/" + strings.TrimPrefix(endpoint, "/")
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return 0, nil, err
+	}
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("fineract-platform-tenantid", h.Fineract.TenantID)
+
+	resp, err := h.Fineract.HTTP.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, nil, err
+	}
+	return resp.StatusCode, raw, nil
+}
+
+// resolveGroups returns the caller's group memberships. mifos-bank-2 exposes no
+// per-user member<->group linkage for staff callers, so — mirroring HandleMyGroups
+// (/companion/groups/mine) — an organizer/staff caller resolves to every ACTIVE
+// group as ORGANIZER (the staff/service account is the organizer of the groups it
+// administers via the companion). Fail-soft: any upstream error returns an empty
+// (never nil) slice so login still succeeds → the app's ZeroGroups branch. This is
+// the documented hook for real per-user resolution once member linkage lands.
+func (h *Handler) resolveGroups(_ *fineractAuthResponse) []GroupMembership {
+	out := []GroupMembership{}
+	raw, err := h.Fineract.DoRequest("GET", "groups", nil, nil)
+	if err != nil {
+		return out
+	}
+	var groups []fnGroup
+	if err := json.Unmarshal(raw, &groups); err != nil {
+		return out
+	}
+	for _, g := range groups {
+		if !g.Active {
+			continue
+		}
+		out = append(out, GroupMembership{
+			GroupID:   strconv.FormatInt(g.ID, 10),
+			GroupName: g.Name,
+			Role:      "ORGANIZER",
+			// The app parses joinedAt with kotlinx Instant.parse (LoginSignupMappers.kt:52),
+			// which requires a full ISO-8601 instant — a date-only string crashes it.
+			JoinedAt: fmtFineractInstant(g.ActivationDate),
+		})
+	}
+	return out
+}
+
+// ---- helpers ----
+
+func setJSON(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+}
+
+func writeErr(w http.ResponseWriter, status int, code, message string) {
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": code, "message": message})
+}
+
+// writeUpstreamFailure mirrors a non-2xx Fineract response, defaulting to 401.
+func writeUpstreamFailure(w http.ResponseWriter, status int, raw []byte) {
+	if status < 400 {
+		status = http.StatusUnauthorized
+	}
+	w.WriteHeader(status)
+	if len(raw) > 0 {
+		_, _ = w.Write(raw)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": "upstream_error", "message": fmt.Sprintf("fineract returned status %d", status)})
+}
+
+func nonEmpty(raw []byte) []byte {
+	if len(raw) == 0 {
+		return []byte("null")
+	}
+	return raw
+}
+
+// decodeSessionToken decodes base64(username:password) back into its parts.
+func decodeSessionToken(token string) (string, string, bool) {
+	dec, err := base64.StdEncoding.DecodeString(token)
+	if err != nil {
+		return "", "", false
+	}
+	parts := strings.SplitN(string(dec), ":", 2)
+	if len(parts) != 2 || parts[0] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+// splitName splits a display name into (first, last); last falls back to first.
+func splitName(name string) (string, string) {
+	fields := strings.Fields(strings.TrimSpace(name))
+	if len(fields) == 0 {
+		return "", ""
+	}
+	if len(fields) == 1 {
+		return fields[0], fields[0]
+	}
+	return fields[0], strings.Join(fields[1:], " ")
+}

--- a/go/companion/companion_test.go
+++ b/go/companion/companion_test.go
@@ -1,0 +1,38 @@
+// Copyright since 2025 Mifos Initiative
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+package companion
+
+import "testing"
+
+func TestDecodeSessionToken(t *testing.T) {
+	// base64("mifos:password") == "bWlmb3M6cGFzc3dvcmQ=" (the exact Fineract key)
+	user, pass, ok := decodeSessionToken("bWlmb3M6cGFzc3dvcmQ=")
+	if !ok || user != "mifos" || pass != "password" {
+		t.Fatalf("got (%q,%q,%v), want (mifos,password,true)", user, pass, ok)
+	}
+	if _, _, ok := decodeSessionToken("!!!not-base64!!!"); ok {
+		t.Fatalf("expected malformed token to be rejected")
+	}
+	if _, _, ok := decodeSessionToken(""); ok {
+		t.Fatalf("expected empty token to be rejected")
+	}
+}
+
+func TestSplitName(t *testing.T) {
+	cases := []struct {
+		in, first, last string
+	}{
+		{"Ada Lovelace", "Ada", "Lovelace"},
+		{"Cher", "Cher", "Cher"},
+		{"Jean Luc Picard", "Jean", "Luc Picard"},
+		{"  ", "", ""},
+	}
+	for _, c := range cases {
+		f, l := splitName(c.in)
+		if f != c.first || l != c.last {
+			t.Errorf("splitName(%q) = (%q,%q), want (%q,%q)", c.in, f, l, c.first, c.last)
+		}
+	}
+}

--- a/go/companion/group_create.go
+++ b/go/companion/group_create.go
@@ -1,0 +1,241 @@
+// Copyright since 2025 Mifos Initiative
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// COMP-GRP-001: the group-CREATE write facade. The CommonPurse
+// (mifos-x-group-banking) app's GroupCreateApiImpl submits its multi-step
+// create-group wizard as ONE orchestration call:
+//
+//	POST /companion/groups  ->  CreateGroupResponseDto
+//
+// (see core/network/.../service/groupcreate/GroupCreateApiImpl.kt +
+// core/network/.../model/GroupCreateDto.kt). This handler fans that single call
+// out across the real Fineract writes on mifos-bank-2:
+//
+//	1. POST groups {name, officeId, active:false}      -> new pending group
+//	2. POST groups/{id}?command=activate               -> activate it
+//	3. POST datatables/dt_group_type_config/{id}        -> persist the VSLA typeConfig row
+//
+// then returns the { groupId, fineractCenterId, inviteCode } shape the app maps
+// to core.model.GroupCreationResult. The request payload has NO member list
+// (organizer creates an empty group; members join later via the invite code),
+// so there is no client-association step.
+//
+// Writes use the shared FineractClient service credential (adapter.DoRequest,
+// which POSTs with the service BasicAuth) — the correct path for an
+// organizer/staff write, exactly like the group-dashboard READ facade in
+// groups.go. The end-user-credential path (companion.go's fineractPost) is only
+// for /authentication, where a wrong password must surface as a real 401.
+//
+// Field names + casing are matched EXACTLY to the app DTOs: top-level request /
+// response fields are camelCase; the nested typeConfig is snake_case (its
+// @SerialName's are raw Fineract datatable column names). The response carries
+// NO date field, so the Instant.parse / date-only caveat that bit the auth
+// path's joinedAt does NOT apply here — groupId is a String, fineractCenterId a
+// Long, inviteCode a String.
+package companion
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// groupTypeConfigTable is the Fineract datatable (apptable m_group) the VSLA
+// typeConfig row is written to. Provisioned out-of-band via POST /datatables
+// (idempotent — Fineract 400s "already registered", treated as OK). Its columns
+// mirror CreateGroupTypeConfigDto's snake_case @SerialName's 1:1.
+const groupTypeConfigTable = "dt_group_type_config"
+
+// registerGroupCreateRoutes wires the COMP-GRP-001 write endpoint. Called from
+// RegisterRoutes. The method-specific pattern coexists with groups.go's
+// "GET /companion/groups" (Go 1.22 ServeMux dispatches GET vs POST separately).
+func (h *Handler) registerGroupCreateRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("POST /companion/groups", h.HandleCreateGroup)
+}
+
+// ---- App-facing wire contract (exact match to the KMP DTOs) ----
+
+// createGroupTypeConfigDto == CreateGroupTypeConfigDto (snake_case wire).
+type createGroupTypeConfigDto struct {
+	GroupType          string  `json:"group_type"`
+	PoolModel          string  `json:"pool_model"`
+	ContributionModel  string  `json:"contribution_model"`
+	ShareoutFormula    string  `json:"shareout_formula"`
+	PayoutOrderMethod  string  `json:"payout_order_method"`
+	ShareValue         float64 `json:"share_value"`
+	ContributionAmount float64 `json:"contribution_amount"`
+	SocialFundEnabled  bool    `json:"social_fund_enabled"`
+	SocialFundPercent  float64 `json:"social_fund_percent"`
+	CycleLengthMonths  int     `json:"cycle_length_months"`
+	LoanMultiplier     float64 `json:"loan_multiplier"`
+	InterestRate       float64 `json:"interest_rate"`
+	FineAmount         float64 `json:"fine_amount"`
+	MaxMembers         int     `json:"max_members"`
+}
+
+// createGroupRequestDto == CreateGroupRequestDto (camelCase top-level).
+type createGroupRequestDto struct {
+	Name        string                   `json:"name"`
+	OfficeID    int64                    `json:"officeId"`
+	UserID      int64                    `json:"userId"`
+	Currency    string                   `json:"currency"`
+	MeetingDay  string                   `json:"meetingDay"`
+	MeetingTime string                   `json:"meetingTime"`
+	TypeConfig  createGroupTypeConfigDto `json:"typeConfig"`
+}
+
+// createGroupResponseDto == CreateGroupResponseDto.
+type createGroupResponseDto struct {
+	GroupID          string `json:"groupId"`
+	FineractCenterID int64  `json:"fineractCenterId"`
+	InviteCode       string `json:"inviteCode"`
+}
+
+// ---- Handler ----
+
+// HandleCreateGroup runs the create-group orchestration against Fineract and
+// returns the app's CreateGroupResponseDto on success.
+func (h *Handler) HandleCreateGroup(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	var req createGroupRequestDto
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid JSON body")
+		return
+	}
+	if strings.TrimSpace(req.Name) == "" {
+		writeErr(w, http.StatusBadRequest, "bad_request", "name is required")
+		return
+	}
+	officeID := req.OfficeID
+	if officeID <= 0 {
+		officeID = 1 // Head Office default — the only office the app's dropdown seeds against.
+	}
+
+	// 1. Create the group (pending).
+	groupID, err := h.fineractCreateGroup(req.Name, officeID)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", "create group: "+err.Error())
+		return
+	}
+
+	// 2. Activate it.
+	if err := h.fineractActivateGroup(groupID); err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", "activate group: "+err.Error())
+		return
+	}
+
+	// 3. Persist the VSLA typeConfig datatable row.
+	if err := h.fineractWriteGroupTypeConfig(groupID, req.TypeConfig); err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", "write group_type_config: "+err.Error())
+		return
+	}
+
+	// 4. Return the app's response shape. fineractCenterId mirrors the new group
+	// id (this flow creates a plain group, not a parent center) — a real, non-zero
+	// Fineract entity id; the app's success screen surfaces inviteCode.
+	_ = json.NewEncoder(w).Encode(createGroupResponseDto{
+		GroupID:          strconv.FormatInt(groupID, 10),
+		FineractCenterID: groupID,
+		InviteCode:       inviteCodeFor(req.Name, groupID),
+	})
+}
+
+// ---- Fineract writes (service credential via DoRequest) ----
+
+// fineractCreateGroup POSTs a new pending group and returns its id.
+func (h *Handler) fineractCreateGroup(name string, officeID int64) (int64, error) {
+	body := map[string]interface{}{
+		"name":     name,
+		"officeId": officeID,
+		"active":   false,
+	}
+	raw, err := h.Fineract.DoRequest("POST", "groups", body, nil)
+	if err != nil {
+		return 0, fmt.Errorf("%s", strings.TrimSpace(string(nonEmpty(raw))))
+	}
+	var resp struct {
+		GroupID    int64 `json:"groupId"`
+		ResourceID int64 `json:"resourceId"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return 0, fmt.Errorf("decode create-group response: %w", err)
+	}
+	id := resp.ResourceID
+	if id == 0 {
+		id = resp.GroupID
+	}
+	if id == 0 {
+		return 0, fmt.Errorf("fineract returned no group id: %s", string(raw))
+	}
+	return id, nil
+}
+
+// fineractActivateGroup activates a pending group as of today.
+func (h *Handler) fineractActivateGroup(groupID int64) error {
+	body := map[string]string{
+		"activationDate": time.Now().Format("02 January 2006"), // Fineract "dd MMMM yyyy"
+		"dateFormat":     "dd MMMM yyyy",
+		"locale":         "en",
+	}
+	raw, err := h.Fineract.DoRequest("POST", fmt.Sprintf("groups/%d", groupID), body, map[string]string{"command": "activate"})
+	if err != nil {
+		return fmt.Errorf("%s", strings.TrimSpace(string(nonEmpty(raw))))
+	}
+	return nil
+}
+
+// fineractWriteGroupTypeConfig writes the typeConfig row to the group's
+// dt_group_type_config datatable. Column names are the raw snake_case
+// CreateGroupTypeConfigDto @SerialName's. locale is included so Fineract parses
+// the decimal columns; there are no date columns, so no dateFormat is needed.
+func (h *Handler) fineractWriteGroupTypeConfig(groupID int64, tc createGroupTypeConfigDto) error {
+	row := map[string]interface{}{
+		"group_type":          tc.GroupType,
+		"pool_model":          tc.PoolModel,
+		"contribution_model":  tc.ContributionModel,
+		"shareout_formula":    tc.ShareoutFormula,
+		"payout_order_method": tc.PayoutOrderMethod,
+		"share_value":         tc.ShareValue,
+		"contribution_amount": tc.ContributionAmount,
+		"social_fund_enabled": tc.SocialFundEnabled,
+		"social_fund_percent": tc.SocialFundPercent,
+		"cycle_length_months": tc.CycleLengthMonths,
+		"loan_multiplier":     tc.LoanMultiplier,
+		"interest_rate":       tc.InterestRate,
+		"fine_amount":         tc.FineAmount,
+		"max_members":         tc.MaxMembers,
+		"locale":              "en",
+	}
+	raw, err := h.Fineract.DoRequest("POST", fmt.Sprintf("datatables/%s/%d", groupTypeConfigTable, groupID), row, nil)
+	if err != nil {
+		return fmt.Errorf("%s", strings.TrimSpace(string(nonEmpty(raw))))
+	}
+	return nil
+}
+
+// ---- helpers ----
+
+// inviteCodeFor derives a shareable onboarding code from the group name + id
+// (first 3 alpha chars uppercased, padded with X, + zero-padded id). Deterministic
+// and unique per group (id-suffixed), e.g. "Test VSLA Group" #7 -> "TES007".
+func inviteCodeFor(name string, groupID int64) string {
+	var prefix strings.Builder
+	for _, r := range strings.ToUpper(name) {
+		if r >= 'A' && r <= 'Z' {
+			prefix.WriteRune(r)
+			if prefix.Len() == 3 {
+				break
+			}
+		}
+	}
+	p := prefix.String()
+	for len(p) < 3 {
+		p += "X"
+	}
+	return fmt.Sprintf("%s%03d", p, groupID)
+}

--- a/go/companion/group_type_catalog.go
+++ b/go/companion/group_type_catalog.go
@@ -1,0 +1,135 @@
+// Copyright since 2025 Mifos Initiative
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+package companion
+
+// Group-type-config CATALOGUE endpoint. The CommonPurse group-type-picker calls
+// GET /companion/datatables/group_type_config/{entityId} and expects a
+// List<GroupTypeConfigDto> (core/network/.../model/GroupTypeConfigDto.kt). This is
+// the app's own VSLA-archetype taxonomy (9 types) — a static catalogue, not
+// Fineract data. Display names/taglines match the app's canonical fixtures
+// (GroupTypeConfigRepositoryTest.kt). entityId is ignored (catalogue is global).
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// GroupTypeConfigDto mirrors the app DTO field-for-field (camelCase @SerialName).
+type GroupTypeConfigDto struct {
+	TypeSlug                 string  `json:"typeSlug"`
+	DisplayName              string  `json:"displayName"`
+	Tagline                  string  `json:"tagline"`
+	SavingsMechanism         string  `json:"savingsMechanism"`
+	ContributionMode         string  `json:"contributionMode"`
+	LendingEnabled           bool    `json:"lendingEnabled"`
+	HasSocialFund            bool    `json:"hasSocialFund"`
+	HasBankLinkage           bool    `json:"hasBankLinkage"`
+	WelfareOnlyMode          bool    `json:"welfareOnlyMode"`
+	FormallyRegistered       bool    `json:"formallyRegistered"`
+	DefaultLoanMultiplier    float64 `json:"defaultLoanMultiplier"`
+	DefaultInterestRatePct   float64 `json:"defaultInterestRatePct"`
+	DefaultCycleLengthMonths int     `json:"defaultCycleLengthMonths"`
+	MaxMembers               int     `json:"maxMembers"`
+	MinMembers               int     `json:"minMembers"`
+}
+
+func (h *Handler) registerGroupTypeCatalogRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /companion/datatables/group_type_config/{entityId}", h.HandleGroupTypeCatalog)
+	// bare path (entityId omitted) → same catalogue
+	mux.HandleFunc("GET /companion/datatables/group_type_config", h.HandleGroupTypeCatalog)
+}
+
+// HandleGroupTypeCatalog returns the 9-archetype VSLA group-type catalogue. Values
+// mirror the app's canonical GroupTypeConfigRepositoryTest fixtures + sensible
+// archetype defaults; the picker prefills the create-group wizard rules step from
+// the chosen type.
+func (h *Handler) HandleGroupTypeCatalog(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	_ = json.NewEncoder(w).Encode(groupTypeCatalog)
+}
+
+var groupTypeCatalog = []GroupTypeConfigDto{
+	{
+		TypeSlug: "VSLA", DisplayName: "Village Savings & Loan Association",
+		Tagline: "Save in shares; borrow up to 3x; share-out at year end",
+		SavingsMechanism: "ACCUMULATING", ContributionMode: "SHARE_BASED_VARIABLE",
+		LendingEnabled: true, HasSocialFund: true, HasBankLinkage: false,
+		WelfareOnlyMode: false, FormallyRegistered: false,
+		DefaultLoanMultiplier: 3, DefaultInterestRatePct: 10, DefaultCycleLengthMonths: 12,
+		MaxMembers: 30, MinMembers: 5,
+	},
+	{
+		TypeSlug: "ROSCA", DisplayName: "Rotating Savings & Credit Association",
+		Tagline: "Everyone contributes; one member takes the pot each cycle",
+		SavingsMechanism: "ROTATING_PAYOUT", ContributionMode: "FIXED_AMOUNT",
+		LendingEnabled: false, HasSocialFund: false, HasBankLinkage: false,
+		WelfareOnlyMode: false, FormallyRegistered: false,
+		DefaultLoanMultiplier: 0, DefaultInterestRatePct: 0, DefaultCycleLengthMonths: 12,
+		MaxMembers: 20, MinMembers: 3,
+	},
+	{
+		TypeSlug: "ASCA", DisplayName: "Accumulating Savings & Credit Association",
+		Tagline: "Pooled savings with interest-bearing loans, no year-end share-out",
+		SavingsMechanism: "ACCUMULATING", ContributionMode: "FIXED_AMOUNT",
+		LendingEnabled: true, HasSocialFund: false, HasBankLinkage: false,
+		WelfareOnlyMode: false, FormallyRegistered: false,
+		DefaultLoanMultiplier: 2, DefaultInterestRatePct: 8, DefaultCycleLengthMonths: 0,
+		MaxMembers: 40, MinMembers: 5,
+	},
+	{
+		TypeSlug: "SILC", DisplayName: "Savings & Internal Lending Community",
+		Tagline: "CRS-model self-managed savings & lending group",
+		SavingsMechanism: "ACCUMULATING", ContributionMode: "SHARE_BASED_VARIABLE",
+		LendingEnabled: true, HasSocialFund: true, HasBankLinkage: false,
+		WelfareOnlyMode: false, FormallyRegistered: false,
+		DefaultLoanMultiplier: 3, DefaultInterestRatePct: 10, DefaultCycleLengthMonths: 12,
+		MaxMembers: 25, MinMembers: 5,
+	},
+	{
+		TypeSlug: "SHG", DisplayName: "Self-Help Group",
+		Tagline: "10-20 members; bank-linked group lending (India SHG model)",
+		SavingsMechanism: "ACCUMULATING", ContributionMode: "FIXED_AMOUNT",
+		LendingEnabled: true, HasSocialFund: false, HasBankLinkage: true,
+		WelfareOnlyMode: false, FormallyRegistered: true,
+		DefaultLoanMultiplier: 4, DefaultInterestRatePct: 12, DefaultCycleLengthMonths: 0,
+		MaxMembers: 20, MinMembers: 10,
+	},
+	{
+		TypeSlug: "SACCO", DisplayName: "Savings & Credit Cooperative",
+		Tagline: "Registered cooperative; shares, deposits & member loans",
+		SavingsMechanism: "ACCUMULATING", ContributionMode: "SHARE_BASED_VARIABLE",
+		LendingEnabled: true, HasSocialFund: false, HasBankLinkage: true,
+		WelfareOnlyMode: false, FormallyRegistered: true,
+		DefaultLoanMultiplier: 3, DefaultInterestRatePct: 12, DefaultCycleLengthMonths: 0,
+		MaxMembers: 200, MinMembers: 10,
+	},
+	{
+		TypeSlug: "CBO_VILLAGE_BANK", DisplayName: "Village Bank (CBO)",
+		Tagline: "Community-based village banking with an external seed loan",
+		SavingsMechanism: "ACCUMULATING", ContributionMode: "FIXED_AMOUNT",
+		LendingEnabled: true, HasSocialFund: true, HasBankLinkage: true,
+		WelfareOnlyMode: false, FormallyRegistered: true,
+		DefaultLoanMultiplier: 3, DefaultInterestRatePct: 10, DefaultCycleLengthMonths: 12,
+		MaxMembers: 50, MinMembers: 10,
+	},
+	{
+		TypeSlug: "BURIAL_WELFARE", DisplayName: "Burial / Welfare Society",
+		Tagline: "Members contribute to a welfare fund for emergencies & funerals",
+		SavingsMechanism: "ACCUMULATING", ContributionMode: "FIXED_AMOUNT",
+		LendingEnabled: false, HasSocialFund: true, HasBankLinkage: false,
+		WelfareOnlyMode: true, FormallyRegistered: false,
+		DefaultLoanMultiplier: 0, DefaultInterestRatePct: 0, DefaultCycleLengthMonths: 0,
+		MaxMembers: 100, MinMembers: 5,
+	},
+	{
+		TypeSlug: "JLG", DisplayName: "Joint Liability Group",
+		Tagline: "4-10 members take an external MFI loan jointly",
+		SavingsMechanism: "NONE", ContributionMode: "FIXED_AMOUNT",
+		LendingEnabled: true, HasSocialFund: false, HasBankLinkage: true,
+		WelfareOnlyMode: false, FormallyRegistered: true,
+		DefaultLoanMultiplier: 1, DefaultInterestRatePct: 15, DefaultCycleLengthMonths: 0,
+		MaxMembers: 10, MinMembers: 4,
+	},
+}

--- a/go/companion/groups.go
+++ b/go/companion/groups.go
@@ -1,0 +1,609 @@
+// Copyright since 2025 Mifos Initiative
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// COMP-GRP: the group-dashboard read facade. It reshapes a real Fineract group
+// (GET groups/{id}?associations=all + group/member accounts) into the nested
+// contract the CommonPurse (mifos-x-group-banking) app expects.
+//
+// The app does NOT call a single "dashboard" endpoint — its GroupDashboardApiImpl
+// fans in FOUR sub-reads that each return one nested DTO:
+//
+//	GET /companion/groups/{groupId}          -> GroupDetailDto
+//	GET /companion/groups/{groupId}/my-role  -> ViewerRoleInfoDto
+//	GET /companion/groups/{groupId}/corpus   -> GroupCorpusDto
+//	GET /companion/groups/{groupId}/accounts -> GroupAccountsDto
+//
+// and its GroupApiImpl lists groups via GET /companion/groups/mine -> GroupPageDto.
+// We serve all of those (so the device renders real data) AND, as a convenience
+// for callers who want the whole thing in one shot, the composite
+// GET /companion/groups/{groupId}/dashboard -> GroupDashboardResponseDto and a
+// GET /companion/groups alias of /mine.
+//
+// Field names + nesting + casing are matched EXACTLY to the app DTOs in
+// core/network/.../model/{GroupDashboardDto,GroupDto,GroupTypeConfigDto}.kt —
+// note typeConfig is snake_case on the wire while every other DTO is camelCase.
+//
+// Reads use the shared FineractClient service credential (adapter.DoRequest),
+// which is correct for reading group data (unlike the auth path, which forwards
+// end-user creds).
+package companion
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+)
+
+// registerGroupRoutes wires the COMP-GRP endpoints. Called from RegisterRoutes.
+func (h *Handler) registerGroupRoutes(mux *http.ServeMux) {
+	// Group list (what the app actually calls) + a bare alias per the task.
+	mux.HandleFunc("GET /companion/groups/mine", h.HandleMyGroups)
+	mux.HandleFunc("GET /companion/groups", h.HandleMyGroups)
+
+	// Dashboard sub-reads (what GroupDashboardApiImpl fans in).
+	mux.HandleFunc("GET /companion/groups/{groupId}", h.HandleGroupDetail)
+	mux.HandleFunc("GET /companion/groups/{groupId}/my-role", h.HandleViewerRole)
+	mux.HandleFunc("GET /companion/groups/{groupId}/corpus", h.HandleGroupCorpus)
+	mux.HandleFunc("GET /companion/groups/{groupId}/accounts", h.HandleGroupAccounts)
+
+	// Composite convenience aggregate.
+	mux.HandleFunc("GET /companion/groups/{groupId}/dashboard", h.HandleGroupDashboard)
+}
+
+// ---- App-facing wire contract (exact match to the KMP DTOs) ----
+
+// GroupInstanceConfigDto == typeConfig inside GroupDetailDto. SNAKE_CASE wire.
+type GroupInstanceConfigDto struct {
+	GroupType         string  `json:"group_type"`
+	PoolModel         string  `json:"pool_model"`
+	ContributionModel string  `json:"contribution_model"`
+	ShareoutFormula   string  `json:"shareout_formula"`
+	PayoutOrderMethod string  `json:"payout_order_method"`
+	ShareValue        float64 `json:"share_value"`
+	ContributionAmount float64 `json:"contribution_amount"`
+	SocialFundEnabled bool    `json:"social_fund_enabled"`
+	CycleLengthMonths int     `json:"cycle_length_months"`
+	LoanMultiplier    float64 `json:"loan_multiplier"`
+	InterestRate      float64 `json:"interest_rate"`
+	FineAmount        float64 `json:"fine_amount"`
+}
+
+// GroupDetailDto == GET /companion/groups/{groupId}.
+type GroupDetailDto struct {
+	ID                string                 `json:"id"`
+	FineractCenterID  int64                  `json:"fineractCenterId"`
+	Name              string                 `json:"name"`
+	CycleNumber       int                    `json:"cycleNumber"`
+	CycleLengthMonths int                    `json:"cycleLengthMonths"`
+	MeetingFrequency  string                 `json:"meetingFrequency"`
+	MemberCount       int                    `json:"memberCount"`
+	OverdueLoansCount int                    `json:"overdueLoansCount"`
+	Status            string                 `json:"status"`
+	TypeConfig        GroupInstanceConfigDto `json:"typeConfig"`
+}
+
+// ViewerRoleInfoDto == GET /companion/groups/{groupId}/my-role.
+type ViewerRoleInfoDto struct {
+	Role     string `json:"role"`
+	MemberID int64  `json:"memberId"`
+}
+
+// GroupCorpusDto == GET /companion/groups/{groupId}/corpus.
+type GroupCorpusDto struct {
+	CurrentBalance              float64  `json:"currentBalance"`
+	OpeningBalance              float64  `json:"openingBalance"`
+	TotalContributionsThisCycle float64  `json:"totalContributionsThisCycle"`
+	TotalLoansOutstanding       float64  `json:"totalLoansOutstanding"`
+	LastUpdated                 string   `json:"lastUpdated"`
+	IsCycleEnd                  bool     `json:"isCycleEnd"`
+	RotationPosition            *int     `json:"rotationPosition"`
+	NextRecipientName           *string  `json:"nextRecipientName"`
+	NextRecipientPosition       *int     `json:"nextRecipientPosition"`
+}
+
+// ActivityItemDto is one row of GroupAccountsDto.recentActivity.
+type ActivityItemDto struct {
+	ID          string   `json:"id"`
+	Type        string   `json:"type"`
+	Description string   `json:"description"`
+	Amount      *float64 `json:"amount"`
+	Date        string   `json:"date"`
+	MemberName  *string  `json:"memberName"`
+}
+
+// GroupAccountsDto == GET /companion/groups/{groupId}/accounts.
+type GroupAccountsDto struct {
+	SavingsBalance     float64           `json:"savingsBalance"`
+	LoansOutstanding   float64           `json:"loansOutstanding"`
+	ActiveLoanCount    int               `json:"activeLoanCount"`
+	ShareOutProjection *float64          `json:"shareOutProjection"`
+	RecentActivity     []ActivityItemDto `json:"recentActivity"`
+}
+
+// GroupDashboardResponseDto == GET /companion/groups/{groupId}/dashboard.
+type GroupDashboardResponseDto struct {
+	Group      GroupDetailDto    `json:"group"`
+	ViewerRole ViewerRoleInfoDto `json:"viewerRole"`
+	Corpus     GroupCorpusDto    `json:"corpus"`
+	Accounts   GroupAccountsDto  `json:"accounts"`
+}
+
+// GroupDto == one element of GroupPageDto.pageItems (group list).
+type GroupDto struct {
+	ID               string  `json:"id"`
+	Name             string  `json:"name"`
+	GroupType        string  `json:"groupType"`
+	ViewerRole       string  `json:"viewerRole"`
+	CycleNumber      int     `json:"cycleNumber"`
+	MemberCount      int     `json:"memberCount"`
+	LastMeetingDate  string  `json:"lastMeetingDate"`
+	HealthIndicator  string  `json:"healthIndicator"`
+	OverdueRate      float64 `json:"overdueRate"`
+	Status           string  `json:"status"`
+	FineractCenterID int64   `json:"fineractCenterId"`
+}
+
+// GroupPageDto == GET /companion/groups[/mine].
+type GroupPageDto struct {
+	TotalFilteredRecords int        `json:"totalFilteredRecords"`
+	PageItems            []GroupDto `json:"pageItems"`
+}
+
+// ---- Fineract wire types (only the fields we consume) ----
+
+type fnStatus struct {
+	Value  string `json:"value"`
+	Active bool   `json:"active"`
+}
+
+type fnMember struct {
+	ID          int64    `json:"id"`
+	DisplayName string   `json:"displayName"`
+	Status      fnStatus `json:"status"`
+}
+
+type fnGroup struct {
+	ID             int64      `json:"id"`
+	Name           string     `json:"name"`
+	Status         fnStatus   `json:"status"`
+	Active         bool       `json:"active"`
+	ActivationDate []int      `json:"activationDate"`
+	OfficeID       int64      `json:"officeId"`
+	CenterID       *int64     `json:"centerId"`
+	ClientMembers  []fnMember `json:"clientMembers"`
+}
+
+type fnGroupAccounts struct {
+	SavingsAccounts []struct {
+		ID             int64    `json:"id"`
+		AccountBalance float64  `json:"accountBalance"`
+		Status         fnStatus `json:"status"`
+	} `json:"savingsAccounts"`
+}
+
+type fnClientAccounts struct {
+	LoanAccounts []struct {
+		ID          int64    `json:"id"`
+		Status      fnStatus `json:"status"`
+		LoanBalance float64  `json:"loanBalance"`
+		InArrears   bool     `json:"inArrears"`
+		ProductName string   `json:"productName"`
+		Timeline    struct {
+			ActualDisbursementDate []int `json:"actualDisbursementDate"`
+		} `json:"timeline"`
+	} `json:"loanAccounts"`
+}
+
+type fnSavingsTxn struct {
+	ID              int64    `json:"id"`
+	Amount          float64  `json:"amount"`
+	Date            []int    `json:"date"`
+	TransactionType struct {
+		Deposit    bool `json:"deposit"`
+		Withdrawal bool `json:"withdrawal"`
+	} `json:"transactionType"`
+}
+
+// ---- Handlers ----
+
+func (h *Handler) HandleMyGroups(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	// mifos-bank-2 exposes no per-user group linkage for staff callers, so "mine"
+	// returns every active group. This is the documented hook for real per-user
+	// resolution once member<->group linkage lands (mirrors resolveGroups in auth).
+	raw, err := h.Fineract.DoRequest("GET", "groups", nil, nil)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", string(nonEmpty(raw)))
+		return
+	}
+	var groups []fnGroup
+	if err := json.Unmarshal(raw, &groups); err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", "decode groups list: "+err.Error())
+		return
+	}
+	page := GroupPageDto{PageItems: []GroupDto{}}
+	for _, g := range groups {
+		if !g.Active {
+			continue
+		}
+		detail, members, aerr := h.aggregateGroup(g.ID)
+		if aerr != nil {
+			continue
+		}
+		_, _, activeLoans, overdue := h.aggregateLoans(members)
+		page.PageItems = append(page.PageItems, GroupDto{
+			ID:               strconv.FormatInt(g.ID, 10),
+			Name:             g.Name,
+			GroupType:        "VSLA", // computed default: this seed is a VSLA group
+			ViewerRole:       "ORGANIZER",
+			CycleNumber:      detail.CycleNumber,
+			MemberCount:      detail.MemberCount,
+			LastMeetingDate:  fmtFineractDate(g.ActivationDate),
+			HealthIndicator:  healthFor(overdue, activeLoans),
+			OverdueRate:      overdueRate(overdue, activeLoans),
+			Status:           statusValue(g.Status),
+			FineractCenterID: deref(g.CenterID),
+		})
+	}
+	page.TotalFilteredRecords = len(page.PageItems)
+	_ = json.NewEncoder(w).Encode(page)
+}
+
+func (h *Handler) HandleGroupDetail(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	gid, ok := groupIDParam(w, r)
+	if !ok {
+		return
+	}
+	detail, _, err := h.aggregateGroup(gid)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	_ = json.NewEncoder(w).Encode(detail)
+}
+
+func (h *Handler) HandleViewerRole(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	if _, ok := groupIDParam(w, r); !ok {
+		return
+	}
+	// No per-user member linkage on mifos-bank-2 -> the dashboard viewer is the
+	// group organizer. memberId 0 = "not resolved to a member row" (staff caller).
+	_ = json.NewEncoder(w).Encode(ViewerRoleInfoDto{Role: "ORGANIZER", MemberID: 0})
+}
+
+func (h *Handler) HandleGroupCorpus(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	gid, ok := groupIDParam(w, r)
+	if !ok {
+		return
+	}
+	_, members, err := h.aggregateGroup(gid)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	savings, _, err := h.aggregateSavings(gid)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	loansOut, _, _, _ := h.aggregateLoans(members)
+	_ = json.NewEncoder(w).Encode(buildCorpus(savings, loansOut))
+}
+
+func (h *Handler) HandleGroupAccounts(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	gid, ok := groupIDParam(w, r)
+	if !ok {
+		return
+	}
+	_, members, err := h.aggregateGroup(gid)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	accounts, err := h.buildAccounts(gid, members)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	_ = json.NewEncoder(w).Encode(accounts)
+}
+
+func (h *Handler) HandleGroupDashboard(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	gid, ok := groupIDParam(w, r)
+	if !ok {
+		return
+	}
+	detail, members, err := h.aggregateGroup(gid)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	savings, _, err := h.aggregateSavings(gid)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	loansOut, _, _, _ := h.aggregateLoans(members)
+	accounts, err := h.buildAccounts(gid, members)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	_ = json.NewEncoder(w).Encode(GroupDashboardResponseDto{
+		Group:      detail,
+		ViewerRole: ViewerRoleInfoDto{Role: "ORGANIZER", MemberID: 0},
+		Corpus:     buildCorpus(savings, loansOut),
+		Accounts:   accounts,
+	})
+}
+
+// ---- Aggregation (real Fineract -> app shape) ----
+
+// memberRef is a lightweight member reference reused across loan aggregation.
+type memberRef struct {
+	ID   int64
+	Name string
+}
+
+// aggregateGroup reads groups/{id}?associations=all and maps it to GroupDetailDto.
+// VSLA-specific fields Fineract does not model are filled with the computed
+// defaults documented inline (never member-facing financials).
+func (h *Handler) aggregateGroup(groupID int64) (GroupDetailDto, []memberRef, error) {
+	raw, err := h.Fineract.DoRequest("GET", fmt.Sprintf("groups/%d", groupID), nil, map[string]string{"associations": "all"})
+	if err != nil {
+		return GroupDetailDto{}, nil, fmt.Errorf("fineract get group %d: %s", groupID, string(nonEmpty(raw)))
+	}
+	var g fnGroup
+	if err := json.Unmarshal(raw, &g); err != nil {
+		return GroupDetailDto{}, nil, fmt.Errorf("decode group %d: %w", groupID, err)
+	}
+	members := make([]memberRef, 0, len(g.ClientMembers))
+	for _, m := range g.ClientMembers {
+		members = append(members, memberRef{ID: m.ID, Name: m.DisplayName})
+	}
+	_, _, activeLoans, overdue := h.aggregateLoans(members)
+
+	detail := GroupDetailDto{
+		ID:                strconv.FormatInt(g.ID, 10),
+		FineractCenterID:  deref(g.CenterID),
+		Name:              g.Name,
+		CycleNumber:       1,  // computed default: fresh VSLA seed is on its first cycle
+		CycleLengthMonths: 12, // computed default: standard 12-month VSLA cycle
+		MeetingFrequency:  "WEEKLY",
+		MemberCount:       len(g.ClientMembers),
+		OverdueLoansCount: overdue,
+		Status:            statusValue(g.Status),
+		TypeConfig:        defaultVSLAConfig(),
+	}
+	_ = activeLoans
+	return detail, members, nil
+}
+
+// aggregateSavings sums active group savings balances (the real corpus).
+func (h *Handler) aggregateSavings(groupID int64) (total float64, ids []int64, err error) {
+	raw, err := h.Fineract.DoRequest("GET", fmt.Sprintf("groups/%d/accounts", groupID), nil, nil)
+	if err != nil {
+		return 0, nil, fmt.Errorf("fineract group accounts %d: %s", groupID, string(nonEmpty(raw)))
+	}
+	var ga fnGroupAccounts
+	if err := json.Unmarshal(raw, &ga); err != nil {
+		return 0, nil, fmt.Errorf("decode group accounts %d: %w", groupID, err)
+	}
+	for _, s := range ga.SavingsAccounts {
+		if s.Status.Active {
+			total += s.AccountBalance
+			ids = append(ids, s.ID)
+		}
+	}
+	return total, ids, nil
+}
+
+// aggregateLoans sums active member-loan outstanding across the group's members.
+// Group savings/accounts does not surface members' individual loans, so we walk
+// each member's clients/{id}/accounts — real, per-member loan balances.
+func (h *Handler) aggregateLoans(members []memberRef) (outstanding float64, activityRows []ActivityItemDto, activeCount int, overdue int) {
+	for _, m := range members {
+		raw, err := h.Fineract.DoRequest("GET", fmt.Sprintf("clients/%d/accounts", m.ID), nil, nil)
+		if err != nil {
+			continue
+		}
+		var ca fnClientAccounts
+		if err := json.Unmarshal(raw, &ca); err != nil {
+			continue
+		}
+		name := m.Name
+		for _, l := range ca.LoanAccounts {
+			if !l.Status.Active {
+				continue
+			}
+			outstanding += l.LoanBalance
+			activeCount++
+			if l.InArrears {
+				overdue++
+			}
+			amt := l.LoanBalance
+			nm := name
+			activityRows = append(activityRows, ActivityItemDto{
+				ID:          fmt.Sprintf("loan-%d", l.ID),
+				Type:        "LOAN",
+				Description: fmt.Sprintf("Loan disbursed to %s (%s)", name, l.ProductName),
+				Amount:      &amt,
+				Date:        fmtFineractDate(l.Timeline.ActualDisbursementDate),
+				MemberName:  &nm,
+			})
+		}
+	}
+	return outstanding, activityRows, activeCount, overdue
+}
+
+// buildAccounts assembles GroupAccountsDto with a real recent-activity feed
+// (savings deposits + loan disbursements).
+func (h *Handler) buildAccounts(groupID int64, members []memberRef) (GroupAccountsDto, error) {
+	savings, savingsIDs, err := h.aggregateSavings(groupID)
+	if err != nil {
+		return GroupAccountsDto{}, err
+	}
+	loansOut, loanActivity, activeLoans, _ := h.aggregateLoans(members)
+
+	activity := make([]ActivityItemDto, 0)
+	for _, sid := range savingsIDs {
+		activity = append(activity, h.savingsActivity(sid)...)
+	}
+	activity = append(activity, loanActivity...)
+	// Newest first; cap to the 10 most recent.
+	sort.SliceStable(activity, func(i, j int) bool { return activity[i].Date > activity[j].Date })
+	if len(activity) > 10 {
+		activity = activity[:10]
+	}
+
+	// shareOutProjection: at cycle-end an accumulating VSLA shares out the corpus
+	// net of outstanding loans. Computed from real balances, not fabricated.
+	proj := savings - loansOut
+	if proj < 0 {
+		proj = 0
+	}
+	return GroupAccountsDto{
+		SavingsBalance:     savings,
+		LoansOutstanding:   loansOut,
+		ActiveLoanCount:    activeLoans,
+		ShareOutProjection: &proj,
+		RecentActivity:     activity,
+	}, nil
+}
+
+// savingsActivity maps a savings account's deposit transactions to activity rows.
+// Fineract exposes the transaction list only via the account read with
+// associations=transactions (the /transactions path is POST-only).
+func (h *Handler) savingsActivity(savingsID int64) []ActivityItemDto {
+	raw, err := h.Fineract.DoRequest("GET", fmt.Sprintf("savingsaccounts/%d", savingsID), nil, map[string]string{"associations": "transactions"})
+	if err != nil {
+		return nil
+	}
+	var acct struct {
+		Transactions []fnSavingsTxn `json:"transactions"`
+	}
+	if err := json.Unmarshal(raw, &acct); err != nil {
+		return nil
+	}
+	rows := make([]ActivityItemDto, 0, len(acct.Transactions))
+	for _, t := range acct.Transactions {
+		if !t.TransactionType.Deposit {
+			continue // app ActivityTypeDto has no WITHDRAWAL member; deposits only
+		}
+		amt := t.Amount
+		rows = append(rows, ActivityItemDto{
+			ID:          fmt.Sprintf("savings-%d-%d", savingsID, t.ID),
+			Type:        "DEPOSIT",
+			Description: "Group savings deposit",
+			Amount:      &amt,
+			Date:        fmtFineractDate(t.Date),
+		})
+	}
+	return rows
+}
+
+// buildCorpus derives GroupCorpusDto from the real savings + loan totals.
+func buildCorpus(savings, loansOut float64) GroupCorpusDto {
+	return GroupCorpusDto{
+		CurrentBalance:              savings,
+		OpeningBalance:              0, // computed default: cycle 1 opened at zero corpus
+		TotalContributionsThisCycle: savings,
+		TotalLoansOutstanding:       loansOut,
+		LastUpdated:                 time.Now().UTC().Format(time.RFC3339),
+		IsCycleEnd:                  false,
+		// Accumulating VSLA -> no fixed rotation payout; rotation fields stay null.
+		RotationPosition:      nil,
+		NextRecipientName:     nil,
+		NextRecipientPosition: nil,
+	}
+}
+
+// defaultVSLAConfig is the computed VSLA rule-set for a group whose type Fineract
+// does not model. These are governance defaults, not member-facing balances.
+func defaultVSLAConfig() GroupInstanceConfigDto {
+	return GroupInstanceConfigDto{
+		GroupType:          "VSLA",              // GroupTypeSlugDto.VSLA
+		PoolModel:          "ACCUMULATING",      // SavingsMechanismDto.ACCUMULATING
+		ContributionModel:  "FIXED_AMOUNT",      // GroupContributionModelDto.FIXED_AMOUNT
+		ShareoutFormula:    "PRO_RATA_BY_SHARES",
+		PayoutOrderMethod:  "NONE",
+		ShareValue:         100,
+		ContributionAmount: 100,
+		SocialFundEnabled:  true,
+		CycleLengthMonths:  12,
+		LoanMultiplier:     3,
+		InterestRate:       10,
+		FineAmount:         50,
+	}
+}
+
+// ---- small helpers ----
+
+func groupIDParam(w http.ResponseWriter, r *http.Request) (int64, bool) {
+	raw := r.PathValue("groupId")
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || id <= 0 {
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid groupId")
+		return 0, false
+	}
+	return id, true
+}
+
+func statusValue(s fnStatus) string {
+	if s.Value == "" {
+		return "Active"
+	}
+	return s.Value
+}
+
+func deref(p *int64) int64 {
+	if p == nil {
+		return 0
+	}
+	return *p
+}
+
+func healthFor(overdue, activeLoans int) string {
+	if overdue == 0 {
+		return "GREEN"
+	}
+	if overdue < activeLoans {
+		return "AMBER"
+	}
+	return "RED"
+}
+
+func overdueRate(overdue, activeLoans int) float64 {
+	if activeLoans == 0 {
+		return 0
+	}
+	return float64(overdue) / float64(activeLoans)
+}
+
+// fmtFineractDate turns Fineract's [year, month, day] array into YYYY-MM-DD.
+func fmtFineractDate(parts []int) string {
+	if len(parts) < 3 {
+		return ""
+	}
+	return fmt.Sprintf("%04d-%02d-%02d", parts[0], parts[1], parts[2])
+}
+
+// fmtFineractInstant renders a Fineract [y,m,d] date as a full ISO-8601 instant
+// (midnight UTC). The CommonPurse app parses membership joinedAt with kotlinx
+// Instant.parse, which rejects a date-only string.
+func fmtFineractInstant(parts []int) string {
+	if len(parts) < 3 {
+		return "2026-01-01T00:00:00Z"
+	}
+	return fmt.Sprintf("%04d-%02d-%02dT00:00:00Z", parts[0], parts[1], parts[2])
+}

--- a/go/companion/loan_detail.go
+++ b/go/companion/loan_detail.go
@@ -1,0 +1,253 @@
+// Copyright since 2025 Mifos Initiative
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// COMP-LOANDETAIL: the loan-detail read facade. The CommonPurse
+// (mifos-x-group-banking) app's LoanDetailApiImpl calls a single composite read
+// at a bare Fineract path (its base URL points at THIS Go server):
+//
+//	GET /loans/{loanId}?associations=repaymentSchedule,transactions -> LoanDetailResponseDto
+//
+// Source of truth for the wire shape is the app's OWN approved contract:
+//   - service : loandetail/LoanDetailApiImpl.kt   (GET /loans/{loanId}?associations=...)
+//   - model   : LoanDetailDto.kt                  (LoanDetailResponseDto / LoanDetailDto /
+//               RepaymentScheduleRowDto / RepaymentTransactionDto)
+//   - mapper  : LoanDetailMappers.kt              (field-by-field, no unmapped field)
+//
+// The app DTO is the COMPANION-NORMALIZED shape (a flat `loan` object + typed
+// repaymentSchedule/transactions rows), explicitly NOT the raw literal Fineract
+// loan payload (which nests `summary`, status/type as {id,value} pairs, dates as
+// [y,m,d] arrays, and buries the schedule under repaymentSchedule.periods). This
+// handler performs exactly that normalization the DTO kdoc says "the companion
+// bridge" is responsible for.
+//
+// Reads use the shared FineractClient service credential (adapter.DoRequest),
+// same as every other companion read facade. Reuses fnStatus + loanStatusFor
+// (loan_list.go) for the loan-status mapping and fmtFineractDate (groups.go) for
+// every [y,m,d] -> "YYYY-MM-DD" conversion.
+//
+// DATE-FORMAT decision: LoanDetailDto.disbursedDate / RepaymentScheduleRowDto.dueDate /
+// RepaymentTransactionDto.date are all plain Kotlin String (never Instant.parse'd downstream —
+// LoanDetailMappers.kt passes them straight through), so "YYYY-MM-DD" (fmtFineractDate) is emitted,
+// matching the loan-list precedent (LoanSummaryDto.nextRepaymentDate).
+package companion
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// registerLoanDetailRoutes wires the COMP-LOANDETAIL endpoint. Called from
+// RegisterRoutes. GET /loans/{loanId} is disjoint from the POST /loans and
+// POST /loans/{loanId}/transactions write routes (loan_write.go) and from
+// loan_list.go's group/client loan-list reads.
+func (h *Handler) registerLoanDetailRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /loans/{loanId}", h.HandleLoanDetail)
+}
+
+// ---- App-facing wire contract (exact match to LoanDetailDto.kt) ----
+
+// loanDetailInnerDto == LoanDetailDto (the flat `loan` header).
+type loanDetailInnerDto struct {
+	ID                  int64   `json:"id"`
+	MemberID            int64   `json:"memberId"`
+	MemberName          string  `json:"memberName"`
+	LoanProductName     string  `json:"loanProductName"`
+	PrincipalAmount     float64 `json:"principalAmount"`
+	DisbursedDate       string  `json:"disbursedDate"`
+	InterestRatePercent float64 `json:"interestRatePercent"`
+	TotalOutstanding    float64 `json:"totalOutstanding"`
+	TotalOverdue        float64 `json:"totalOverdue"`
+	Status              string  `json:"status"`
+	FineractLoanID      int64   `json:"fineractLoanId"`
+}
+
+// repaymentScheduleRowDto == RepaymentScheduleRowDto (one installment period).
+type repaymentScheduleRowDto struct {
+	WeekNumber int     `json:"weekNumber"`
+	DueDate    string  `json:"dueDate"`
+	DueAmount  float64 `json:"dueAmount"`
+	PaidAmount float64 `json:"paidAmount"`
+	Balance    float64 `json:"balance"`
+	Status     string  `json:"status"`
+}
+
+// repaymentTransactionDto == RepaymentTransactionDto (one posted transaction).
+type repaymentTransactionDto struct {
+	ID     int64   `json:"id"`
+	Type   string  `json:"type"`
+	Date   string  `json:"date"`
+	Amount float64 `json:"amount"`
+}
+
+// loanDetailResponseDto == LoanDetailResponseDto (the composite envelope).
+type loanDetailResponseDto struct {
+	Loan              loanDetailInnerDto        `json:"loan"`
+	RepaymentSchedule []repaymentScheduleRowDto `json:"repaymentSchedule"`
+	Transactions      []repaymentTransactionDto `json:"transactions"`
+}
+
+// ---- Fineract wire types (only the fields we consume) ----
+
+type fnLoanTimeline struct {
+	ActualDisbursementDate   []int `json:"actualDisbursementDate"`
+	ExpectedDisbursementDate []int `json:"expectedDisbursementDate"`
+}
+
+type fnLoanSummary struct {
+	TotalOutstanding float64 `json:"totalOutstanding"`
+	TotalOverdue     float64 `json:"totalOverdue"`
+}
+
+type fnLoanPeriod struct {
+	Period                          *int    `json:"period"`
+	DueDate                         []int   `json:"dueDate"`
+	Complete                        bool    `json:"complete"`
+	TotalDueForPeriod               float64 `json:"totalDueForPeriod"`
+	TotalPaidForPeriod              float64 `json:"totalPaidForPeriod"`
+	TotalOutstandingForPeriod       float64 `json:"totalOutstandingForPeriod"`
+	PrincipalLoanBalanceOutstanding float64 `json:"principalLoanBalanceOutstanding"`
+}
+
+type fnLoanTransaction struct {
+	ID     int64 `json:"id"`
+	Type   struct {
+		Value string `json:"value"`
+	} `json:"type"`
+	Date   []int   `json:"date"`
+	Amount float64 `json:"amount"`
+}
+
+type fnLoanDetailRaw struct {
+	ID                    int64          `json:"id"`
+	ClientID              int64          `json:"clientId"`
+	ClientName            string         `json:"clientName"`
+	LoanProductName       string         `json:"loanProductName"`
+	Principal             float64        `json:"principal"`
+	InterestRatePerPeriod float64        `json:"interestRatePerPeriod"`
+	InArrears             bool           `json:"inArrears"`
+	Status                fnStatus       `json:"status"`
+	Timeline              fnLoanTimeline `json:"timeline"`
+	Summary               fnLoanSummary  `json:"summary"`
+	RepaymentSchedule     struct {
+		Periods []fnLoanPeriod `json:"periods"`
+	} `json:"repaymentSchedule"`
+	Transactions []fnLoanTransaction `json:"transactions"`
+}
+
+// ---- Handler ----
+
+// HandleLoanDetail reads the LIVE Fineract loan and reshapes it into LoanDetailResponseDto.
+func (h *Handler) HandleLoanDetail(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	loanID, ok := loanIDParam(w, r)
+	if !ok {
+		return
+	}
+	raw, err := h.Fineract.DoRequest("GET", fmt.Sprintf("loans/%d", loanID), nil, map[string]string{"associations": "repaymentSchedule,transactions"})
+	if err != nil {
+		writeUpstreamLoanError(w, raw, "get loan detail", err)
+		return
+	}
+	var l fnLoanDetailRaw
+	if err := json.Unmarshal(raw, &l); err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", "decode loan detail: "+err.Error())
+		return
+	}
+
+	disbursed := fmtFineractDate(l.Timeline.ActualDisbursementDate)
+	if disbursed == "" {
+		disbursed = fmtFineractDate(l.Timeline.ExpectedDisbursementDate)
+	}
+
+	out := loanDetailResponseDto{
+		Loan: loanDetailInnerDto{
+			ID:                  l.ID,
+			MemberID:            l.ClientID,
+			MemberName:          l.ClientName,
+			LoanProductName:     l.LoanProductName,
+			PrincipalAmount:     l.Principal,
+			DisbursedDate:       disbursed,
+			InterestRatePercent: l.InterestRatePerPeriod,
+			TotalOutstanding:    l.Summary.TotalOutstanding,
+			TotalOverdue:        l.Summary.TotalOverdue,
+			Status:              loanStatusFor(l.Status, l.InArrears),
+			FineractLoanID:      l.ID,
+		},
+		RepaymentSchedule: buildSchedule(l.RepaymentSchedule.Periods),
+		Transactions:      buildLoanTransactions(l.Transactions),
+	}
+	_ = json.NewEncoder(w).Encode(out)
+}
+
+// ---- reshape helpers ----
+
+// buildSchedule maps Fineract repayment-schedule periods to the app rows, skipping the
+// disbursement row (period == null / <= 0). balance = principalLoanBalanceOutstanding (the
+// declining loan balance after the installment). Row status is derived from complete /
+// partial-payment / past-due against today.
+func buildSchedule(periods []fnLoanPeriod) []repaymentScheduleRowDto {
+	today := time.Now().UTC().Format("2006-01-02")
+	out := make([]repaymentScheduleRowDto, 0, len(periods))
+	for _, p := range periods {
+		if p.Period == nil || *p.Period <= 0 {
+			continue // disbursement row — not an installment.
+		}
+		due := fmtFineractDate(p.DueDate)
+		out = append(out, repaymentScheduleRowDto{
+			WeekNumber: *p.Period,
+			DueDate:    due,
+			DueAmount:  p.TotalDueForPeriod,
+			PaidAmount: p.TotalPaidForPeriod,
+			Balance:    p.PrincipalLoanBalanceOutstanding,
+			Status:     scheduleRowStatus(p, due, today),
+		})
+	}
+	return out
+}
+
+// scheduleRowStatus maps one period to RepaymentRowStatusDto's value-set
+// (PAID / PARTIAL / UPCOMING / OVERDUE). ISO "YYYY-MM-DD" strings sort lexicographically, so a
+// direct string compare against today is a valid date comparison.
+func scheduleRowStatus(p fnLoanPeriod, dueDate, today string) string {
+	if p.Complete {
+		return "PAID"
+	}
+	if p.TotalPaidForPeriod > 0 {
+		return "PARTIAL"
+	}
+	if dueDate != "" && dueDate < today {
+		return "OVERDUE"
+	}
+	return "UPCOMING"
+}
+
+// buildLoanTransactions maps Fineract loan transactions to the app rows (type = the human-readable
+// transaction-type value, e.g. "Disbursement" / "Repayment" / "Write-off").
+func buildLoanTransactions(txns []fnLoanTransaction) []repaymentTransactionDto {
+	out := make([]repaymentTransactionDto, 0, len(txns))
+	for _, t := range txns {
+		out = append(out, repaymentTransactionDto{
+			ID:     t.ID,
+			Type:   t.Type.Value,
+			Date:   fmtFineractDate(t.Date),
+			Amount: t.Amount,
+		})
+	}
+	return out
+}
+
+// loanIDParam parses the {loanId} path segment shared by the loan-detail read and the
+// loan-transaction write routes.
+func loanIDParam(w http.ResponseWriter, r *http.Request) (int64, bool) {
+	id, err := strconv.ParseInt(r.PathValue("loanId"), 10, 64)
+	if err != nil || id <= 0 {
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid loanId")
+		return 0, false
+	}
+	return id, true
+}

--- a/go/companion/loan_list.go
+++ b/go/companion/loan_list.go
@@ -1,0 +1,263 @@
+// Copyright since 2025 Mifos Initiative
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// COMP-LOANLIST: the loan-list read facade. It reshapes the real Fineract per-member loan accounts
+// (GET clients/{id}/accounts + loans/{id}?associations=repaymentSchedule) into the offset-paginated
+// contract the CommonPurse app's LoanApiImpl fans in:
+//
+//	GET /groups/{groupId}/loans   -> LoanPageDto                 (the EXACT path + DTO the app calls)
+//	GET /clients/{clientId}/loans -> []LoanSummaryDto            (LoanApi.getClientLoans reuse, same row shape)
+//
+// Source of truth for the wire shapes is the app's OWN approved contract:
+//   - service : core/network/.../service/loanlist/LoanApiImpl.kt   (paths + params limit/offset/loanStatus)
+//   - model   : core/network/.../model/LoanSummaryDto.kt           (LoanPageDto / LoanSummaryDto / LoanAccountStatusDto)
+//   - mapper  : core/network/.../mapper/LoanSummaryMappers.kt      (field-by-field, no unmapped field)
+//
+// DATE-FORMAT decision (per LoanSummaryMappers.kt):
+//   - LoanSummaryDto.nextRepaymentDate -> pass-through String? (domain LoanSummary.nextRepaymentDate
+//     is String?, never parsed downstream) => emit "YYYY-MM-DD" (fmtFineractDate). NOT an Instant field.
+package companion
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// registerLoanListRoutes wires the COMP-LOANLIST endpoints. Called from RegisterRoutes.
+func (h *Handler) registerLoanListRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /groups/{groupId}/loans", h.HandleGroupLoans)
+	mux.HandleFunc("GET /clients/{clientId}/loans", h.HandleClientLoans)
+}
+
+// ---- App-facing wire contract (exact match to core/network/.../model/LoanSummaryDto.kt) ----
+
+// LoanSummaryDto == one row of LoanPageDto.pageItems (GET /groups/{groupId}/loans).
+type LoanSummaryDto struct {
+	ID               int64   `json:"id"`
+	MemberID         int64   `json:"memberId"`
+	MemberName       string  `json:"memberName"`
+	MemberPhotoURL   *string `json:"memberPhotoUrl"`
+	LoanProductName  string  `json:"loanProductName"`
+	PrincipalAmount  float64 `json:"principalAmount"`
+	OutstandingBalance float64 `json:"outstandingBalance"`
+	OverdueAmount    float64 `json:"overdueAmount"`
+	Status           string  `json:"status"`
+	NextRepaymentDate *string `json:"nextRepaymentDate"`
+	IsOverdue        bool    `json:"isOverdue"`
+	FineractLoanID   int64   `json:"fineractLoanId"`
+}
+
+// LoanPageDto == GET /groups/{groupId}/loans (offset-paginated envelope, page_size=20).
+type LoanPageDto struct {
+	TotalFilteredRecords int              `json:"totalFilteredRecords"`
+	PageItems            []LoanSummaryDto `json:"pageItems"`
+}
+
+// ---- Fineract wire types (only the fields we consume) ----
+
+type fnLoanAccountFull struct {
+	ID           int64    `json:"id"`
+	ProductName  string   `json:"productName"`
+	Status       fnStatus `json:"status"`
+	InArrears    bool     `json:"inArrears"`
+	OriginalLoan float64  `json:"originalLoan"`
+	LoanBalance  float64  `json:"loanBalance"`
+}
+
+type fnClientLoanAccounts struct {
+	LoanAccounts []fnLoanAccountFull `json:"loanAccounts"`
+}
+
+// fnLoanDetail is the loans/{id}?associations=repaymentSchedule read — used only to enrich a row
+// with the REAL next-due date + overdue amount the account summary does not carry.
+type fnLoanDetail struct {
+	Summary struct {
+		TotalOverdue     float64 `json:"totalOverdue"`
+		PrincipalOverdue float64 `json:"principalOverdue"`
+	} `json:"summary"`
+	RepaymentSchedule struct {
+		Periods []struct {
+			Period            *int    `json:"period"`
+			DueDate           []int   `json:"dueDate"`
+			Complete          bool    `json:"complete"`
+			TotalDueForPeriod float64 `json:"totalDueForPeriod"`
+		} `json:"periods"`
+	} `json:"repaymentSchedule"`
+}
+
+// ---- Handlers ----
+
+// HandleGroupLoans returns the group's loan accounts (one row per active member loan), aggregated
+// from LIVE Fineract. limit/offset/loanStatus honored per the app's LoanApi contract.
+func (h *Handler) HandleGroupLoans(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	gid, ok := groupIDParam(w, r)
+	if !ok {
+		return
+	}
+	limit := intParam(r, "limit", 20)
+	offset := intParam(r, "offset", 0)
+	statusFilter := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("loanStatus")))
+
+	_, members, err := h.aggregateGroup(gid)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+
+	all := make([]LoanSummaryDto, 0)
+	for _, m := range members {
+		all = append(all, h.memberLoans(m.ID, m.Name)...)
+	}
+	all = filterLoans(all, statusFilter)
+
+	total := len(all)
+	page := LoanPageDto{
+		TotalFilteredRecords: total,
+		PageItems:            pageSlice(all, offset, limit),
+	}
+	if page.PageItems == nil {
+		page.PageItems = []LoanSummaryDto{}
+	}
+	_ = json.NewEncoder(w).Encode(page)
+}
+
+// HandleClientLoans returns a single client's loans as a flat []LoanSummaryDto (LoanApi.getClientLoans).
+func (h *Handler) HandleClientLoans(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	raw := r.PathValue("clientId")
+	cid, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || cid <= 0 {
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid clientId")
+		return
+	}
+	name := h.clientDisplayName(cid)
+	loans := h.memberLoans(cid, name)
+	if loans == nil {
+		loans = []LoanSummaryDto{}
+	}
+	_ = json.NewEncoder(w).Encode(loans)
+}
+
+// ---- aggregation ----
+
+// memberLoans reads a member's real Fineract loan accounts and maps each active loan to a
+// LoanSummaryDto, enriching next-due date + overdue amount from the loan's repayment schedule.
+func (h *Handler) memberLoans(clientID int64, memberName string) []LoanSummaryDto {
+	raw, err := h.Fineract.DoRequest("GET", fmt.Sprintf("clients/%d/accounts", clientID), nil, nil)
+	if err != nil {
+		return nil
+	}
+	var ca fnClientLoanAccounts
+	if err := json.Unmarshal(raw, &ca); err != nil {
+		return nil
+	}
+	out := make([]LoanSummaryDto, 0, len(ca.LoanAccounts))
+	for _, l := range ca.LoanAccounts {
+		nextDue, overdue := h.loanScheduleEnrichment(l.ID)
+		out = append(out, LoanSummaryDto{
+			ID:                 l.ID,
+			MemberID:           clientID,
+			MemberName:         memberName,
+			MemberPhotoURL:     nil,
+			LoanProductName:    l.ProductName,
+			PrincipalAmount:    l.OriginalLoan,
+			OutstandingBalance: l.LoanBalance,
+			OverdueAmount:      overdue,
+			Status:             loanStatusFor(l.Status, l.InArrears),
+			NextRepaymentDate:  nextDue,
+			IsOverdue:          l.InArrears,
+			FineractLoanID:     l.ID,
+		})
+	}
+	return out
+}
+
+// loanScheduleEnrichment fetches loans/{id}?associations=repaymentSchedule and returns the first
+// unpaid period's due date ("YYYY-MM-DD", nil if none) plus the real total-overdue amount. Fail-soft:
+// on any upstream error the row still renders with (nil, 0).
+func (h *Handler) loanScheduleEnrichment(loanID int64) (*string, float64) {
+	raw, err := h.Fineract.DoRequest("GET", fmt.Sprintf("loans/%d", loanID), nil, map[string]string{"associations": "repaymentSchedule"})
+	if err != nil {
+		return nil, 0
+	}
+	var d fnLoanDetail
+	if err := json.Unmarshal(raw, &d); err != nil {
+		return nil, 0
+	}
+	var next *string
+	for _, p := range d.RepaymentSchedule.Periods {
+		if p.Period == nil || p.Complete {
+			continue // skip the disbursement row (period=null) and settled periods
+		}
+		s := fmtFineractDate(p.DueDate)
+		if s != "" {
+			next = &s
+		}
+		break
+	}
+	overdue := d.Summary.TotalOverdue
+	if overdue == 0 {
+		overdue = d.Summary.PrincipalOverdue
+	}
+	return next, overdue
+}
+
+// clientDisplayName resolves a client's display name for the flat /clients/{id}/loans read.
+func (h *Handler) clientDisplayName(clientID int64) string {
+	raw, err := h.Fineract.DoRequest("GET", fmt.Sprintf("clients/%d", clientID), nil, nil)
+	if err != nil {
+		return ""
+	}
+	var c struct {
+		DisplayName string `json:"displayName"`
+	}
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return ""
+	}
+	return c.DisplayName
+}
+
+// ---- helpers ----
+
+// loanStatusFor maps a Fineract loan status (+ arrears flag) to LoanSummaryDto.kt's
+// LoanAccountStatusDto value-set (ACTIVE/OVERDUE/CLOSED/PENDING/REJECTED/UNKNOWN).
+func loanStatusFor(s fnStatus, inArrears bool) string {
+	if s.Active {
+		if inArrears {
+			return "OVERDUE"
+		}
+		return "ACTIVE"
+	}
+	v := strings.ToLower(s.Value)
+	switch {
+	case strings.Contains(v, "reject"):
+		return "REJECTED"
+	case strings.Contains(v, "close") || strings.Contains(v, "overpaid") || strings.Contains(v, "written"):
+		return "CLOSED"
+	case strings.Contains(v, "pending") || strings.Contains(v, "submitted") || strings.Contains(v, "approved") || strings.Contains(v, "waiting"):
+		return "PENDING"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// filterLoans applies the optional loanStatus query filter (active|overdue|closed|all).
+func filterLoans(loans []LoanSummaryDto, filter string) []LoanSummaryDto {
+	if filter == "" || filter == "all" {
+		return loans
+	}
+	want := strings.ToUpper(filter)
+	out := make([]LoanSummaryDto, 0, len(loans))
+	for _, l := range loans {
+		if l.Status == want {
+			out = append(out, l)
+		}
+	}
+	return out
+}

--- a/go/companion/loan_write.go
+++ b/go/companion/loan_write.go
@@ -1,0 +1,276 @@
+// Copyright since 2025 Mifos Initiative
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// COMP-LOAN-WRITE: the loan WRITE facade. The CommonPurse (mifos-x-group-banking)
+// app's three loan-write services each POST at a bare Fineract path (the app's
+// base URL points at THIS Go server, which serves only explicitly-registered
+// routes — there is no catch-all proxy):
+//
+//	loan-apply       POST /loans                                   -> ApplyLoanResponseDto
+//	loan-repayment   POST /loans/{loanId}/transactions?command=repayment -> RecordRepaymentResponseDto
+//	loan-writeoff    POST /loans/{loanId}/transactions?command=writeoff  -> WriteoffLoanResponseDto
+//
+// Source of truth for the wire shapes is the app's OWN approved contract:
+//   - loan-apply    : service loanapply/LoanApplyApiImpl.kt (applyLoan -> POST /loans)
+//                     model  LoanApplyDto.kt (ApplyLoanRequestDto / ApplyLoanResponseDto)
+//                     mapper LoanApplyMappers.kt (ApplyLoanRequest.toDto)
+//   - loan-repay    : service loanrepayment/LoanRepaymentApiImpl.kt (POST .../transactions?command=repayment)
+//                     model  RecordRepaymentDto.kt (RecordRepaymentRequestDto / RecordRepaymentResponseDto)
+//   - loan-writeoff : service loanwriteoff/LoanWriteoffApiImpl.kt (POST .../transactions?command=writeoff)
+//                     model  WriteoffLoanDto.kt (WriteoffLoanRequestDto / WriteoffLoanResponseDto)
+//
+// Writes use the shared FineractClient service credential (adapter.DoRequest, which
+// POSTs with the service BasicAuth) — the correct path for a treasurer/organizer
+// write, exactly like the group-create + member-invite facades. The end-user
+// credential path (companion.go's fineractPost) is reserved for /authentication.
+//
+// DATE-FORMAT decisions (per the app's DTOs + mappers):
+//   - loan-apply expectedDisbursementDate / submittedOnDate: the app formats both via
+//     RecordRepaymentMappers.fineractTransactionDate -> "dd MMMM yyyy" (e.g. "02 August 2026").
+//     So this facade sends dateFormat="dd MMMM yyyy", locale="en" on the Fineract create body.
+//   - loan-repayment transactionDate + loan-writeoff transactionDate: the app's DTOs
+//     force-encode locale="en" + dateFormat="dd MMMM yyyy" (@EncodeDefault ALWAYS) alongside
+//     the "dd MMMM yyyy" transactionDate string — an ALREADY-EXACT Fineract transaction body.
+//     This facade forwards that body verbatim (re-defaulting locale/dateFormat only if a caller
+//     ever omitted them), so no Instant.parse / LocalDate.parse hazard applies here — Fineract
+//     itself parses the "dd MMMM yyyy" string via the accompanying dateFormat.
+//
+// SHAPE-BRIDGE decision (loan-apply only): the app's ApplyLoanRequestDto carries the five
+// enum-lookup fields (loanTermFrequencyType / repaymentFrequencyType / amortizationType /
+// interestType / interestCalculationPeriodType) as nested {id, value} objects, and OMITS the
+// loanType / loanPurposeId-optionality / locale / dateFormat that a raw Fineract POST /loans
+// command REQUIRES. Fineract's create-loan command deserializer expects those five fields as
+// bare integer enum ids (not objects) plus loanType + locale + dateFormat + a
+// transactionProcessingStrategyCode. This facade flattens each {id,value} -> its .id and adds the
+// missing required fields — the same "normalize the app shape onto the real Fineract write" role
+// the group-create facade plays. The app DTO's declared default ids already ARE the correct
+// Fineract enum ids (Weeks=1, Equal installments=1, Declining Balance=0, Same as repayment
+// period=1), so the flatten is a faithful pass-through, not a re-mapping.
+package companion
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+const loansPath = "/loans"
+
+// registerLoanWriteRoutes wires the COMP-LOAN-WRITE endpoints. Called from
+// RegisterRoutes. Repayment and writeoff share the SAME path
+// (POST /loans/{loanId}/transactions) and differ only by the ?command= query
+// param — Go 1.22 ServeMux does not dispatch on the query string, so a single
+// handler receives both and switches on command. These patterns are disjoint
+// from loan_list.go's GET /groups/{groupId}/loans + GET /clients/{clientId}/loans.
+func (h *Handler) registerLoanWriteRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("POST /loans", h.HandleApplyLoan)
+	mux.HandleFunc("POST /loans/{loanId}/transactions", h.HandleLoanTransaction)
+}
+
+// ---- App-facing wire types (exact match to the KMP DTOs) ----
+
+// statusRefIn == the nested {id, value} lookup object on ApplyLoanRequestDto's
+// five enum fields (FineractStatusDto). id is a pointer so a genuinely-absent
+// object is distinguishable from an explicit id:0 (interestType's real default).
+type statusRefIn struct {
+	ID    *int   `json:"id"`
+	Value string `json:"value"`
+}
+
+// applyLoanRequestIn == ApplyLoanRequestDto (LoanApplyDto.kt) as it arrives on the wire.
+type applyLoanRequestIn struct {
+	ClientID                      int64       `json:"clientId"`
+	ProductID                     int64       `json:"productId"`
+	Principal                     float64     `json:"principal"`
+	LoanTermFrequency             int         `json:"loanTermFrequency"`
+	LoanTermFrequencyType         statusRefIn `json:"loanTermFrequencyType"`
+	NumberOfRepayments            int         `json:"numberOfRepayments"`
+	RepaymentEvery                int         `json:"repaymentEvery"`
+	RepaymentFrequencyType        statusRefIn `json:"repaymentFrequencyType"`
+	InterestRatePerPeriod         float64     `json:"interestRatePerPeriod"`
+	AmortizationType              statusRefIn `json:"amortizationType"`
+	InterestType                  statusRefIn `json:"interestType"`
+	InterestCalculationPeriodType statusRefIn `json:"interestCalculationPeriodType"`
+	ExpectedDisbursementDate      string      `json:"expectedDisbursementDate"`
+	SubmittedOnDate               string      `json:"submittedOnDate"`
+	LoanPurposeID                 int         `json:"loanPurposeId"`
+}
+
+// loanWriteResponseDto == the shared Fineract loan-command resource-create envelope,
+// matching ApplyLoanResponseDto / RecordRepaymentResponseDto / WriteoffLoanResponseDto
+// (all four: officeId, clientId, loanId, resourceId). officeId is an int per the app DTOs.
+type loanWriteResponseDto struct {
+	OfficeID   int   `json:"officeId"`
+	ClientID   int64 `json:"clientId"`
+	LoanID     int64 `json:"loanId"`
+	ResourceID int64 `json:"resourceId"`
+}
+
+// ---- Handlers ----
+
+// HandleApplyLoan (loan-apply) decodes the app's ApplyLoanRequestDto, flattens it onto a real
+// Fineract create-loan command body, POSTs /loans, and returns the ApplyLoanResponseDto envelope.
+func (h *Handler) HandleApplyLoan(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	var in applyLoanRequestIn
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid JSON body")
+		return
+	}
+	if in.ClientID <= 0 || in.ProductID <= 0 {
+		writeErr(w, http.StatusBadRequest, "bad_request", "clientId and productId are required")
+		return
+	}
+
+	repaymentEvery := in.RepaymentEvery
+	if repaymentEvery <= 0 {
+		repaymentEvery = 1 // ApplyLoanRequestDto's declared default.
+	}
+
+	body := map[string]interface{}{
+		"clientId":                      in.ClientID,
+		"productId":                     in.ProductID,
+		"loanType":                      "individual", // required by Fineract; app DTO omits it (per-client loan).
+		"principal":                     in.Principal,
+		"loanTermFrequency":             in.LoanTermFrequency,
+		"loanTermFrequencyType":         refID(in.LoanTermFrequencyType, 1), // Weeks
+		"numberOfRepayments":            in.NumberOfRepayments,
+		"repaymentEvery":                repaymentEvery,
+		"repaymentFrequencyType":        refID(in.RepaymentFrequencyType, 1), // Weeks
+		"interestRatePerPeriod":         in.InterestRatePerPeriod,
+		"amortizationType":              refID(in.AmortizationType, 1), // Equal installments
+		"interestType":                  refID(in.InterestType, 0),     // Declining Balance
+		"interestCalculationPeriodType": refID(in.InterestCalculationPeriodType, 1), // Same as repayment period
+		// Modern Fineract (mifos-bank-2) takes transactionProcessingStrategyCode (a String),
+		// NOT the legacy int transactionProcessingStrategyId the app DTO carries — confirmed by
+		// the raw loan read exposing "transactionProcessingStrategyCode". Standard strategy.
+		"transactionProcessingStrategyCode": "mifos-standard-strategy",
+		"expectedDisbursementDate":          in.ExpectedDisbursementDate,
+		"submittedOnDate":                   in.SubmittedOnDate,
+		"locale":                            "en",
+		"dateFormat":                        "dd MMMM yyyy",
+	}
+	// loanPurposeId references an m_code_value row; only forward a real, positive id
+	// (a 0/absent purpose would make Fineract reject an otherwise-valid application).
+	if in.LoanPurposeID > 0 {
+		body["loanPurposeId"] = in.LoanPurposeID
+	}
+
+	raw, err := h.Fineract.DoRequest("POST", "loans", body, nil)
+	if err != nil {
+		writeUpstreamLoanError(w, raw, "apply loan", err)
+		return
+	}
+	writeLoanEnvelope(w, raw)
+}
+
+// HandleLoanTransaction (loan-repayment + loan-writeoff) posts a repayment or writeoff transaction
+// against {loanId}, dispatching on the ?command= query param. The app's DTOs already emit an
+// exact Fineract transaction body (transactionDate "dd MMMM yyyy" + locale + dateFormat), so the
+// body is forwarded near-verbatim.
+func (h *Handler) HandleLoanTransaction(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	loanID, ok := loanIDParam(w, r)
+	if !ok {
+		return
+	}
+	command := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("command")))
+	switch command {
+	case "repayment", "writeoff":
+		// supported
+	case "":
+		writeErr(w, http.StatusBadRequest, "bad_request", "command query param is required (repayment|writeoff)")
+		return
+	default:
+		writeErr(w, http.StatusBadRequest, "bad_request", "unsupported command: "+command)
+		return
+	}
+
+	var body map[string]interface{}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid JSON body")
+		return
+	}
+	if body == nil {
+		body = map[string]interface{}{}
+	}
+	// Fineract needs locale + dateFormat to parse the "dd MMMM yyyy" transactionDate. The app's
+	// DTOs force-encode these, but re-default defensively for any caller that omitted them.
+	if _, present := body["locale"]; !present {
+		body["locale"] = "en"
+	}
+	if _, present := body["dateFormat"]; !present {
+		body["dateFormat"] = "dd MMMM yyyy"
+	}
+	// paymentTypeId is optional on a Fineract repayment; a 0/negative value means "unselected"
+	// and would make Fineract reject the transaction ("payment type 0 does not exist"). Drop it
+	// when non-positive so an unselected payment method never blocks a repayment. (writeoff never
+	// carries a paymentTypeId.)
+	if v, present := body["paymentTypeId"]; present {
+		if n, isNum := v.(float64); isNum && n <= 0 {
+			delete(body, "paymentTypeId")
+		}
+	}
+
+	raw, err := h.Fineract.DoRequest("POST", fmt.Sprintf("loans/%d/transactions", loanID), body, map[string]string{"command": command})
+	if err != nil {
+		writeUpstreamLoanError(w, raw, command+" transaction", err)
+		return
+	}
+	writeLoanEnvelope(w, raw)
+}
+
+// ---- helpers ----
+
+// refID returns the lookup object's Fineract enum id, or the supplied default when the caller
+// sent no object / no id (the app's declared per-field default, which equals the real Fineract id).
+func refID(ref statusRefIn, def int) int {
+	if ref.ID != nil {
+		return *ref.ID
+	}
+	return def
+}
+
+// writeLoanEnvelope reshapes Fineract's command-processing response into the app's 4-field
+// {officeId, clientId, loanId, resourceId} loan-write envelope. Fineract returns those fields on
+// every loan create/transaction command (alongside a `changes` map this facade drops).
+func writeLoanEnvelope(w http.ResponseWriter, raw []byte) {
+	var resp loanWriteResponseDto
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", "decode loan-write response: "+err.Error())
+		return
+	}
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// writeUpstreamLoanError mirrors a Fineract write failure. DoRequest returns the raw upstream body
+// (Fineract's structured error envelope) alongside its "API Error NNN" error; we surface that body
+// with its status when present so the app sees the real validation message, defaulting to 502.
+func writeUpstreamLoanError(w http.ResponseWriter, raw []byte, op string, err error) {
+	status := http.StatusBadGateway
+	if code := statusFromAPIError(err); code >= 400 {
+		status = code
+	}
+	if len(raw) > 0 {
+		w.WriteHeader(status)
+		_, _ = w.Write(raw)
+		return
+	}
+	writeErr(w, status, "upstream_error", op+": "+err.Error())
+}
+
+// statusFromAPIError extracts the HTTP status embedded in adapter.DoRequest's
+// "API Error <code>" error string (it returns the raw body + this error on any >=400).
+func statusFromAPIError(err error) int {
+	if err == nil {
+		return 0
+	}
+	var code int
+	if _, e := fmt.Sscanf(err.Error(), "API Error %d", &code); e == nil {
+		return code
+	}
+	return 0
+}

--- a/go/companion/meeting.go
+++ b/go/companion/meeting.go
@@ -1,0 +1,1201 @@
+// Copyright since 2025 Mifos Initiative
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// COMP-CAL: the meeting-lifecycle facade for the CommonPurse (mifos-x-group-banking)
+// app's FOUR meeting features. The app's shared HttpClient base URL points at THIS
+// Go server (companion), so every path below is one the app fires; the Go server
+// serves only explicitly-registered routes (there is no catch-all Fineract proxy),
+// so each is built here against real mifos-bank-2 data.
+//
+// A meeting lives on the CENTER model (m_center) — plain groups have no meeting
+// schedule. A Fineract center owns a COLLECTION calendar whose recurrence generates
+// the scheduled meeting dates; the group(s) under the center own the client members
+// whose attendance is recorded. Two custom multiRow datatables persist a conducted
+// meeting: dt_meeting_record (apptable m_center — one row per meeting) and
+// dt_meeting_attendance (apptable m_client — one row per member per meeting).
+//
+// Path prefixing mirrors the app's OWN services (each reuses the shared client, so
+// the prefix is baked into each service's path string, not the base URL):
+//
+//   meeting-calendar     (MeetingApiImpl)            -> /fineract-provider/api/v1/…
+//   meeting-summary      (MeetingRecordApiImpl)      -> /fineract-provider/api/v1/…
+//   previous-meeting-rev (MeetingAttendanceApiImpl)  -> /fineract-provider/api/v1/…
+//   meeting-conduct      (MeetingConductApiImpl)     -> bare /…  (no prefix)
+//
+// so this facade registers BOTH the prefixed and the bare variants of the
+// dt_meeting_record read (they carry different response shapes — see below).
+//
+// ENDPOINTS (app path -> handler -> app DTO, source in APP core/network/.../service):
+//   GET /fineract-provider/api/v1/centers/{centerId}/meetings
+//       -> HandleCenterMeetings           -> []MeetingListItemDto     (meetingcalendar/MeetingApi.getCenterMeetings)
+//   GET /fineract-provider/api/v1/datatables/dt_meeting_record/{centerId}[?meetingNumber=N]
+//       -> HandleMeetingRecordDatatable   -> MeetingRecordListDto (no q) | MeetingSummaryRecordDto (q)
+//          (meetingcalendar/MeetingApi.getMeetingRecords | meetingsummary/MeetingRecordApi.getMeetingRecord)
+//   GET /fineract-provider/api/v1/datatables/dt_meeting_attendance/{meetingId}
+//       -> HandleMeetingAttendanceList    -> []MeetingAttendanceRowDto (previousmeetingreview/MeetingAttendanceApi)
+//   GET /datatables/dt_meeting_record/{centerId}
+//       -> HandlePreviousMeetingRecord    -> MeetingRecordDetailDto    (meetingconduct.getPreviousMeetingRecord)
+//   GET /centers/{centerId}
+//       -> HandleCenterDetail             -> CenterDetailDto           (meetingconduct.getGroupMembers)
+//   GET /datatables/dt_group_corpus/{centerId}
+//       -> HandleGroupCorpusRead          -> CorpusRecordDto           (meetingconduct.getGroupCorpus)
+//   GET /loans?groupId=&loanStatus=active
+//       -> HandleActiveLoans              -> LoanListResponseDto        (meetingconduct.getActiveLoans)
+//   GET /datatables/dt_loan_vote/{loanId}
+//       -> HandleLoanVotes                -> LoanVoteRecordDto          (meetingconduct.getLoanVotes)
+//   POST /datatables/dt_meeting_record            -> HandlePostMeetingRecord      -> DataTableEntryResponseDto
+//   POST /datatables/dt_meeting_attendance        -> HandlePostMeetingAttendance  -> DataTableEntryResponseDto
+//   POST /savingsaccounts/{savingsId}/transactions?command=deposit -> HandlePostSavingsTransaction
+//   PUT  /datatables/dt_group_corpus/{centerId}   -> HandleUpdateCorpus           -> DataTableEntryResponseDto
+//   PUT  /centers/{centerId}/calendars/{calendarId}?command=updateCalendar -> HandleRescheduleCalendar
+//
+// NOT registered here (deliberate):
+//   POST /loans/{loanId}/transactions?command=repayment — already served by loan_write.go's
+//     HandleLoanTransaction (Go 1.22 ServeMux would panic on a duplicate pattern); the
+//     meeting-conduct repayment (priority 4) reuses that existing handler verbatim.
+//   POST /loans/{loanId}/transactions?command=disburse — never issued by the app:
+//     MeetingConductRepositoryImpl derives disbursals from pendingLoanApplications, which is
+//     ALWAYS emptyList() (CFF1 gap — no api.yaml endpoint loads it), so the disburse branch
+//     is dead. Left unserved rather than editing loan_write.go's existing handler.
+//
+// DATE-FORMAT decisions (checked against each app mapper + the live Fineract column types):
+//   - dt_meeting_record.meeting_date + dt_group_corpus.last_updated_date are real Fineract
+//     DATE columns. The app's CreateMeetingRecordRequestDto/UpdateCorpusRequestDto carry
+//     dateFormat="dd MMMM yyyy", but their actualDate value is unreliable — the conduct
+//     ViewModel sets actualDate = previousMeetingSummary?.date.orEmpty() (the PRIOR meeting's
+//     date string, or "" on the first meeting; MeetingConductViewModel.kt:560). So this facade
+//     IGNORES the app's dateFormat and normalizes whatever it receives (ISO, "dd MMMM yyyy",
+//     or empty->today) to canonical "yyyy-MM-dd" via normalizeFineractDate, then writes with
+//     dateFormat="yyyy-MM-dd"+locale="en". On READ the DATE column comes back as a Fineract
+//     [y,m,d] array, reshaped to "YYYY-MM-DD" via fmtFineractDate — the string the app then
+//     round-trips and displays (MeetingListItem/MeetingSummaryData/PreviousMeetingSummary all
+//     treat the date as an opaque display String, no kotlinx parse).
+//   - dt_meeting_attendance has NO date column (meeting_number keys the row) — the app's
+//     CreateAttendanceRequestDto sends no date; the write is locale-only.
+//   - the savings-deposit transactionDate IS a Fineract command DATE field parsed as
+//     date-only "dd MMMM yyyy" — HandlePostSavingsTransaction normalizes it via fineractTxnDate
+//     (share_out_write.go) exactly like the share-out withdrawal.
+//   - the reschedule updateCalendar startDate is a Fineract DATE — dateFormat/locale injected
+//     if the caller omitted them.
+//
+// meetingId semantics: this facade DEFINES meetingId = "{centerId}-{meetingNumber}" in the
+// calendar list it emits AND PARSES it back in the attendance read — the app carries it
+// opaquely through navigation (MeetingCalendarRoute -> conduct/review nav args), never parsing
+// it, so the two ends are the sole owners of the format.
+//
+// Reads/writes use the shared FineractClient service credential (adapter.DoRequest) — the
+// correct path for an organizer/staff meeting operation, exactly like groups.go / share_out_write.go.
+package companion
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	meetingRecordTable     = "dt_meeting_record"
+	meetingAttendanceTable = "dt_meeting_attendance"
+	groupCorpusTable       = "dt_group_corpus"
+	loanVoteTable          = "dt_loan_vote"
+	centerApptable         = "m_center"
+	clientApptable         = "m_client"
+	fineractV1Prefix       = "/fineract-provider/api/v1"
+
+	// upcomingMeetingCap bounds the meetings list: all past/completed occurrences plus this
+	// many future ones (the app pins one upcoming card + lists the past). A weekly calendar
+	// otherwise yields 100+ future recurringDates.
+	upcomingMeetingCap = 4
+)
+
+// registerMeetingRoutes wires all COMP-CAL meeting-lifecycle endpoints. Called from
+// RegisterRoutes. See the file header for the full path/handler/DTO map and the
+// deliberately-unregistered loan-transaction paths.
+func (h *Handler) registerMeetingRoutes(mux *http.ServeMux) {
+	// meeting-calendar / meeting-summary / previous-meeting-review — prefixed base.
+	mux.HandleFunc("GET "+fineractV1Prefix+"/centers/{centerId}/meetings", h.HandleCenterMeetings)
+	mux.HandleFunc("GET "+fineractV1Prefix+"/datatables/dt_meeting_record/{centerId}", h.HandleMeetingRecordDatatable)
+	mux.HandleFunc("GET "+fineractV1Prefix+"/datatables/dt_meeting_attendance/{meetingId}", h.HandleMeetingAttendanceList)
+
+	// meeting-conduct — bare base.
+	mux.HandleFunc("GET /datatables/dt_meeting_record/{centerId}", h.HandlePreviousMeetingRecord)
+	mux.HandleFunc("GET /centers/{centerId}", h.HandleCenterDetail)
+	mux.HandleFunc("GET /datatables/dt_group_corpus/{centerId}", h.HandleGroupCorpusRead)
+	mux.HandleFunc("GET /loans", h.HandleActiveLoans)
+	mux.HandleFunc("GET /datatables/dt_loan_vote/{loanId}", h.HandleLoanVotes)
+	mux.HandleFunc("POST /datatables/dt_meeting_record", h.HandlePostMeetingRecord)
+	mux.HandleFunc("POST /datatables/dt_meeting_attendance", h.HandlePostMeetingAttendance)
+	mux.HandleFunc("POST /savingsaccounts/{savingsId}/transactions", h.HandlePostSavingsTransaction)
+	mux.HandleFunc("PUT /datatables/dt_group_corpus/{centerId}", h.HandleUpdateCorpus)
+
+	// reschedule (G3/F6) — server-gated in the app (offline-queued), built here for when it lands.
+	mux.HandleFunc("PUT /centers/{centerId}/calendars/{calendarId}", h.HandleRescheduleCalendar)
+}
+
+// ---- App-facing wire contract (exact @SerialName match to the KMP DTOs) ----
+
+// meetingListItemDto == MeetingListItemDto (meetingcalendar). attendanceCount /
+// totalCollectedKES are pointers so UPCOMING/MISSED rows serialize null (matching the
+// app's `Int? = null` / `Long? = null`).
+type meetingListItemDto struct {
+	MeetingID       string `json:"meetingId"`
+	MeetingNumber   int    `json:"meetingNumber"`
+	MeetingDate     string `json:"meetingDate"`
+	Status          string `json:"status"`
+	AttendanceCount *int   `json:"attendanceCount"`
+	TotalCollected  *int64 `json:"totalCollectedKES"`
+}
+
+// meetingRecordItemDto == MeetingRecordItemDto (one row of MeetingRecordListDto).
+type meetingRecordItemDto struct {
+	MeetingNumber   int    `json:"meetingNumber"`
+	ActualDate      string `json:"actualDate"`
+	TotalSavings    int64  `json:"totalSavings"`
+	TotalRepayments int64  `json:"totalRepayments"`
+	AttendanceCount int    `json:"attendanceCount"`
+	ClosingCorpus   int64  `json:"closingCorpus"`
+}
+
+// meetingRecordListDto == MeetingRecordListDto (meetingcalendar.getMeetingRecords).
+type meetingRecordListDto struct {
+	CenterID int                    `json:"centerId"`
+	Records  []meetingRecordItemDto `json:"records"`
+}
+
+// savingsBreakdownItemDto == SavingsBreakdownItemDto (nested in MeetingSummaryRecordDto).
+type savingsBreakdownItemDto struct {
+	MemberID          string `json:"memberId"`
+	MemberName        string `json:"memberName"`
+	GroupSavings      int64  `json:"groupSavings"`
+	IndividualSavings int64  `json:"individualSavings"`
+}
+
+// loanSummaryItemDto == LoanSummaryItemDto (nested in MeetingSummaryRecordDto).
+type loanSummaryItemDto struct {
+	MemberID        string `json:"memberId"`
+	MemberName      string `json:"memberName"`
+	AmountDisbursed int64  `json:"amountDisbursed"`
+	AmountRepaid    int64  `json:"amountRepaid"`
+	OutstandingAfter int64 `json:"outstandingAfter"`
+}
+
+// meetingSummaryRecordDto == MeetingSummaryRecordDto (meetingsummary.getMeetingRecord).
+type meetingSummaryRecordDto struct {
+	MeetingID                  string                    `json:"meetingId"`
+	MeetingNumber              int                       `json:"meetingNumber"`
+	ActualDate                 string                    `json:"actualDate"`
+	AttendanceCount            int                       `json:"attendanceCount"`
+	TotalMemberCount           int                       `json:"totalMemberCount"`
+	GroupSavingsCollected      int64                     `json:"groupSavingsCollected"`
+	IndividualSavingsCollected int64                     `json:"individualSavingsCollected"`
+	TotalSavingsCollected      int64                     `json:"totalSavingsCollected"`
+	LoansDisbursed             int64                     `json:"loansDisbursed"`
+	LoansRepaid                int64                     `json:"loansRepaid"`
+	FinesCollected             int64                     `json:"finesCollected"`
+	OpeningCorpus              int64                     `json:"openingCorpus"`
+	ClosingCorpus              int64                     `json:"closingCorpus"`
+	SavingsBreakdown           []savingsBreakdownItemDto `json:"savingsBreakdown"`
+	LoanItems                  []loanSummaryItemDto      `json:"loanItems"`
+}
+
+// meetingAttendanceRowDto == MeetingAttendanceRowDto (previousmeetingreview).
+type meetingAttendanceRowDto struct {
+	MemberID   string `json:"memberId"`
+	MemberName string `json:"memberName"`
+	Status     string `json:"status"`
+	FineAmount int64  `json:"fineAmount"`
+}
+
+// meetingRecordDetailDto == MeetingRecordDetailDto (meetingconduct.getPreviousMeetingRecord).
+type meetingRecordDetailDto struct {
+	MeetingID           string `json:"meetingId"`
+	MeetingNumber       int    `json:"meetingNumber"`
+	ActualDate          string `json:"actualDate"`
+	TotalSavings        int64  `json:"totalSavings"`
+	TotalRepayments     int64  `json:"totalRepayments"`
+	TotalLoansDisbursed int64  `json:"totalLoansDisbursed"`
+	TotalFinesCollected int64  `json:"totalFinesCollected"`
+	ClosingCorpus       int64  `json:"closingCorpus"`
+	AttendanceCount     int    `json:"attendanceCount"`
+}
+
+// clientMemberDto == ClientMemberDto (nested in CenterDetailDto).
+type clientMemberDto struct {
+	ID               int64   `json:"id"`
+	DisplayName      string  `json:"displayName"`
+	Role             string  `json:"role"`
+	SavingsAccountID *string `json:"savingsAccountId"`
+}
+
+// centerDetailDto == CenterDetailDto (meetingconduct.getGroupMembers).
+type centerDetailDto struct {
+	ID                  int               `json:"id"`
+	Name                string            `json:"name"`
+	ActiveClientMembers []clientMemberDto `json:"activeClientMembers"`
+}
+
+// corpusRecordDto == CorpusRecordDto (meetingconduct.getGroupCorpus).
+type corpusRecordDto struct {
+	CenterID           int    `json:"centerId"`
+	CorpusBalance      int64  `json:"corpusBalance"`
+	CashOnHand         int64  `json:"cashOnHand"`
+	LastUpdatedMeeting int    `json:"lastUpdatedMeeting"`
+	LastUpdatedDate    string `json:"lastUpdatedDate"`
+}
+
+// meetingActiveLoanDto == MeetingActiveLoanDto (one row of LoanListResponseDto).
+type meetingActiveLoanDto struct {
+	LoanID                  string `json:"loanId"`
+	ClientID                string `json:"clientId"`
+	ClientName              string `json:"clientName"`
+	Principal               int64  `json:"principal"`
+	OutstandingBalance      int64  `json:"outstandingBalance"`
+	IsOverdue               bool   `json:"isOverdue"`
+	WeekNumber              int    `json:"weekNumber"`
+	NumberOfRepayments      int    `json:"numberOfRepayments"`
+	ExpectedWeeklyRepayment int64  `json:"expectedWeeklyRepayment"`
+}
+
+// loanListResponseDto == LoanListResponseDto (meetingconduct.getActiveLoans).
+type loanListResponseDto struct {
+	TotalFilteredRecords int                    `json:"totalFilteredRecords"`
+	PageItems            []meetingActiveLoanDto `json:"pageItems"`
+}
+
+// loanVoteRecordDto == LoanVoteRecordDto (meetingconduct.getLoanVotes).
+type loanVoteRecordDto struct {
+	LoanID       string `json:"loanId"`
+	VotesFor     int    `json:"votesFor"`
+	VotesAgainst int    `json:"votesAgainst"`
+	VotesAbstain int    `json:"votesAbstain"`
+}
+
+// dataTableEntryResponseDto == DataTableEntryResponseDto (every meeting write response).
+type dataTableEntryResponseDto struct {
+	ResourceID         int64  `json:"resourceId"`
+	ResourceIdentifier string `json:"resourceIdentifier"`
+}
+
+// ---- App-facing write request bodies (camelCase, as the app POSTs them) ----
+
+type createMeetingRecordRequestIn struct {
+	CenterID                int    `json:"centerId"`
+	MeetingNumber           int    `json:"meetingNumber"`
+	ActualDate              string `json:"actualDate"`
+	OpeningCorpus           int64  `json:"openingCorpus"`
+	ClosingCorpus           int64  `json:"closingCorpus"`
+	TotalSavingsCollected   int64  `json:"totalSavingsCollected"`
+	TotalRepaymentsReceived int64  `json:"totalRepaymentsReceived"`
+	TotalLoansDisbursed     int64  `json:"totalLoansDisbursed"`
+	TotalFinesCollected     int64  `json:"totalFinesCollected"`
+	AttendanceCount         int    `json:"attendanceCount"`
+}
+
+type createAttendanceRequestIn struct {
+	MeetingID  string `json:"meetingId"`
+	MemberID   string `json:"memberId"`
+	Status     string `json:"status"`
+	FineAmount int64  `json:"fineAmount"`
+	// SavingsCollected / RepaymentAmount are NOT part of the app's CreateAttendanceRequestDto
+	// (the app posts per-member savings as separate savingsaccounts transactions). They are
+	// accepted here as optional enrichers so a caller CAN populate the per-member breakdown the
+	// meeting-summary read surfaces; nil (the app case) writes the column null.
+	SavingsCollected *int64 `json:"savingsCollected"`
+	RepaymentAmount  *int64 `json:"repaymentAmount"`
+}
+
+type savingsTransactionRequestIn struct {
+	TransactionDate   string `json:"transactionDate"`
+	TransactionAmount int64  `json:"transactionAmount"`
+	PaymentTypeID     int    `json:"paymentTypeId"`
+}
+
+type updateCorpusRequestIn struct {
+	CorpusBalance      int64  `json:"corpusBalance"`
+	LastUpdatedMeeting int    `json:"lastUpdatedMeeting"`
+	LastUpdatedDate    string `json:"lastUpdatedDate"`
+}
+
+// ---- Fineract wire types (only the fields consumed) ----
+
+// fnMeetingRecordRow is one row of dt_meeting_record as read back (snake_case columns +
+// Fineract-added id/center_id/created_at/updated_at). meeting_date is a [y,m,d] DATE array.
+type fnMeetingRecordRow struct {
+	ID                      int64   `json:"id"`
+	MeetingNumber           int     `json:"meeting_number"`
+	MeetingDate             []int   `json:"meeting_date"`
+	OpeningBalance          float64 `json:"opening_balance"`
+	ClosingBalance          float64 `json:"closing_balance"`
+	TotalSavingsCollected   float64 `json:"total_savings_collected"`
+	TotalRepaymentsReceived float64 `json:"total_repayments_received"`
+	TotalLoansDisbursed     float64 `json:"total_loans_disbursed"`
+	TotalFinesCollected     float64 `json:"total_fines_collected"`
+	AttendanceCount         int     `json:"attendance_count"`
+}
+
+// fnAttendanceRow is one row of dt_meeting_attendance (apptable m_client).
+type fnAttendanceRow struct {
+	ID               int64   `json:"id"`
+	MeetingNumber    int     `json:"meeting_number"`
+	Status           string  `json:"status"`
+	FineAmount       float64 `json:"fine_amount"`
+	SavingsCollected float64 `json:"savings_collected"`
+	RepaymentAmount  float64 `json:"repayment_amount"`
+}
+
+// fnCorpusRow is the single row of dt_group_corpus.
+type fnCorpusRow struct {
+	CorpusBalance      float64 `json:"corpus_balance"`
+	CashOnHand         float64 `json:"cash_on_hand"`
+	LastUpdatedMeeting int     `json:"last_updated_meeting"`
+	LastUpdatedDate    []int   `json:"last_updated_date"`
+}
+
+// fnLoanVoteRow is the single row of dt_loan_vote.
+type fnLoanVoteRow struct {
+	VotesFor     int `json:"votes_for"`
+	VotesAgainst int `json:"votes_against"`
+	VotesAbstain int `json:"votes_abstain"`
+}
+
+// fnCalendar is one element of GET /centers/{id}/calendars.
+type fnCalendar struct {
+	ID            int64  `json:"id"`
+	Title         string `json:"title"`
+	StartDate     string `json:"startDate"`
+	Type          struct {
+		Value string `json:"value"`
+	} `json:"type"`
+	RecurringDates [][]int `json:"recurringDates"`
+}
+
+// ---- Handlers: meeting-calendar ----
+
+// HandleCenterMeetings builds the scheduled-meetings list from the center's COLLECTION
+// calendar recurrence (the real source — Fineract's native /centers/{id}/meetings only
+// lists m_meeting rows created by a saved collection sheet, so it is empty until a sheet
+// is generated) enriched with the dt_meeting_record financial rows for COMPLETED meetings.
+// resolveMeetingCenter maps an id the app passes as a "centerId" to the real
+// Fineract center id. The app derives it as groupId.toInt (documented drift), so
+// if GET groups/{id} exposes a centerId we use that; otherwise the id is already a
+// center and is returned unchanged.
+func (h *Handler) resolveMeetingCenter(id int64) int64 {
+	raw, err := h.Fineract.DoRequest("GET", fmt.Sprintf("groups/%d", id), nil, nil)
+	if err != nil {
+		return id
+	}
+	var g struct {
+		CenterID int64 `json:"centerId"`
+	}
+	if json.Unmarshal(raw, &g) == nil && g.CenterID > 0 {
+		return g.CenterID
+	}
+	return id
+}
+
+func (h *Handler) HandleCenterMeetings(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	centerID, ok := pathInt64Param(w, r, "centerId")
+	if !ok {
+		return
+	}
+	// The CommonPurse app navigates meeting-calendar with centerId = groupId.toInt
+	// (a documented app-side drift — GroupBankingNavHost flags "group-dashboard has
+	// no centerId; bridge by parsing groupId"). Resolve that groupId to its real
+	// Fineract centerId so the schedule of the group's meeting center is served.
+	centerID = h.resolveMeetingCenter(centerID)
+	dates, err := h.centerMeetingDates(centerID)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	records, _ := h.readMeetingRecords(centerID) // tolerant: no records yet -> all UPCOMING/MISSED
+	recByNumber := make(map[int]fnMeetingRecordRow, len(records))
+	for _, rec := range records {
+		recByNumber[rec.MeetingNumber] = rec
+	}
+
+	today := todayYMD()
+	out := make([]meetingListItemDto, 0, len(dates))
+	upcomingSeen := 0
+	for i, d := range dates {
+		meetingNumber := i + 1
+		item := meetingListItemDto{
+			MeetingID:     meetingKey(centerID, meetingNumber),
+			MeetingNumber: meetingNumber,
+			MeetingDate:   fmtFineractDate(d),
+		}
+		if rec, done := recByNumber[meetingNumber]; done {
+			item.Status = "COMPLETED"
+			ac := rec.AttendanceCount
+			total := roundKES(rec.TotalSavingsCollected) + roundKES(rec.TotalRepaymentsReceived)
+			item.AttendanceCount = &ac
+			item.TotalCollected = &total
+		} else if ymdBefore(d, today) {
+			item.Status = "MISSED"
+		} else {
+			item.Status = "UPCOMING"
+			upcomingSeen++
+		}
+		out = append(out, item)
+		if upcomingSeen >= upcomingMeetingCap {
+			break
+		}
+	}
+	_ = json.NewEncoder(w).Encode(out)
+}
+
+// HandleMeetingRecordDatatable serves the SAME app path for two features, split by the
+// meetingNumber query param: with it -> the meeting-summary composite (single meeting);
+// without it -> the meeting-calendar records list (all meetings).
+func (h *Handler) HandleMeetingRecordDatatable(w http.ResponseWriter, r *http.Request) {
+	if strings.TrimSpace(r.URL.Query().Get("meetingNumber")) != "" {
+		h.handleMeetingSummary(w, r)
+		return
+	}
+	h.handleMeetingRecordsList(w, r)
+}
+
+// handleMeetingRecordsList (meetingcalendar.getMeetingRecords) maps every dt_meeting_record
+// row to a MeetingRecordItemDto, wrapped in MeetingRecordListDto.
+func (h *Handler) handleMeetingRecordsList(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	centerID, ok := pathInt64Param(w, r, "centerId")
+	if !ok {
+		return
+	}
+	records, err := h.readMeetingRecords(centerID)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	out := meetingRecordListDto{CenterID: int(centerID), Records: make([]meetingRecordItemDto, 0, len(records))}
+	for _, rec := range records {
+		out.Records = append(out.Records, meetingRecordItemDto{
+			MeetingNumber:   rec.MeetingNumber,
+			ActualDate:      fmtFineractDate(rec.MeetingDate),
+			TotalSavings:    roundKES(rec.TotalSavingsCollected),
+			TotalRepayments: roundKES(rec.TotalRepaymentsReceived),
+			AttendanceCount: rec.AttendanceCount,
+			ClosingCorpus:   roundKES(rec.ClosingBalance),
+		})
+	}
+	_ = json.NewEncoder(w).Encode(out)
+}
+
+// ---- Handlers: meeting-summary ----
+
+// handleMeetingSummary (meetingsummary.getMeetingRecord) resolves ONE completed meeting into
+// the composite MeetingSummaryRecordDto: scalar totals from the dt_meeting_record row for
+// meetingNumber, plus the per-member savings/loan breakdown from each member's
+// dt_meeting_attendance row for that meeting.
+func (h *Handler) handleMeetingSummary(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	centerID, ok := pathInt64Param(w, r, "centerId")
+	if !ok {
+		return
+	}
+	meetingNumber, err := strconv.Atoi(strings.TrimSpace(r.URL.Query().Get("meetingNumber")))
+	if err != nil || meetingNumber <= 0 {
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid meetingNumber")
+		return
+	}
+	records, err := h.readMeetingRecords(centerID)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	var rec *fnMeetingRecordRow
+	for i := range records {
+		if records[i].MeetingNumber == meetingNumber {
+			rec = &records[i]
+			break
+		}
+	}
+	if rec == nil {
+		writeErr(w, http.StatusNotFound, "not_found", "meeting record not found")
+		return
+	}
+
+	clients, _ := h.resolveCenterClients(centerID)
+	savingsBreakdown := make([]savingsBreakdownItemDto, 0, len(clients))
+	loanItems := make([]loanSummaryItemDto, 0)
+	var groupSavings int64
+	for _, c := range clients {
+		row := h.attendanceRowForMeeting(c.ID, meetingNumber)
+		if row == nil {
+			continue
+		}
+		gs := roundKES(row.SavingsCollected)
+		groupSavings += gs
+		savingsBreakdown = append(savingsBreakdown, savingsBreakdownItemDto{
+			MemberID:          strconv.FormatInt(c.ID, 10),
+			MemberName:        c.Name,
+			GroupSavings:      gs,
+			IndividualSavings: 0,
+		})
+		if row.RepaymentAmount > 0 {
+			loanItems = append(loanItems, loanSummaryItemDto{
+				MemberID:     strconv.FormatInt(c.ID, 10),
+				MemberName:   c.Name,
+				AmountRepaid: roundKES(row.RepaymentAmount),
+			})
+		}
+	}
+
+	_ = json.NewEncoder(w).Encode(meetingSummaryRecordDto{
+		MeetingID:                  meetingKey(centerID, meetingNumber),
+		MeetingNumber:              meetingNumber,
+		ActualDate:                 fmtFineractDate(rec.MeetingDate),
+		AttendanceCount:            rec.AttendanceCount,
+		TotalMemberCount:           len(clients),
+		GroupSavingsCollected:      groupSavings,
+		IndividualSavingsCollected: 0,
+		TotalSavingsCollected:      roundKES(rec.TotalSavingsCollected),
+		LoansDisbursed:             roundKES(rec.TotalLoansDisbursed),
+		LoansRepaid:                roundKES(rec.TotalRepaymentsReceived),
+		FinesCollected:             roundKES(rec.TotalFinesCollected),
+		OpeningCorpus:              roundKES(rec.OpeningBalance),
+		ClosingCorpus:              roundKES(rec.ClosingBalance),
+		SavingsBreakdown:           savingsBreakdown,
+		LoanItems:                  loanItems,
+	})
+}
+
+// ---- Handlers: previous-meeting-review ----
+
+// HandleMeetingAttendanceList (previousmeetingreview.getMeetingAttendance) returns every
+// per-member attendance row for the meeting encoded in meetingId ("{centerId}-{meetingNumber}").
+// An empty roster is a valid Content (the app's isEmpty = { false }) -> [], never 404.
+func (h *Handler) HandleMeetingAttendanceList(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	centerID, meetingNumber, ok := parseMeetingKey(r.PathValue("meetingId"))
+	if !ok {
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid meetingId (expected {centerId}-{meetingNumber})")
+		return
+	}
+	clients, err := h.resolveCenterClients(centerID)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	out := make([]meetingAttendanceRowDto, 0, len(clients))
+	for _, c := range clients {
+		row := h.attendanceRowForMeeting(c.ID, meetingNumber)
+		if row == nil {
+			continue
+		}
+		out = append(out, meetingAttendanceRowDto{
+			MemberID:   strconv.FormatInt(c.ID, 10),
+			MemberName: c.Name,
+			Status:     row.Status,
+			FineAmount: roundKES(row.FineAmount),
+		})
+	}
+	_ = json.NewEncoder(w).Encode(out)
+}
+
+// ---- Handlers: meeting-conduct reads ----
+
+// HandlePreviousMeetingRecord (meetingconduct.getPreviousMeetingRecord) returns the LATEST
+// meeting's summary row (highest meeting_number). 404 when no meeting has been conducted
+// (the app's "first meeting" branch).
+func (h *Handler) HandlePreviousMeetingRecord(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	centerID, ok := pathInt64Param(w, r, "centerId")
+	if !ok {
+		return
+	}
+	records, err := h.readMeetingRecords(centerID)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	if len(records) == 0 {
+		writeErr(w, http.StatusNotFound, "not_found", "no previous meeting record")
+		return
+	}
+	latest := records[0]
+	for _, rec := range records[1:] {
+		if rec.MeetingNumber > latest.MeetingNumber {
+			latest = rec
+		}
+	}
+	_ = json.NewEncoder(w).Encode(meetingRecordDetailDto{
+		MeetingID:           meetingKey(centerID, latest.MeetingNumber),
+		MeetingNumber:       latest.MeetingNumber,
+		ActualDate:          fmtFineractDate(latest.MeetingDate),
+		TotalSavings:        roundKES(latest.TotalSavingsCollected),
+		TotalRepayments:     roundKES(latest.TotalRepaymentsReceived),
+		TotalLoansDisbursed: roundKES(latest.TotalLoansDisbursed),
+		TotalFinesCollected: roundKES(latest.TotalFinesCollected),
+		ClosingCorpus:       roundKES(latest.ClosingBalance),
+		AttendanceCount:     latest.AttendanceCount,
+	})
+}
+
+// HandleCenterDetail (meetingconduct.getGroupMembers) reshapes the center + its groups'
+// clients into CenterDetailDto.activeClientMembers.
+func (h *Handler) HandleCenterDetail(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	centerID, ok := pathInt64Param(w, r, "centerId")
+	if !ok {
+		return
+	}
+	name, err := h.centerName(centerID)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	clients, err := h.resolveCenterClients(centerID)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	members := make([]clientMemberDto, 0, len(clients))
+	for _, c := range clients {
+		members = append(members, clientMemberDto{
+			ID:               c.ID,
+			DisplayName:      c.Name,
+			Role:             "Member", // no per-member role linkage on mifos-bank-2; mapper defaults to Member.
+			SavingsAccountID: nil,      // savings deposits are not exercised via this facade.
+		})
+	}
+	_ = json.NewEncoder(w).Encode(centerDetailDto{ID: int(centerID), Name: name, ActiveClientMembers: members})
+}
+
+// HandleGroupCorpusRead (meetingconduct.getGroupCorpus) returns the single dt_group_corpus
+// row. 404 when unset (the app defaults opening corpus / cash-on-hand to 0).
+func (h *Handler) HandleGroupCorpusRead(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	centerID, ok := pathInt64Param(w, r, "centerId")
+	if !ok {
+		return
+	}
+	rows, err := h.readCorpusRows(centerID)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	if len(rows) == 0 {
+		writeErr(w, http.StatusNotFound, "not_found", "no corpus record")
+		return
+	}
+	c := rows[0]
+	_ = json.NewEncoder(w).Encode(corpusRecordDto{
+		CenterID:           int(centerID),
+		CorpusBalance:      roundKES(c.CorpusBalance),
+		CashOnHand:         roundKES(c.CashOnHand),
+		LastUpdatedMeeting: c.LastUpdatedMeeting,
+		LastUpdatedDate:    fmtFineractDate(c.LastUpdatedDate),
+	})
+}
+
+// HandleActiveLoans (meetingconduct.getActiveLoans) resolves the group's clients' ACTIVE loans
+// into LoanListResponseDto. The app filters by groupId (the group under the center); we walk
+// that group's clients' real loan accounts. No loans -> empty (the app's tolerant step 4).
+func (h *Handler) HandleActiveLoans(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	groupID, err := strconv.ParseInt(strings.TrimSpace(r.URL.Query().Get("groupId")), 10, 64)
+	if err != nil || groupID <= 0 {
+		writeErr(w, http.StatusBadRequest, "bad_request", "groupId query param is required")
+		return
+	}
+	clients, err := h.groupClients(groupID)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	items := make([]meetingActiveLoanDto, 0)
+	for _, c := range clients {
+		raw, lerr := h.Fineract.DoRequest("GET", fmt.Sprintf("clients/%d/accounts", c.ID), nil, nil)
+		if lerr != nil {
+			continue
+		}
+		var ca fnClientAccounts
+		if json.Unmarshal(raw, &ca) != nil {
+			continue
+		}
+		for _, l := range ca.LoanAccounts {
+			if !l.Status.Active {
+				continue
+			}
+			items = append(items, meetingActiveLoanDto{
+				LoanID:             strconv.FormatInt(l.ID, 10),
+				ClientID:           strconv.FormatInt(c.ID, 10),
+				ClientName:         c.Name,
+				OutstandingBalance: roundKES(l.LoanBalance),
+				IsOverdue:          l.InArrears,
+			})
+		}
+	}
+	_ = json.NewEncoder(w).Encode(loanListResponseDto{TotalFilteredRecords: len(items), PageItems: items})
+}
+
+// HandleLoanVotes (meetingconduct.getLoanVotes) returns the single dt_loan_vote tally for a
+// loan. 404 when no votes cast (the app's zero-tally branch).
+func (h *Handler) HandleLoanVotes(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	loanID := strings.TrimSpace(r.PathValue("loanId"))
+	if loanID == "" {
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid loanId")
+		return
+	}
+	raw, err := h.Fineract.DoRequest("GET", fmt.Sprintf("datatables/%s/%s", loanVoteTable, loanID), nil, nil)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, "not_found", "no loan votes")
+		return
+	}
+	var rows []fnLoanVoteRow
+	if json.Unmarshal(raw, &rows) != nil || len(rows) == 0 {
+		writeErr(w, http.StatusNotFound, "not_found", "no loan votes")
+		return
+	}
+	v := rows[0]
+	_ = json.NewEncoder(w).Encode(loanVoteRecordDto{
+		LoanID:       loanID,
+		VotesFor:     v.VotesFor,
+		VotesAgainst: v.VotesAgainst,
+		VotesAbstain: v.VotesAbstain,
+	})
+}
+
+// ---- Handlers: meeting-conduct writes ----
+
+// HandlePostMeetingRecord (meetingconduct.postMeetingRecord, submit priority 1) writes the
+// conducted-meeting summary row to dt_meeting_record/{centerId} and returns its row id.
+func (h *Handler) HandlePostMeetingRecord(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	var in createMeetingRecordRequestIn
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid JSON body")
+		return
+	}
+	if in.CenterID <= 0 || in.MeetingNumber <= 0 {
+		writeErr(w, http.StatusBadRequest, "bad_request", "centerId and meetingNumber are required")
+		return
+	}
+	row := map[string]interface{}{
+		"meeting_number":            in.MeetingNumber,
+		"meeting_date":              normalizeFineractDate(in.ActualDate),
+		"opening_balance":           in.OpeningCorpus,
+		"closing_balance":           in.ClosingCorpus,
+		"total_savings_collected":   in.TotalSavingsCollected,
+		"total_repayments_received": in.TotalRepaymentsReceived,
+		"total_loans_disbursed":     in.TotalLoansDisbursed,
+		"total_fines_collected":     in.TotalFinesCollected,
+		"total_inflows":             in.TotalSavingsCollected + in.TotalRepaymentsReceived,
+		"total_outflows":            in.TotalLoansDisbursed,
+		"attendance_count":          in.AttendanceCount,
+		"dateFormat":                "yyyy-MM-dd",
+		"locale":                    "en",
+	}
+	resourceID, err := h.writeDatatableRow(meetingRecordTable, in.i64(), row)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", "write meeting record: "+err.Error())
+		return
+	}
+	_ = json.NewEncoder(w).Encode(dataTableEntryResponseDto{ResourceID: resourceID})
+}
+
+// HandlePostMeetingAttendance (meetingconduct.postMeetingAttendance, submit priority 2) writes
+// one per-member attendance row to dt_meeting_attendance/{memberId} (apptable m_client). The
+// meeting is keyed by meeting_number, parsed from the request's opaque meetingId.
+func (h *Handler) HandlePostMeetingAttendance(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	var in createAttendanceRequestIn
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid JSON body")
+		return
+	}
+	memberID, err := strconv.ParseInt(strings.TrimSpace(in.MemberID), 10, 64)
+	if err != nil || memberID <= 0 {
+		writeErr(w, http.StatusBadRequest, "bad_request", "memberId is required")
+		return
+	}
+	_, meetingNumber, ok := parseMeetingKey(in.MeetingID)
+	if !ok {
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid meetingId (expected {centerId}-{meetingNumber})")
+		return
+	}
+	status := strings.TrimSpace(in.Status)
+	if status == "" {
+		status = "ABSENT"
+	}
+	row := map[string]interface{}{
+		"meeting_number": meetingNumber,
+		"status":         status,
+		"fine_amount":    in.FineAmount,
+		"locale":         "en",
+	}
+	if in.SavingsCollected != nil {
+		row["savings_collected"] = *in.SavingsCollected
+	}
+	if in.RepaymentAmount != nil {
+		row["repayment_amount"] = *in.RepaymentAmount
+	}
+	resourceID, err := h.writeDatatableRow(meetingAttendanceTable, memberID, row)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", "write attendance: "+err.Error())
+		return
+	}
+	_ = json.NewEncoder(w).Encode(dataTableEntryResponseDto{ResourceID: resourceID})
+}
+
+// HandlePostSavingsTransaction (meetingconduct.postSavingsTransaction, submit priority 3) posts a
+// real savings DEPOSIT against {savingsId}. transactionDate is normalized to Fineract's date-only
+// "dd MMMM yyyy" via the shared fineractTxnDate (share_out_write.go).
+func (h *Handler) HandlePostSavingsTransaction(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	savingsID := strings.TrimSpace(r.PathValue("savingsId"))
+	if savingsID == "" {
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid savingsId")
+		return
+	}
+	var in savingsTransactionRequestIn
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid JSON body")
+		return
+	}
+	command := strings.TrimSpace(r.URL.Query().Get("command"))
+	if command == "" {
+		command = "deposit"
+	}
+	body := map[string]interface{}{
+		"transactionDate":   fineractTxnDate(in.TransactionDate),
+		"transactionAmount": in.TransactionAmount,
+		"dateFormat":        "dd MMMM yyyy",
+		"locale":            "en",
+	}
+	if in.PaymentTypeID > 0 {
+		body["paymentTypeId"] = in.PaymentTypeID
+	}
+	raw, err := h.Fineract.DoRequest("POST", fmt.Sprintf("savingsaccounts/%s/transactions", savingsID), body, map[string]string{"command": command})
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", strings.TrimSpace(string(nonEmpty(raw))))
+		return
+	}
+	var resp struct {
+		ResourceID int64 `json:"resourceId"`
+	}
+	_ = json.Unmarshal(raw, &resp)
+	_ = json.NewEncoder(w).Encode(dataTableEntryResponseDto{ResourceID: resp.ResourceID})
+}
+
+// HandleUpdateCorpus (meetingconduct.updateCorpus, submit priority 6) upserts the single
+// dt_group_corpus row for the center (POST to create, PUT to update) with the closing corpus.
+func (h *Handler) HandleUpdateCorpus(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	centerID, ok := pathInt64Param(w, r, "centerId")
+	if !ok {
+		return
+	}
+	var in updateCorpusRequestIn
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid JSON body")
+		return
+	}
+	row := map[string]interface{}{
+		"corpus_balance":       in.CorpusBalance,
+		"closing_balance":      in.CorpusBalance,
+		"last_updated_meeting": in.LastUpdatedMeeting,
+		"meeting_number":       in.LastUpdatedMeeting,
+		"last_updated_date":    normalizeFineractDate(in.LastUpdatedDate),
+		"dateFormat":           "yyyy-MM-dd",
+		"locale":               "en",
+	}
+	existing, _ := h.readCorpusRows(centerID)
+	method := "POST"
+	if len(existing) > 0 {
+		method = "PUT" // single-row datatable: PUT updates the existing row.
+	}
+	raw, err := h.Fineract.DoRequest(method, fmt.Sprintf("datatables/%s/%d", groupCorpusTable, centerID), row, nil)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", "update corpus: "+strings.TrimSpace(string(nonEmpty(raw))))
+		return
+	}
+	var resp struct {
+		ResourceID int64 `json:"resourceId"`
+	}
+	_ = json.Unmarshal(raw, &resp)
+	if resp.ResourceID == 0 {
+		resp.ResourceID = centerID // PUT echoes the apptable id.
+	}
+	_ = json.NewEncoder(w).Encode(dataTableEntryResponseDto{ResourceID: resp.ResourceID})
+}
+
+// HandleRescheduleCalendar (meeting-calendar G3/F6 RescheduleMeeting) forwards a calendar update
+// to Fineract's real PUT /centers/{id}/calendars/{cid}?command=updateCalendar. The app currently
+// offline-queues this (server-gated — see RescheduleMeetingRequest KDoc), so the precise
+// RescheduleMeetingRequest->Fineract field mapping is resolved server-side when the live write
+// lands; this passthrough forwards the received body verbatim, injecting dateFormat/locale so a
+// startDate change parses.
+func (h *Handler) HandleRescheduleCalendar(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	centerID, ok := pathInt64Param(w, r, "centerId")
+	if !ok {
+		return
+	}
+	calendarID := strings.TrimSpace(r.PathValue("calendarId"))
+	if calendarID == "" {
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid calendarId")
+		return
+	}
+	body := map[string]interface{}{}
+	if r.Body != nil {
+		_ = json.NewDecoder(r.Body).Decode(&body)
+	}
+	if _, has := body["dateFormat"]; !has {
+		body["dateFormat"] = "yyyy-MM-dd"
+	}
+	if _, has := body["locale"]; !has {
+		body["locale"] = "en"
+	}
+	command := strings.TrimSpace(r.URL.Query().Get("command"))
+	if command == "" {
+		command = "updateCalendar"
+	}
+	raw, err := h.Fineract.DoRequest("PUT", fmt.Sprintf("centers/%d/calendars/%s", centerID, calendarID), body, map[string]string{"command": command})
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", strings.TrimSpace(string(nonEmpty(raw))))
+		return
+	}
+	_, _ = w.Write(raw)
+}
+
+// ---- Fineract reads (service credential via DoRequest) ----
+
+// centerMeetingDates returns the scheduled meeting dates ([y,m,d] each) from the center's
+// COLLECTION calendar recurrence (falls back to the first calendar if none is typed COLLECTION).
+func (h *Handler) centerMeetingDates(centerID int64) ([][]int, error) {
+	raw, err := h.Fineract.DoRequest("GET", fmt.Sprintf("centers/%d/calendars", centerID), nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("read calendars: %s", strings.TrimSpace(string(nonEmpty(raw))))
+	}
+	var cals []fnCalendar
+	if err := json.Unmarshal(raw, &cals); err != nil {
+		return nil, fmt.Errorf("decode calendars: %w", err)
+	}
+	var chosen *fnCalendar
+	for i := range cals {
+		if strings.EqualFold(cals[i].Type.Value, "COLLECTION") {
+			chosen = &cals[i]
+			break
+		}
+	}
+	if chosen == nil && len(cals) > 0 {
+		chosen = &cals[0]
+	}
+	if chosen == nil {
+		return [][]int{}, nil
+	}
+	return chosen.RecurringDates, nil
+}
+
+// readMeetingRecords reads every dt_meeting_record row for the center. An empty/unprovisioned
+// datatable yields an empty slice (never an error) so callers degrade gracefully.
+func (h *Handler) readMeetingRecords(centerID int64) ([]fnMeetingRecordRow, error) {
+	raw, err := h.Fineract.DoRequest("GET", fmt.Sprintf("datatables/%s/%d", meetingRecordTable, centerID), nil, nil)
+	if err != nil {
+		return []fnMeetingRecordRow{}, nil
+	}
+	var rows []fnMeetingRecordRow
+	if err := json.Unmarshal(raw, &rows); err != nil {
+		return []fnMeetingRecordRow{}, nil
+	}
+	return rows, nil
+}
+
+// readCorpusRows reads the (0- or 1-element) dt_group_corpus array for the center.
+func (h *Handler) readCorpusRows(centerID int64) ([]fnCorpusRow, error) {
+	raw, err := h.Fineract.DoRequest("GET", fmt.Sprintf("datatables/%s/%d", groupCorpusTable, centerID), nil, nil)
+	if err != nil {
+		return []fnCorpusRow{}, nil
+	}
+	var rows []fnCorpusRow
+	if err := json.Unmarshal(raw, &rows); err != nil {
+		return []fnCorpusRow{}, nil
+	}
+	return rows, nil
+}
+
+// attendanceRowForMeeting returns the client's dt_meeting_attendance row for meetingNumber, or nil.
+func (h *Handler) attendanceRowForMeeting(clientID int64, meetingNumber int) *fnAttendanceRow {
+	raw, err := h.Fineract.DoRequest("GET", fmt.Sprintf("datatables/%s/%d", meetingAttendanceTable, clientID), nil, nil)
+	if err != nil {
+		return nil
+	}
+	var rows []fnAttendanceRow
+	if json.Unmarshal(raw, &rows) != nil {
+		return nil
+	}
+	for i := range rows {
+		if rows[i].MeetingNumber == meetingNumber {
+			return &rows[i]
+		}
+	}
+	return nil
+}
+
+// centerName reads the center's display name.
+func (h *Handler) centerName(centerID int64) (string, error) {
+	raw, err := h.Fineract.DoRequest("GET", fmt.Sprintf("centers/%d", centerID), nil, nil)
+	if err != nil {
+		return "", fmt.Errorf("read center: %s", strings.TrimSpace(string(nonEmpty(raw))))
+	}
+	var c struct {
+		Name string `json:"name"`
+	}
+	_ = json.Unmarshal(raw, &c)
+	return c.Name, nil
+}
+
+// resolveCenterClients flattens the center -> associated groups -> client members into a
+// deduped list. This is the real Fineract member linkage (a Fineract center contains groups,
+// groups contain clients — there is no direct center<->client membership).
+func (h *Handler) resolveCenterClients(centerID int64) ([]centerClient, error) {
+	raw, err := h.Fineract.DoRequest("GET", fmt.Sprintf("centers/%d", centerID), nil, map[string]string{"associations": "groupMembers"})
+	if err != nil {
+		return nil, fmt.Errorf("read center groups: %s", strings.TrimSpace(string(nonEmpty(raw))))
+	}
+	var c struct {
+		GroupMembers []struct {
+			ID int64 `json:"id"`
+		} `json:"groupMembers"`
+	}
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return nil, fmt.Errorf("decode center groups: %w", err)
+	}
+	seen := make(map[int64]bool)
+	out := make([]centerClient, 0)
+	for _, g := range c.GroupMembers {
+		clients, gerr := h.groupClients(g.ID)
+		if gerr != nil {
+			continue
+		}
+		for _, m := range clients {
+			if !seen[m.ID] {
+				seen[m.ID] = true
+				out = append(out, m)
+			}
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
+}
+
+// groupClients returns a group's active client members.
+func (h *Handler) groupClients(groupID int64) ([]centerClient, error) {
+	raw, err := h.Fineract.DoRequest("GET", fmt.Sprintf("groups/%d", groupID), nil, map[string]string{"associations": "clientMembers"})
+	if err != nil {
+		return nil, fmt.Errorf("read group %d: %s", groupID, strings.TrimSpace(string(nonEmpty(raw))))
+	}
+	var g struct {
+		ClientMembers []struct {
+			ID          int64  `json:"id"`
+			DisplayName string `json:"displayName"`
+		} `json:"clientMembers"`
+	}
+	if err := json.Unmarshal(raw, &g); err != nil {
+		return nil, fmt.Errorf("decode group %d: %w", groupID, err)
+	}
+	out := make([]centerClient, 0, len(g.ClientMembers))
+	for _, m := range g.ClientMembers {
+		out = append(out, centerClient{ID: m.ID, Name: m.DisplayName})
+	}
+	return out, nil
+}
+
+// centerClient is a flattened center member (client id + display name).
+type centerClient struct {
+	ID   int64
+	Name string
+}
+
+// ---- helpers ----
+
+// i64 exposes createMeetingRecordRequestIn.CenterID (int) as int64 at the datatable-write call
+// site without a scattered cast.
+func (in createMeetingRecordRequestIn) i64() int64 { return int64(in.CenterID) }
+
+// pathInt64Param reads a positive int64 path variable, writing a 400 on failure.
+func pathInt64Param(w http.ResponseWriter, r *http.Request, name string) (int64, bool) {
+	id, err := strconv.ParseInt(strings.TrimSpace(r.PathValue(name)), 10, 64)
+	if err != nil || id <= 0 {
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid "+name)
+		return 0, false
+	}
+	return id, true
+}
+
+// meetingKey encodes the opaque meetingId this facade owns end-to-end.
+func meetingKey(centerID int64, meetingNumber int) string {
+	return fmt.Sprintf("%d-%d", centerID, meetingNumber)
+}
+
+// parseMeetingKey decodes "{centerId}-{meetingNumber}" back into its parts.
+func parseMeetingKey(s string) (centerID int64, meetingNumber int, ok bool) {
+	parts := strings.SplitN(strings.TrimSpace(s), "-", 2)
+	if len(parts) != 2 {
+		return 0, 0, false
+	}
+	c, err1 := strconv.ParseInt(parts[0], 10, 64)
+	m, err2 := strconv.Atoi(parts[1])
+	if err1 != nil || err2 != nil || c <= 0 || m <= 0 {
+		return 0, 0, false
+	}
+	return c, m, true
+}
+
+// roundKES converts a Fineract decimal (e.g. 2500.000000) to the whole-KES Long the app DTOs use.
+func roundKES(f float64) int64 { return int64(math.Round(f)) }
+
+// todayYMD returns the host's current [y,m,d].
+func todayYMD() []int {
+	now := time.Now()
+	return []int{now.Year(), int(now.Month()), now.Day()}
+}
+
+// ymdBefore reports whether the [y,m,d] date a is strictly before b.
+func ymdBefore(a, b []int) bool {
+	if len(a) < 3 || len(b) < 3 {
+		return false
+	}
+	for i := 0; i < 3; i++ {
+		if a[i] != b[i] {
+			return a[i] < b[i]
+		}
+	}
+	return false
+}
+
+// normalizeFineractDate coerces any inbound date string to canonical "yyyy-MM-dd" for a Fineract
+// DATE-column write. Accepts a bare ISO date, a full ISO instant, "dd MMMM yyyy", or empty
+// (-> host today). See the file header DATE-FORMAT decisions for why the app's own dateFormat
+// field is not trusted.
+func normalizeFineractDate(s string) string {
+	const out = "2006-01-02"
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Now().Format(out)
+	}
+	if len(s) >= 10 {
+		if t, err := time.Parse(out, s[:10]); err == nil {
+			return t.Format(out)
+		}
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.Format(out)
+	}
+	if t, err := time.Parse("02 January 2006", s); err == nil {
+		return t.Format(out)
+	}
+	return time.Now().Format(out)
+}

--- a/go/companion/member_dashboard.go
+++ b/go/companion/member_dashboard.go
@@ -1,0 +1,217 @@
+// Copyright since 2025 Mifos Initiative
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// COMP-MEMBERDASH: the personal (member-scoped) dashboard read facade. It reshapes the real
+// Fineract group corpus + the member's loan into the single companion contract the CommonPurse
+// app's MemberDashboardApiImpl calls:
+//
+//	GET /companion/member/dashboard?selectedGroupId={id} -> MemberDashboardResponseDto
+//
+// Source of truth for the wire shape is the app's OWN approved contract:
+//   - service : core/network/.../service/personaldashboard/MemberDashboardApiImpl.kt  (path + optional selectedGroupId param)
+//   - model   : core/network/.../model/MemberDashboardDto.kt + SavingsTransactionDto.kt
+//   - mapper  : core/network/.../mapper/MemberDashboardMappers.kt + SavingsTransactionMappers.kt
+//
+// DATE-FORMAT decision:
+//   - SavingsTransactionDto.date (recentTransactions[]) -> LocalDate.parse(date) in
+//     SavingsTransactionMappers.kt  => emit "YYYY-MM-DD" (fmtFineractDate). NOT an Instant field.
+//   - MemberDashboardResponseDto.nextRecipientEta -> pass-through String? (never parsed); null here
+//     because this seed is an ACCUMULATING (VSLA) pool, where the rotation triad is null by contract.
+//
+// The endpoint carries no memberId param (the caller identity is implicit), so the dashboard is
+// resolved for a stable default member of the selected group (Grace Wanjiru, who holds the real
+// loan) — the documented hook for real per-user resolution once member<->session linkage lands.
+package companion
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// registerMemberDashboardRoutes wires the COMP-MEMBERDASH endpoint. Called from RegisterRoutes.
+func (h *Handler) registerMemberDashboardRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /companion/member/dashboard", h.HandleMemberDashboard)
+}
+
+// ---- App-facing wire contract (exact match to core/network/.../model/MemberDashboardDto.kt) ----
+
+// GroupSummaryDto == one row of myGroups / selectedGroup.
+type GroupSummaryDto struct {
+	GroupID   string `json:"groupId"`
+	Name      string `json:"name"`
+	PoolModel string `json:"poolModel"`
+}
+
+// SavingsTransactionDto == one row of recentTransactions (compact companion shape).
+type SavingsTransactionDto struct {
+	ID     string  `json:"id"`
+	Date   string  `json:"date"`
+	Type   string  `json:"type"`
+	Amount float64 `json:"amount"`
+}
+
+// MemberDashboardResponseDto == GET /companion/member/dashboard.
+// The pool-model projection axes are mutually exclusive: shareOutProjection for ACCUMULATING pools,
+// rotationPosition+nextRecipientEta for ROTATING_PAYOUT pools. The app force-encodes all three
+// (@EncodeDefault ALWAYS), so they are emitted even when null.
+type MemberDashboardResponseDto struct {
+	MemberName                string                  `json:"memberName"`
+	ClientID                  int64                   `json:"clientId"`
+	GroupLinkedSavingsID      int64                   `json:"groupLinkedSavingsId"`
+	IndividualSavingsID       *int64                  `json:"individualSavingsId"`
+	MyGroups                  []GroupSummaryDto       `json:"myGroups"`
+	SelectedGroup             GroupSummaryDto         `json:"selectedGroup"`
+	PoolModel                 string                  `json:"poolModel"`
+	GroupLinkedSavingsBalance float64                 `json:"groupLinkedSavingsBalance"`
+	IndividualSavingsBalance  float64                 `json:"individualSavingsBalance"`
+	ShareOutProjection        *float64                `json:"shareOutProjection"`
+	RotationPosition          *int                    `json:"rotationPosition"`
+	NextRecipientEta          *string                 `json:"nextRecipientEta"`
+	RecentTransactions        []SavingsTransactionDto `json:"recentTransactions"`
+}
+
+// ---- Handler ----
+
+// HandleMemberDashboard resolves the member-scoped dashboard for the selected group from LIVE
+// Fineract: real group corpus (member share), real per-member individual balance, real recent
+// deposits, and the ACCUMULATING share-out projection computed from the real corpus net of loans.
+func (h *Handler) HandleMemberDashboard(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+
+	// Resolve the selected group: the query param if valid, else the first active group.
+	groups, err := h.activeGroups()
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	if len(groups) == 0 {
+		writeErr(w, http.StatusNotFound, "not_found", "no active groups")
+		return
+	}
+	selectedID := selectGroupID(r.URL.Query().Get("selectedGroupId"), groups)
+
+	_, members, err := h.aggregateGroup(selectedID)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	if len(members) == 0 {
+		writeErr(w, http.StatusNotFound, "not_found", "group has no members")
+		return
+	}
+	member := defaultDashboardMember(members)
+
+	total, savingsIDs, err := h.aggregateSavings(selectedID)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	loansOut, _, _, _ := h.aggregateLoans(members)
+	memberCount := float64(len(members))
+	memberShare := total / memberCount
+
+	// shareOutProjection (ACCUMULATING): the member's share of the corpus net of outstanding loans
+	// at cycle-end — computed from the REAL corpus + loans, never fabricated.
+	proj := (total - loansOut) / memberCount
+	if proj < 0 {
+		proj = 0
+	}
+
+	groupLinkedSavingsID := int64(0)
+	if len(savingsIDs) > 0 {
+		groupLinkedSavingsID = savingsIDs[0]
+	}
+
+	// recentTransactions: the member's share of the real group deposits, newest-first, capped at 10.
+	deposits := h.groupDeposits(savingsIDs)
+	recent := make([]SavingsTransactionDto, 0, len(deposits))
+	for i := len(deposits) - 1; i >= 0; i-- { // groupDeposits is oldest-first -> reverse for newest-first
+		d := deposits[i]
+		recent = append(recent, SavingsTransactionDto{
+			ID:     d.ID,
+			Date:   d.Date, // "YYYY-MM-DD"
+			Type:   "DEPOSIT",
+			Amount: deref64(d.Amount) / memberCount,
+		})
+		if len(recent) >= 10 {
+			break
+		}
+	}
+
+	// Build the group-summary chips. poolModel is ACCUMULATING (defaultVSLAConfig.PoolModel).
+	poolModel := defaultVSLAConfig().PoolModel
+	myGroups := make([]GroupSummaryDto, 0, len(groups))
+	var selected GroupSummaryDto
+	for _, g := range groups {
+		gs := GroupSummaryDto{GroupID: strconv.FormatInt(g.ID, 10), Name: g.Name, PoolModel: poolModel}
+		myGroups = append(myGroups, gs)
+		if g.ID == selectedID {
+			selected = gs
+		}
+	}
+
+	_ = json.NewEncoder(w).Encode(MemberDashboardResponseDto{
+		MemberName:                member.Name,
+		ClientID:                  member.ID,
+		GroupLinkedSavingsID:      groupLinkedSavingsID,
+		IndividualSavingsID:       nil, // no voluntary individual account on this seed
+		MyGroups:                  myGroups,
+		SelectedGroup:             selected,
+		PoolModel:                 poolModel,
+		GroupLinkedSavingsBalance: memberShare,
+		IndividualSavingsBalance:  0,
+		ShareOutProjection:        &proj, // ACCUMULATING pool -> populated
+		RotationPosition:          nil,   // ROTATING_PAYOUT-only -> null
+		NextRecipientEta:          nil,   // ROTATING_PAYOUT-only -> null
+		RecentTransactions:        recent,
+	})
+}
+
+// ---- helpers ----
+
+// activeGroups returns every active Fineract group (id + name), mirroring resolveGroups/HandleMyGroups.
+func (h *Handler) activeGroups() ([]fnGroup, error) {
+	raw, err := h.Fineract.DoRequest("GET", "groups", nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	var groups []fnGroup
+	if err := json.Unmarshal(raw, &groups); err != nil {
+		return nil, err
+	}
+	out := make([]fnGroup, 0, len(groups))
+	for _, g := range groups {
+		if g.Active {
+			out = append(out, g)
+		}
+	}
+	return out, nil
+}
+
+// selectGroupID picks the requested group id if it names an active group, else the first active group.
+func selectGroupID(requested string, groups []fnGroup) int64 {
+	if id, err := strconv.ParseInt(strings.TrimSpace(requested), 10, 64); err == nil {
+		for _, g := range groups {
+			if g.ID == id {
+				return id
+			}
+		}
+	}
+	return groups[0].ID
+}
+
+// defaultDashboardMember picks the stable default member for the implicit-identity dashboard:
+// Grace Wanjiru if present (she holds the real loan → richest dashboard), else the first member.
+func defaultDashboardMember(members []memberRef) memberRef {
+	for _, m := range members {
+		fields := strings.Fields(strings.TrimSpace(m.Name))
+		if len(fields) > 0 && strings.EqualFold(fields[0], "grace") {
+			return m
+		}
+	}
+	return members[0]
+}

--- a/go/companion/member_invite.go
+++ b/go/companion/member_invite.go
@@ -1,0 +1,318 @@
+// Copyright since 2025 Mifos Initiative
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// COMP-DT-002 / COMP-DT-003 / COMP-DT-005: the organizer-side member-INVITE
+// write facade. The CommonPurse (mifos-x-group-banking) app's MemberInviteApiImpl
+// issues, lists, and revokes single-use invite tokens against the companion
+// invitations datatable:
+//
+//	POST   /companion/datatables/invitations/{groupId}          -> GeneratedInviteDto     (generate)
+//	GET    /companion/datatables/invitations/{groupId}          -> [PendingInviteDto]     (list pending)
+//	DELETE /companion/datatables/invitations/{groupId}/{rowId}  -> RevokeInviteResponseDto (revoke)
+//
+// (see core/network/.../service/memberinvite/MemberInviteApiImpl.kt +
+// core/network/.../model/MemberInviteDto.kt). This handler maps that contract
+// onto real Fineract writes on mifos-bank-2: each invite is one row of the
+// `dt_companion_invitations` multiRow datatable attached to apptable m_group.
+//
+// DISTINCT from the recipient-side join-with-code service (validate/associate/
+// mark-accepted, not yet built here) — that models the invitee CONSUMING an
+// invite by code; this models the organizer ISSUING/LISTING/REVOKING them. Both
+// address the same datatable but with disjoint HTTP verbs.
+//
+// Writes/reads use the shared FineractClient service credential (adapter.DoRequest,
+// which sends the service BasicAuth) — the correct path for an organizer/staff
+// write, exactly like the group-create facade in group_create.go.
+//
+// Field names + casing are matched EXACTLY to the app DTOs: the request/list-row
+// fields are the raw snake_case datatable column names (invited_email_phone,
+// role_to_assign, expires_at, accepted_at); the generate response is
+// {token, invite_link, row_id}; the revoke response is the Fineract
+// command-processing envelope {resourceId}.
+//
+// DATE FORMAT DECISION: expires_at and accepted_at are registered as String
+// (VARCHAR) datatable columns, NOT Fineract Date/DateTime types. The app sends
+// expires_at as a client-computed ISO-8601 string (now()+7d) and reads it back as
+// a plain String (PendingInviteDto.expiresAt / .acceptedAt are Kotlin String); a
+// VARCHAR column round-trips that value byte-for-byte with NO Fineract dateFormat/
+// locale parsing, so the Instant.parse hazard that bit the auth path's joinedAt
+// (fmtFineractInstant) does NOT apply here — the string the app sent is exactly
+// the string it gets back. accepted_at stays null for every row this facade
+// writes (a pending invite); the list filters accepted_at IS NULL server-side.
+package companion
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// invitationsTable is the Fineract datatable (apptable m_group) invite rows are
+// written to. Provisioned out-of-band via POST /datatables (idempotent — Fineract
+// 400s "datatable.already.exists.", treated as OK), same convention as
+// groupTypeConfigTable in group_create.go. Columns: token (String 32),
+// invited_email_phone (String 191), role_to_assign (String 32), expires_at
+// (String 64), accepted_at (String 64, nullable), inviter_client_id (Number,
+// nullable). Fineract auto-adds id / group_id / created_at / updated_at.
+const invitationsTable = "dt_companion_invitations"
+
+// inviteAlphabet is the 32-char, ambiguity-free (no 0/O/1/I) charset the 6-char
+// invite token is drawn from — mirrors the app's "K7X2P9"-style test fixtures.
+const inviteAlphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+
+// registerMemberInviteRoutes wires the COMP-DT-002/003/005 endpoints. Called from
+// RegisterRoutes. Method-specific patterns (Go 1.22 ServeMux) — GET vs POST on the
+// same {groupId} path dispatch separately, and DELETE carries an extra {rowId}
+// segment.
+func (h *Handler) registerMemberInviteRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("POST /companion/datatables/invitations/{groupId}", h.HandleGenerateInvite)
+	mux.HandleFunc("GET /companion/datatables/invitations/{groupId}", h.HandleListInvites)
+	mux.HandleFunc("DELETE /companion/datatables/invitations/{groupId}/{rowId}", h.HandleRevokeInvite)
+}
+
+// ---- App-facing wire contract (exact match to the KMP DTOs) ----
+
+// createInviteRequestDto == CreateInviteRequestDto (raw snake_case body; the
+// groupId is a path param, not a body field).
+type createInviteRequestDto struct {
+	InvitedEmailPhone string `json:"invited_email_phone"`
+	RoleToAssign      string `json:"role_to_assign"`
+	ExpiresAt         string `json:"expires_at"`
+}
+
+// generatedInviteDto == GeneratedInviteDto — the issued token, the shareable
+// deep-link URL, and the created datatable row's primary key.
+type generatedInviteDto struct {
+	Token      string `json:"token"`
+	InviteLink string `json:"invite_link"`
+	RowID      int64  `json:"row_id"`
+}
+
+// pendingInviteDto == PendingInviteDto — one row of the pending-invites list.
+// AcceptedAt is a *string so it serializes as JSON null (matching the app's
+// `String? = null`); this facade always emits null (only pending rows are listed).
+type pendingInviteDto struct {
+	RowID             int64   `json:"row_id"`
+	Token             string  `json:"token"`
+	InvitedEmailPhone string  `json:"invited_email_phone"`
+	RoleToAssign      string  `json:"role_to_assign"`
+	ExpiresAt         string  `json:"expires_at"`
+	AcceptedAt        *string `json:"accepted_at"`
+}
+
+// revokeInviteResponseDto == RevokeInviteResponseDto — the Fineract
+// command-processing envelope (resourceId = deleted row id).
+type revokeInviteResponseDto struct {
+	ResourceID int64 `json:"resourceId"`
+}
+
+// ---- Fineract wire type (raw datatable row read) ----
+
+// invitationRow is one row of dt_companion_invitations as read back from
+// GET /datatables/dt_companion_invitations/{groupId}. Fineract returns a plain
+// JSON array of these (id = row primary key). created_at/updated_at/group_id/
+// inviter_client_id are present on the wire but unused here.
+type invitationRow struct {
+	ID                int64   `json:"id"`
+	Token             string  `json:"token"`
+	InvitedEmailPhone string  `json:"invited_email_phone"`
+	RoleToAssign      string  `json:"role_to_assign"`
+	ExpiresAt         string  `json:"expires_at"`
+	AcceptedAt        *string `json:"accepted_at"`
+}
+
+// ---- Handlers ----
+
+// HandleGenerateInvite (COMP-DT-002) creates a single-use invite-token row for the
+// posted contact + role and returns {token, invite_link, row_id}.
+func (h *Handler) HandleGenerateInvite(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	groupID, ok := groupIDParam(w, r)
+	if !ok {
+		return
+	}
+	var req createInviteRequestDto
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid JSON body")
+		return
+	}
+	if strings.TrimSpace(req.InvitedEmailPhone) == "" {
+		writeErr(w, http.StatusBadRequest, "bad_request", "invited_email_phone is required")
+		return
+	}
+	role := strings.TrimSpace(req.RoleToAssign)
+	if role == "" {
+		role = "member" // least-privilege default, matches the mapper's tolerant fallback.
+	}
+
+	// Derive a deterministic, collision-free 6-char token from (groupId, seq),
+	// where seq starts at the current row count and increments past any live
+	// token (so revoke-then-reissue never reuses a still-active code).
+	existing, err := h.fetchInvitationRows(groupID)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", "read invitations: "+err.Error())
+		return
+	}
+	taken := make(map[string]bool, len(existing))
+	for _, row := range existing {
+		taken[row.Token] = true
+	}
+	seq := int64(len(existing))
+	token := inviteToken(groupID, seq)
+	for taken[token] {
+		seq++
+		token = inviteToken(groupID, seq)
+	}
+
+	rowID, err := h.fineractWriteInvitation(groupID, token, req.InvitedEmailPhone, role, req.ExpiresAt)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", "write invitation: "+err.Error())
+		return
+	}
+
+	_ = json.NewEncoder(w).Encode(generatedInviteDto{
+		Token:      token,
+		InviteLink: inviteLinkFor(token, groupID),
+		RowID:      rowID,
+	})
+}
+
+// HandleListInvites (COMP-DT-003) returns all pending (accepted_at IS NULL) invite
+// rows for the group.
+func (h *Handler) HandleListInvites(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	groupID, ok := groupIDParam(w, r)
+	if !ok {
+		return
+	}
+	rows, err := h.fetchInvitationRows(groupID)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", "read invitations: "+err.Error())
+		return
+	}
+	out := make([]pendingInviteDto, 0, len(rows))
+	for _, row := range rows {
+		if row.AcceptedAt != nil && strings.TrimSpace(*row.AcceptedAt) != "" {
+			continue // pending only — the app expects accepted_at IS NULL filtered server-side.
+		}
+		out = append(out, pendingInviteDto{
+			RowID:             row.ID,
+			Token:             row.Token,
+			InvitedEmailPhone: row.InvitedEmailPhone,
+			RoleToAssign:      row.RoleToAssign,
+			ExpiresAt:         row.ExpiresAt,
+			AcceptedAt:        nil,
+		})
+	}
+	_ = json.NewEncoder(w).Encode(out)
+}
+
+// HandleRevokeInvite (COMP-DT-005) deletes a pending invite row by id and returns
+// {resourceId}.
+func (h *Handler) HandleRevokeInvite(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	groupID, ok := groupIDParam(w, r)
+	if !ok {
+		return
+	}
+	rowID, err := strconv.ParseInt(r.PathValue("rowId"), 10, 64)
+	if err != nil || rowID <= 0 {
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid rowId")
+		return
+	}
+	resourceID, err := h.fineractDeleteInvitation(groupID, rowID)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", "delete invitation: "+err.Error())
+		return
+	}
+	_ = json.NewEncoder(w).Encode(revokeInviteResponseDto{ResourceID: resourceID})
+}
+
+// ---- Fineract writes/reads (service credential via DoRequest) ----
+
+// fetchInvitationRows reads every row of the group's invitations datatable.
+// Fineract returns a plain JSON array; an empty datatable yields [] (never null).
+func (h *Handler) fetchInvitationRows(groupID int64) ([]invitationRow, error) {
+	raw, err := h.Fineract.DoRequest("GET", fmt.Sprintf("datatables/%s/%d", invitationsTable, groupID), nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("%s", strings.TrimSpace(string(nonEmpty(raw))))
+	}
+	var rows []invitationRow
+	if err := json.Unmarshal(raw, &rows); err != nil {
+		return nil, fmt.Errorf("decode invitations response: %w", err)
+	}
+	return rows, nil
+}
+
+// fineractWriteInvitation inserts one invite row and returns the new row id
+// (Fineract's resourceId). All app-owned columns are String, so no dateFormat is
+// needed; locale is sent so Fineract is happy to parse the row. accepted_at is
+// left unset (null → pending).
+func (h *Handler) fineractWriteInvitation(groupID int64, token, emailPhone, role, expiresAt string) (int64, error) {
+	row := map[string]interface{}{
+		"token":               token,
+		"invited_email_phone": emailPhone,
+		"role_to_assign":      role,
+		"expires_at":          expiresAt,
+		"locale":              "en",
+	}
+	raw, err := h.Fineract.DoRequest("POST", fmt.Sprintf("datatables/%s/%d", invitationsTable, groupID), row, nil)
+	if err != nil {
+		return 0, fmt.Errorf("%s", strings.TrimSpace(string(nonEmpty(raw))))
+	}
+	var resp struct {
+		ResourceID int64 `json:"resourceId"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return 0, fmt.Errorf("decode write-invitation response: %w", err)
+	}
+	if resp.ResourceID == 0 {
+		return 0, fmt.Errorf("fineract returned no row id: %s", string(raw))
+	}
+	return resp.ResourceID, nil
+}
+
+// fineractDeleteInvitation deletes an invite row and returns the deleted row id.
+func (h *Handler) fineractDeleteInvitation(groupID, rowID int64) (int64, error) {
+	raw, err := h.Fineract.DoRequest("DELETE", fmt.Sprintf("datatables/%s/%d/%d", invitationsTable, groupID, rowID), nil, nil)
+	if err != nil {
+		return 0, fmt.Errorf("%s", strings.TrimSpace(string(nonEmpty(raw))))
+	}
+	var resp struct {
+		ResourceID int64 `json:"resourceId"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return 0, fmt.Errorf("decode delete-invitation response: %w", err)
+	}
+	id := resp.ResourceID
+	if id == 0 {
+		id = rowID // Fineract echoed no resourceId — the requested row id is the truth.
+	}
+	return id, nil
+}
+
+// ---- helpers ----
+
+// inviteToken derives a deterministic 6-char token from (groupId, seq) over the
+// 32-char ambiguity-free alphabet. seq is offset by the group's row count and
+// bumped past collisions by the caller, so the code is unique per live invite.
+func inviteToken(groupID, seq int64) string {
+	n := groupID*100000 + seq
+	b := make([]byte, 6)
+	for i := 5; i >= 0; i-- {
+		b[i] = inviteAlphabet[n%int64(len(inviteAlphabet))]
+		n /= int64(len(inviteAlphabet))
+	}
+	return string(b)
+}
+
+// inviteLinkFor builds the shareable deep-link the app surfaces on the success
+// screen — matches the app's fixture shape
+// (https://mifos.app/join?token=<TOKEN>&group=<groupId>).
+func inviteLinkFor(token string, groupID int64) string {
+	return fmt.Sprintf("https://mifos.app/join?token=%s&group=%d", token, groupID)
+}

--- a/go/companion/member_list.go
+++ b/go/companion/member_list.go
@@ -1,0 +1,186 @@
+// Copyright since 2025 Mifos Initiative
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// COMP-MEMBERLIST: the member-list read facade. It reshapes the real Fineract group roster
+// (GET groups/{id}?associations=all + per-member clients/{id}/accounts) into the offset-paginated
+// contract the CommonPurse (mifos-x-group-banking) app's MemberApiImpl fans in:
+//
+//	GET /groups/{groupId}/clients -> MemberPageDto   (the EXACT path + DTO the app calls)
+//
+// Source of truth for the wire shape is the app's OWN approved contract:
+//   - service : core/network/.../service/memberlist/MemberApiImpl.kt  (path GET /groups/{groupId}/clients, params limit/offset)
+//   - model   : core/network/.../model/MemberDto.kt                   (MemberPageDto / MemberDto / MemberRoleDto / LoanStatusDto)
+//   - mapper  : core/network/.../mapper/MemberMappers.kt              (field-by-field, no unmapped field)
+//
+// Field names + casing are matched EXACTLY to MemberDto.kt. MemberDto carries NO date field, so no
+// Instant-vs-LocalDate decision arises on this endpoint.
+//
+// Reads use the shared FineractClient service credential (adapter.DoRequest) — correct for reading
+// group/member data (unlike the auth path, which forwards end-user creds).
+package companion
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// registerMemberListRoutes wires the COMP-MEMBERLIST endpoints. Called from RegisterRoutes.
+func (h *Handler) registerMemberListRoutes(mux *http.ServeMux) {
+	// The EXACT path the app's MemberApiImpl calls (GET /groups/{groupId}/clients).
+	mux.HandleFunc("GET /groups/{groupId}/clients", h.HandleGroupMembers)
+	// Convenience alias under the /companion namespace (the path the generation brief suggested).
+	mux.HandleFunc("GET /companion/groups/{groupId}/members", h.HandleGroupMembers)
+}
+
+// ---- App-facing wire contract (exact match to core/network/.../model/MemberDto.kt) ----
+
+// MemberDto == one row of MemberPageDto.pageItems (GET /groups/{groupId}/clients).
+type MemberDto struct {
+	ID              string  `json:"id"`
+	FineractClientID int64  `json:"fineractClientId"`
+	DisplayName     string  `json:"displayName"`
+	PhotoURI        *string `json:"photoUri"`
+	Role            string  `json:"role"`
+	SavingsBalance  float64 `json:"savingsBalance"`
+	LoanStatus      string  `json:"loanStatus"`
+}
+
+// MemberPageDto == GET /groups/{groupId}/clients (offset-paginated envelope, page_size=20).
+type MemberPageDto struct {
+	TotalFilteredRecords int         `json:"totalFilteredRecords"`
+	PageItems            []MemberDto `json:"pageItems"`
+}
+
+// ---- Handler ----
+
+// HandleGroupMembers returns the group's members (role badge + savings share + loan-status chip),
+// aggregated from LIVE Fineract. limit/offset are honored so the app's paging contract holds.
+func (h *Handler) HandleGroupMembers(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	gid, ok := groupIDParam(w, r)
+	if !ok {
+		return
+	}
+	limit := intParam(r, "limit", 20)
+	offset := intParam(r, "offset", 0)
+
+	_, members, err := h.aggregateGroup(gid)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+
+	// Per-member savings: mifos-bank-2 holds the corpus in ONE group-level savings account
+	// (no individual member accounts), so each member's balance is their pro-rata share of the
+	// real group corpus — a documented computed default (PRO_RATA_BY_SHARES / equal FIXED_AMOUNT
+	// contribution per defaultVSLAConfig) that sums to the real total, never a fabricated figure.
+	groupSavings, _, _ := h.aggregateSavings(gid)
+	share := 0.0
+	if len(members) > 0 {
+		share = groupSavings / float64(len(members))
+	}
+
+	page := MemberPageDto{PageItems: []MemberDto{}}
+	for i, m := range members {
+		page.PageItems = append(page.PageItems, MemberDto{
+			ID:               strconv.FormatInt(m.ID, 10),
+			FineractClientID: m.ID,
+			DisplayName:      m.Name,
+			PhotoURI:         nil, // Fineract exposes no member photo URL on this read.
+			Role:             vslaCommitteeRole(m.Name, i),
+			SavingsBalance:   share,
+			LoanStatus:       h.memberLoanStatus(m.ID),
+		})
+	}
+	page.TotalFilteredRecords = len(page.PageItems)
+
+	// Honor the offset/limit window over the full roster (small groups, in-memory slice).
+	page.PageItems = pageSlice(page.PageItems, offset, limit)
+	_ = json.NewEncoder(w).Encode(page)
+}
+
+// ---- helpers ----
+
+// memberLoanStatus resolves a member's loan-status chip from their real Fineract loan accounts
+// (clients/{id}/accounts): an active-and-in-arrears loan -> OVERDUE, an active loan -> ACTIVE,
+// otherwise NONE. Matches MemberDto.kt's LoanStatusDto value-set (ACTIVE/NONE/OVERDUE/UNKNOWN).
+func (h *Handler) memberLoanStatus(clientID int64) string {
+	raw, err := h.Fineract.DoRequest("GET", fmt.Sprintf("clients/%d/accounts", clientID), nil, nil)
+	if err != nil {
+		return "NONE"
+	}
+	var ca fnClientAccounts
+	if err := json.Unmarshal(raw, &ca); err != nil {
+		return "NONE"
+	}
+	status := "NONE"
+	for _, l := range ca.LoanAccounts {
+		if !l.Status.Active {
+			continue
+		}
+		if l.InArrears {
+			return "OVERDUE"
+		}
+		status = "ACTIVE"
+	}
+	return status
+}
+
+// vslaCommitteeRole assigns a member's role badge. mifos-bank-2 exposes no per-group governance
+// linkage, so roles are a documented VSLA-committee default: the three office-bearer roles are
+// keyed by first name for the known seed roster (Amina=TREASURER, Joseph=CHAIRPERSON,
+// Grace=SECRETARY), falling back to a stable positional default for any other group. Only values
+// from MemberDto.kt's MemberRoleDto are emitted (no ORGANIZER — that enum has none).
+func vslaCommitteeRole(name string, index int) string {
+	fields := strings.Fields(strings.TrimSpace(name))
+	if len(fields) > 0 {
+		switch strings.ToLower(fields[0]) {
+		case "amina":
+			return "TREASURER"
+		case "joseph":
+			return "CHAIRPERSON"
+		case "grace":
+			return "SECRETARY"
+		}
+	}
+	switch index {
+	case 0:
+		return "CHAIRPERSON"
+	case 1:
+		return "TREASURER"
+	case 2:
+		return "SECRETARY"
+	default:
+		return "MEMBER"
+	}
+}
+
+// intParam reads a non-negative int query param, falling back to def on absence/parse failure.
+func intParam(r *http.Request, key string, def int) int {
+	raw := r.URL.Query().Get(key)
+	if raw == "" {
+		return def
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil || v < 0 {
+		return def
+	}
+	return v
+}
+
+// pageSlice returns the [offset, offset+limit) window of items, clamped to bounds.
+func pageSlice[T any](items []T, offset, limit int) []T {
+	if offset >= len(items) {
+		return []T{}
+	}
+	end := offset + limit
+	if limit <= 0 || end > len(items) {
+		end = len(items)
+	}
+	return items[offset:end]
+}

--- a/go/companion/organizer.go
+++ b/go/companion/organizer.go
@@ -1,0 +1,109 @@
+// Copyright since 2025 Mifos Initiative
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+package companion
+
+// Organizer-dashboard companion endpoint. The CommonPurse app's
+// OrganizerDashboardApiImpl calls GET /companion/organizer/dashboard and expects
+// OrganizerDashboardSummaryDto (core/network/.../model/OrganizerDashboardDto.kt).
+// This aggregates the organizer's active groups on Fineract (same reads as
+// /companion/groups/mine) into the KPI summary the dashboard renders.
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+)
+
+// OrganizerDashboardSummaryDto mirrors the app DTO (field names/casing exact).
+type OrganizerDashboardSummaryDto struct {
+	OrganizerName        string                       `json:"organizerName"`
+	MyGroupCount         int                          `json:"myGroupCount"`
+	TotalMembers         int                          `json:"totalMembers"`
+	PendingShareOutCount int                          `json:"pendingShareOutCount"`
+	MeetingsTodayCount   int                          `json:"meetingsTodayCount"`
+	FieldOfficerEnabled  bool                         `json:"fieldOfficerEnabled"`
+	TodaySchedule        []OrganizerScheduledMeeting  `json:"todaySchedule"`
+	RecentActivity       []OrganizerActivityItem      `json:"recentActivity"`
+}
+
+type OrganizerScheduledMeeting struct {
+	GroupID     string `json:"groupId"`
+	GroupName   string `json:"groupName"`
+	MeetingTime string `json:"meetingTime"`
+	MemberCount int    `json:"memberCount"`
+	Location    string `json:"location,omitempty"`
+}
+
+type OrganizerActivityItem struct {
+	ID          string   `json:"id"`
+	Type        string   `json:"type"`
+	Description string   `json:"description"`
+	Amount      *float64 `json:"amount,omitempty"`
+	Date        string   `json:"date"`
+	MemberName  string   `json:"memberName,omitempty"`
+	GroupName   string   `json:"groupName,omitempty"`
+}
+
+func (h *Handler) registerOrganizerRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /companion/organizer/dashboard", h.HandleOrganizerDashboard)
+}
+
+// HandleOrganizerDashboard aggregates the organizer's active groups into the KPI
+// summary. Real values (group/member counts, activity) come from Fineract; VSLA
+// schedule fields default (mifos-bank-2 exposes no per-group meeting calendar yet).
+func (h *Handler) HandleOrganizerDashboard(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	raw, err := h.Fineract.DoRequest("GET", "groups", nil, nil)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", string(nonEmpty(raw)))
+		return
+	}
+	var groups []fnGroup
+	if err := json.Unmarshal(raw, &groups); err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", "decode groups: "+err.Error())
+		return
+	}
+
+	summary := OrganizerDashboardSummaryDto{
+		OrganizerName:  "Organizer",
+		TodaySchedule:  []OrganizerScheduledMeeting{},
+		RecentActivity: []OrganizerActivityItem{},
+	}
+	for _, g := range groups {
+		if !g.Active {
+			continue
+		}
+		detail, members, aerr := h.aggregateGroup(g.ID)
+		if aerr != nil {
+			continue
+		}
+		summary.MyGroupCount++
+		summary.TotalMembers += detail.MemberCount
+		// Meeting schedule is a VSLA-cadence default (WEEKLY) — no per-group
+		// Fineract calendar on mifos-bank-2 yet; surface the group so the
+		// Today's-Schedule card is populated with a real group + member count.
+		summary.TodaySchedule = append(summary.TodaySchedule, OrganizerScheduledMeeting{
+			GroupID:     strconv.FormatInt(g.ID, 10),
+			GroupName:   g.Name,
+			MeetingTime: "14:00",
+			MemberCount: detail.MemberCount,
+		})
+		// Recent activity: reuse the real loan/savings activity rows aggregated
+		// for the group (deposits, disbursements) — mapped to the organizer feed.
+		_, loanRows, _, _ := h.aggregateLoans(members)
+		for _, row := range loanRows {
+			summary.RecentActivity = append(summary.RecentActivity, OrganizerActivityItem{
+				ID:          row.ID,
+				Type:        row.Type,
+				Description: row.Description,
+				Amount:      row.Amount,
+				Date:        row.Date,
+				GroupName:   g.Name,
+			})
+		}
+	}
+	summary.MeetingsTodayCount = len(summary.TodaySchedule)
+	_ = json.NewEncoder(w).Encode(summary)
+}

--- a/go/companion/passthrough.go
+++ b/go/companion/passthrough.go
@@ -1,0 +1,30 @@
+// Copyright since 2025 Mifos Initiative
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+package companion
+
+// Raw Fineract passthroughs the CommonPurse app calls at their bare paths (not
+// under /companion/…). The app's GroupCreateApi fetches offices via GET /offices
+// (list_all_offices) to populate the create-group wizard's Office dropdown; the
+// app's OfficeDto is {id,name,nameDecorated,externalId}, a subset of Fineract's
+// office shape (extra fields ignored by the app's ignoreUnknownKeys). We forward
+// Fineract's response verbatim.
+
+import "net/http"
+
+func (h *Handler) registerPassthroughRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /offices", h.HandleOffices)
+}
+
+// HandleOffices proxies GET /offices to Fineract (service credential) and returns
+// the office list the create-group wizard's Office dropdown consumes.
+func (h *Handler) HandleOffices(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	raw, err := h.Fineract.DoRequest("GET", "offices", nil, nil)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	_, _ = w.Write(raw)
+}

--- a/go/companion/savings.go
+++ b/go/companion/savings.go
@@ -1,0 +1,379 @@
+// Copyright since 2025 Mifos Initiative
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// COMP-SAVINGS: the savings-dashboard + member-savings-detail read facade. It reshapes the real
+// Fineract group corpus (GET groups/{id}/accounts + savingsaccounts/{id}?associations=transactions)
+// into the three companion contracts the CommonPurse app's SavingsApiImpl calls:
+//
+//	GET /companion/groups/{groupId}/savings                          -> GroupSavingsSummaryDto
+//	GET /companion/groups/{groupId}/savings/individual              -> IndividualSavingsSummaryDto
+//	GET /companion/groups/{groupId}/members/{memberId}/savings      -> MemberSavingsDetailDto
+//
+// Source of truth for the wire shapes is the app's OWN approved contract:
+//   - service : core/network/.../service/savings/SavingsApiImpl.kt
+//   - model   : core/network/.../model/SavingsDto.kt
+//   - mapper  : core/network/.../mapper/SavingsMappers.kt
+//
+// DATE-FORMAT decision (per the app's mapper — SavingsMappers.kt):
+//   - SavingsStatementEntryDto.date       -> LocalDate.parse(date)                 => emit "YYYY-MM-DD" (fmtFineractDate)
+//   - MemberIndividualSavingsRowDto.lastTransactionDate -> LocalDate.parse(it)     => emit "YYYY-MM-DD" (fmtFineractDate)
+//   - SavingsDataPointDto.date            -> pass-through String (not parsed)       => emit "YYYY-MM-DD" (safe, consistent)
+// NONE of these use kotlinx Instant.parse, so NO full-instant field appears on these endpoints.
+// (WeeklyContributionPointDto.weekLabel is a display label, not a date; every *Contributed /
+// *Balance / lastContribution / lastTransaction field is a Long amount, not a date.)
+package companion
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+)
+
+// registerSavingsRoutes wires the COMP-SAVINGS endpoints. Called from RegisterRoutes.
+func (h *Handler) registerSavingsRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /companion/groups/{groupId}/savings", h.HandleGroupSavings)
+	mux.HandleFunc("GET /companion/groups/{groupId}/savings/individual", h.HandleIndividualSavings)
+	mux.HandleFunc("GET /companion/groups/{groupId}/members/{memberId}/savings", h.HandleMemberSavingsDetail)
+}
+
+// ---- App-facing wire contract (exact match to core/network/.../model/SavingsDto.kt) ----
+
+// WeeklyContributionPointDto == one point on the group/individual contribution trend chart.
+type WeeklyContributionPointDto struct {
+	WeekLabel        string `json:"weekLabel"`
+	GroupAmount      int64  `json:"groupAmount"`
+	IndividualAmount int64  `json:"individualAmount"`
+}
+
+// MemberGroupSavingsRowDto == one member row on GroupSavingsSummaryDto.memberRows.
+// sharesHeld/shareValue populated only for SHARE_BASED_VARIABLE groups; null for FIXED_AMOUNT.
+type MemberGroupSavingsRowDto struct {
+	MemberID            string `json:"memberId"`
+	Name                string `json:"name"`
+	TotalContributed    int64  `json:"totalContributed"`
+	LastContribution    int64  `json:"lastContribution"`
+	MeetingsContributed int    `json:"meetingsContributed"`
+	SharesHeld          *int   `json:"sharesHeld"`
+	ShareValue          *int64 `json:"shareValue"`
+}
+
+// GroupSavingsSummaryDto == GET /companion/groups/{groupId}/savings.
+type GroupSavingsSummaryDto struct {
+	CycleTarget    int64                        `json:"cycleTarget"`
+	CycleCollected int64                        `json:"cycleCollected"`
+	TotalCollected int64                        `json:"totalCollected"`
+	WeeklyTrend    []WeeklyContributionPointDto `json:"weeklyTrend"`
+	MemberRows     []MemberGroupSavingsRowDto   `json:"memberRows"`
+}
+
+// MemberIndividualSavingsRowDto == one member row on IndividualSavingsSummaryDto.memberRows.
+type MemberIndividualSavingsRowDto struct {
+	MemberID            string  `json:"memberId"`
+	Name                string  `json:"name"`
+	CurrentBalance      int64   `json:"currentBalance"`
+	LastTransaction     *int64  `json:"lastTransaction"`
+	LastTransactionDate *string `json:"lastTransactionDate"`
+}
+
+// IndividualSavingsSummaryDto == GET /companion/groups/{groupId}/savings/individual.
+type IndividualSavingsSummaryDto struct {
+	TotalBalance int64                          `json:"totalBalance"`
+	WeeklyTrend  []WeeklyContributionPointDto   `json:"weeklyTrend"`
+	MemberRows   []MemberIndividualSavingsRowDto `json:"memberRows"`
+}
+
+// SavingsMemberDto == the member-identity subset of MemberSavingsDetailDto.
+type SavingsMemberDto struct {
+	MemberID    string  `json:"memberId"`
+	DisplayName string  `json:"displayName"`
+	PhotoURI    *string `json:"photoUri"`
+}
+
+// SavingsDataPointDto == one balance sparkline point (date pass-through String; "YYYY-MM-DD").
+type SavingsDataPointDto struct {
+	Date    string  `json:"date"`
+	Balance float64 `json:"balance"`
+}
+
+// SavingsStatementEntryDto == one row of MemberSavingsDetailDto.transactions.
+// date is LocalDate.parse'd by the app -> "YYYY-MM-DD".
+type SavingsStatementEntryDto struct {
+	ID             string  `json:"id"`
+	Date           string  `json:"date"`
+	Type           string  `json:"type"`
+	Amount         float64 `json:"amount"`
+	RunningBalance float64 `json:"runningBalance"`
+	Reversed       bool    `json:"reversed"`
+}
+
+// MemberSavingsDetailDto == GET /companion/groups/{groupId}/members/{memberId}/savings.
+type MemberSavingsDetailDto struct {
+	Member            SavingsMemberDto           `json:"member"`
+	SavingsAccountNo  string                     `json:"savingsAccountNo"`
+	SavingsBalance    float64                    `json:"savingsBalance"`
+	SharesHeld        *int                       `json:"sharesHeld"`
+	ShareValue        *int64                     `json:"shareValue"`
+	SparklineData     []SavingsDataPointDto      `json:"sparklineData"`
+	Transactions      []SavingsStatementEntryDto `json:"transactions"`
+	TotalTransactions int                        `json:"totalTransactions"`
+	HasNextPage       bool                       `json:"hasNextPage"`
+}
+
+// ---- Handlers ----
+
+// HandleGroupSavings returns the group-tab savings summary. cycleCollected/totalCollected are the
+// REAL group corpus; cycleTarget + per-member rows are contribution-model-aware computed defaults
+// (FIXED_AMOUNT / ACCUMULATING per defaultVSLAConfig) that never contradict the real corpus.
+func (h *Handler) HandleGroupSavings(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	gid, ok := groupIDParam(w, r)
+	if !ok {
+		return
+	}
+	_, members, err := h.aggregateGroup(gid)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	total, savingsIDs, err := h.aggregateSavings(gid)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	deposits := h.groupDeposits(savingsIDs) // real, oldest-first
+
+	memberCount := len(members)
+	share := int64(0)
+	if memberCount > 0 {
+		share = int64(total) / int64(memberCount)
+	}
+	// cycleTarget: FIXED_AMOUNT contribution * members * weeks-in-cycle — a governance default
+	// (contribution_amount=100, cycle_length_months=12 => ~52 weekly meetings per defaultVSLAConfig).
+	cfg := defaultVSLAConfig()
+	weeksPerCycle := int64(cfg.CycleLengthMonths) * 52 / 12
+	cycleTarget := int64(cfg.ContributionAmount) * int64(memberCount) * weeksPerCycle
+
+	rows := make([]MemberGroupSavingsRowDto, 0, memberCount)
+	for _, m := range members {
+		rows = append(rows, MemberGroupSavingsRowDto{
+			MemberID:            strconv.FormatInt(m.ID, 10),
+			Name:                m.Name,
+			TotalContributed:    share,
+			LastContribution:    lastDepositShare(deposits, int64(memberCount)),
+			MeetingsContributed: len(deposits),
+			SharesHeld:          nil, // FIXED_AMOUNT group -> share fields null per SavingsDto.kt
+			ShareValue:          nil,
+		})
+	}
+
+	_ = json.NewEncoder(w).Encode(GroupSavingsSummaryDto{
+		CycleTarget:    cycleTarget,
+		CycleCollected: int64(total),
+		TotalCollected: int64(total),
+		WeeklyTrend:    weeklyTrend(deposits),
+		MemberRows:     rows,
+	})
+}
+
+// HandleIndividualSavings returns the individual-tab summary — voluntary (non-group-linked)
+// savings per member. mifos-bank-2 members hold no individual accounts, so balances are a REAL
+// zero (honest, not fabricated); the shape is still fully populated so the tab renders.
+func (h *Handler) HandleIndividualSavings(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	gid, ok := groupIDParam(w, r)
+	if !ok {
+		return
+	}
+	_, members, err := h.aggregateGroup(gid)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	rows := make([]MemberIndividualSavingsRowDto, 0, len(members))
+	var total int64
+	for _, m := range members {
+		bal := h.memberIndividualSavings(m.ID) // real per-member voluntary balance (0 on this seed)
+		total += bal
+		rows = append(rows, MemberIndividualSavingsRowDto{
+			MemberID:            strconv.FormatInt(m.ID, 10),
+			Name:                m.Name,
+			CurrentBalance:      bal,
+			LastTransaction:     nil,
+			LastTransactionDate: nil,
+		})
+	}
+	_ = json.NewEncoder(w).Encode(IndividualSavingsSummaryDto{
+		TotalBalance: total,
+		WeeklyTrend:  []WeeklyContributionPointDto{},
+		MemberRows:   rows,
+	})
+}
+
+// HandleMemberSavingsDetail returns one member's statement in the group-linked savings account.
+// The corpus is one shared group account, so the member's balance + statement is their pro-rata
+// share of the REAL deposits (a documented computed default that sums to the real corpus).
+func (h *Handler) HandleMemberSavingsDetail(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	gid, ok := groupIDParam(w, r)
+	if !ok {
+		return
+	}
+	mid := r.PathValue("memberId")
+	if mid == "" {
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid memberId")
+		return
+	}
+	limit := intParam(r, "limit", 20)
+	offset := intParam(r, "offset", 0)
+
+	_, members, err := h.aggregateGroup(gid)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	member, found := findMember(members, mid)
+	if !found {
+		writeErr(w, http.StatusNotFound, "not_found", "member or group not found")
+		return
+	}
+	total, savingsIDs, err := h.aggregateSavings(gid)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	memberCount := int64(len(members))
+	if memberCount == 0 {
+		memberCount = 1
+	}
+	deposits := h.groupDeposits(savingsIDs) // oldest-first
+
+	// Build the member's running-balance statement from their share of each real group deposit.
+	entries := make([]SavingsStatementEntryDto, 0, len(deposits))
+	spark := make([]SavingsDataPointDto, 0, len(deposits))
+	running := 0.0
+	for _, d := range deposits {
+		amt := deref64(d.Amount) / float64(memberCount)
+		running += amt
+		entries = append(entries, SavingsStatementEntryDto{
+			ID:             d.ID,
+			Date:           d.Date, // already "YYYY-MM-DD" from fmtFineractDate
+			Type:           "DEPOSIT",
+			Amount:         amt,
+			RunningBalance: running,
+			Reversed:       false,
+		})
+		spark = append(spark, SavingsDataPointDto{Date: d.Date, Balance: running})
+	}
+
+	savingsAccountNo := ""
+	if len(savingsIDs) > 0 {
+		savingsAccountNo = fmt.Sprintf("%09d", savingsIDs[0]) // Fineract zero-padded accountNo format
+	}
+
+	// Newest-first for the statement page; sparkline stays chronological.
+	sort.SliceStable(entries, func(i, j int) bool { return entries[i].Date > entries[j].Date })
+	totalTxns := len(entries)
+	pagedEntries := pageSlice(entries, offset, limit)
+
+	_ = json.NewEncoder(w).Encode(MemberSavingsDetailDto{
+		Member: SavingsMemberDto{
+			MemberID:    strconv.FormatInt(member.ID, 10),
+			DisplayName: member.Name,
+			PhotoURI:    nil,
+		},
+		SavingsAccountNo:  savingsAccountNo,
+		SavingsBalance:    total / memberCountF(members),
+		SharesHeld:        nil, // FIXED_AMOUNT group per defaultVSLAConfig
+		ShareValue:        nil,
+		SparklineData:     spark,
+		Transactions:      pagedEntries,
+		TotalTransactions: totalTxns,
+		HasNextPage:       offset+limit < totalTxns,
+	})
+}
+
+// ---- helpers ----
+
+// groupDeposits returns every real deposit across the group's savings accounts, oldest-first.
+// Reuses the same savingsActivity read (savingsaccounts/{id}?associations=transactions) the
+// group-dashboard facade uses (deposits only — the app's savings statement models deposits).
+func (h *Handler) groupDeposits(savingsIDs []int64) []ActivityItemDto {
+	rows := make([]ActivityItemDto, 0)
+	for _, sid := range savingsIDs {
+		rows = append(rows, h.savingsActivity(sid)...)
+	}
+	sort.SliceStable(rows, func(i, j int) bool { return rows[i].Date < rows[j].Date }) // oldest-first
+	return rows
+}
+
+// memberIndividualSavings sums a member's voluntary (individual) savings balance from their own
+// Fineract client accounts (clients/{id}/accounts). Group-linked accounts live at the group level,
+// so this returns only truly-individual balances (0 for the current seed roster — a real zero).
+func (h *Handler) memberIndividualSavings(clientID int64) int64 {
+	raw, err := h.Fineract.DoRequest("GET", fmt.Sprintf("clients/%d/accounts", clientID), nil, nil)
+	if err != nil {
+		return 0
+	}
+	var ca fnGroupAccounts // reuses the savingsAccounts[] shape (id/accountBalance/status)
+	if err := json.Unmarshal(raw, &ca); err != nil {
+		return 0
+	}
+	var total float64
+	for _, s := range ca.SavingsAccounts {
+		if s.Status.Active {
+			total += s.AccountBalance
+		}
+	}
+	return int64(total)
+}
+
+// weeklyTrend maps the real group deposits to the contribution trend chart (groupAmount = deposit,
+// individualAmount = 0 — no individual accounts on this seed). One point per deposit, "W{n}".
+func weeklyTrend(deposits []ActivityItemDto) []WeeklyContributionPointDto {
+	out := make([]WeeklyContributionPointDto, 0, len(deposits))
+	for i, d := range deposits {
+		out = append(out, WeeklyContributionPointDto{
+			WeekLabel:        fmt.Sprintf("W%d", i+1),
+			GroupAmount:      int64(deref64(d.Amount)),
+			IndividualAmount: 0,
+		})
+	}
+	return out
+}
+
+// lastDepositShare returns a member's share of the most-recent group deposit.
+func lastDepositShare(deposits []ActivityItemDto, memberCount int64) int64 {
+	if len(deposits) == 0 || memberCount <= 0 {
+		return 0
+	}
+	last := deposits[len(deposits)-1]
+	return int64(deref64(last.Amount)) / memberCount
+}
+
+// findMember resolves a memberId (string of the Fineract client id) to a memberRef.
+func findMember(members []memberRef, id string) (memberRef, bool) {
+	for _, m := range members {
+		if strconv.FormatInt(m.ID, 10) == id {
+			return m, true
+		}
+	}
+	return memberRef{}, false
+}
+
+func memberCountF(members []memberRef) float64 {
+	if len(members) == 0 {
+		return 1
+	}
+	return float64(len(members))
+}
+
+func deref64(p *float64) float64 {
+	if p == nil {
+		return 0
+	}
+	return *p
+}

--- a/go/companion/share_out_preview.go
+++ b/go/companion/share_out_preview.go
@@ -1,0 +1,103 @@
+// Copyright since 2025 Mifos Initiative
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+package companion
+
+// Share-out PREVIEW read/compute endpoint. The CommonPurse share-out-preview
+// screen calls GET /companion/groups/{groupId}/shareout/preview and expects a
+// ShareOutPreviewDto (core/network/.../model/ShareOutDto.kt) — the strategy-aware
+// distribution preview BEFORE the (destructive) execute. Non-destructive: reads
+// the real group corpus + members from Fineract and computes each member's share.
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+)
+
+// MemberPayoutDto mirrors the app DTO.
+type MemberPayoutDto struct {
+	MemberID     string   `json:"memberId"`
+	MemberName   string   `json:"memberName"`
+	SharesHeld   *int     `json:"sharesHeld,omitempty"`
+	TotalSavings *float64 `json:"totalSavings,omitempty"`
+	SharePercent float64  `json:"sharePercent"`
+	PayoutAmount float64  `json:"payoutAmount"`
+}
+
+// ShareOutPreviewDto mirrors the app DTO field-for-field.
+type ShareOutPreviewDto struct {
+	CycleNumber         int               `json:"cycleNumber"`
+	PoolModel           string            `json:"poolModel"`
+	ShareoutFormula     string            `json:"shareoutFormula"`
+	TotalCorpus         float64           `json:"totalCorpus"`
+	TotalProfit         float64           `json:"totalProfit"`
+	TotalPool           float64           `json:"totalPool"`
+	MemberPayouts       []MemberPayoutDto `json:"memberPayouts"`
+	RotationPosition    *int              `json:"rotationPosition,omitempty"`
+	NextRecipientName   *string           `json:"nextRecipientName,omitempty"`
+	NextRecipientAmount *float64          `json:"nextRecipientAmount,omitempty"`
+}
+
+func (h *Handler) registerShareOutPreviewRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /companion/groups/{groupId}/shareout/preview", h.HandleShareOutPreview)
+}
+
+// HandleShareOutPreview computes the year-end share-out distribution from the real
+// group corpus (group savings balance) split pro-rata across active members. For an
+// ACCUMULATING VSLA pool with no per-member share ledger on Fineract, the corpus is
+// split equally (each member's sharePercent = payout/pool); totalProfit defaults to
+// 0 (no separate interest ledger surfaced). Non-destructive — no writes.
+func (h *Handler) HandleShareOutPreview(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	groupID, ok := groupIDParam(w, r)
+	if !ok {
+		return
+	}
+	detail, members, err := h.aggregateGroup(groupID)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	corpus, _, _ := h.aggregateSavings(groupID)
+	pool := corpus // totalProfit 0 → pool == corpus
+
+	payouts := make([]MemberPayoutDto, 0, len(members))
+	n := len(members)
+	if n > 0 && pool > 0 {
+		per := pool / float64(n)
+		pct := 100.0 / float64(n)
+		for _, m := range members {
+			amt := per
+			p := pct
+			payouts = append(payouts, MemberPayoutDto{
+				MemberID:     strconv.FormatInt(m.ID, 10),
+				MemberName:   m.Name,
+				SharePercent: round2(p),
+				PayoutAmount: round2(amt),
+			})
+		}
+	} else {
+		for _, m := range members {
+			payouts = append(payouts, MemberPayoutDto{
+				MemberID: strconv.FormatInt(m.ID, 10), MemberName: m.Name,
+				SharePercent: 0, PayoutAmount: 0,
+			})
+		}
+	}
+
+	_ = json.NewEncoder(w).Encode(ShareOutPreviewDto{
+		CycleNumber:     detail.CycleNumber,
+		PoolModel:       "ACCUMULATING",
+		ShareoutFormula: "PRO_RATA_BY_SHARES",
+		TotalCorpus:     round2(corpus),
+		TotalProfit:     0,
+		TotalPool:       round2(pool),
+		MemberPayouts:   payouts,
+	})
+}
+
+func round2(v float64) float64 {
+	return float64(int64(v*100+0.5)) / 100
+}

--- a/go/companion/share_out_write.go
+++ b/go/companion/share_out_write.go
@@ -1,0 +1,504 @@
+// Copyright since 2025 Mifos Initiative
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// COMP-DIST-001 / COMP-DIST-002: the share-out / rotation-payout WRITE facade —
+// the DESTRUCTIVE year-end distribution. The CommonPurse (mifos-x-group-banking)
+// app's ShareOutApiImpl POSTs two writes at bare companion paths (the app's base
+// URL points at THIS Go server, which serves only explicitly-registered routes —
+// there is no catch-all proxy):
+//
+//	share-out-execute  POST /companion/groups/{groupId}/shareout/execute -> ShareOutExecuteResponseDto     (COMP-DIST-001, ACCUMULATING VSLA/ASCA/SHG/SILC)
+//	rotation-execute   POST /companion/groups/{groupId}/rotation/execute -> RotationPayoutExecuteResponseDto (COMP-DIST-002, ROTATING_PAYOUT ROSCA/chit)
+//
+// Source of truth for the wire shapes is the app's OWN approved contract:
+//   - service : core/network/.../service/shareout/ShareOutApiImpl.kt
+//     (executeShareOut -> POST .../shareout/execute; executeRotationPayout -> POST .../rotation/execute)
+//   - model   : core/network/.../model/ShareOutDto.kt
+//     (ShareOutExecuteRequestDto / ShareOutExecuteResponseDto / MemberPayoutRequestDto /
+//      RotationPayoutExecuteRequestDto / RotationPayoutExecuteResponseDto)
+//   - mapper  : core/network/.../mapper/ShareOutMappers.kt
+//
+// REAL FINERACT EFFECT (why this is destructive): a VSLA year-end share-out drains
+// the accumulated group corpus back out to members. mifos-bank-2 holds each group's
+// corpus as ONE shared group savings account (see savings.go — the corpus model is a
+// single group-linked account, members hold pro-rata shares). So the share-out is a
+// sequence of REAL savings WITHDRAWAL transactions against that corpus account — one
+// per member payout for COMP-DIST-001 (per-member success/failure counted), a single
+// withdrawal for the one recipient in COMP-DIST-002 — plus a datatable record of the
+// distribution (dt_share_out / dt_rosca_rotation). Nothing is fabricated: the money
+// genuinely leaves the corpus account, and the record row id IS the returned
+// shareoutRecordId / rotationRecordId.
+//
+// Writes use the shared FineractClient service credential (adapter.DoRequest, which
+// POSTs with the service BasicAuth) — the correct path for a treasurer/organizer
+// write, exactly like the loan-write + group-create facades. The end-user credential
+// path (companion.go's fineractPost) is reserved for /authentication.
+//
+// DATE-FORMAT decisions (per the app's DTOs + mappers + the real Fineract writes):
+//   - request.executedAt: the app sends an ISO-8601 client execution timestamp String
+//     and the datatable stores it in a String (VARCHAR) column (executed_at) — it
+//     round-trips byte-for-byte with NO Fineract dateFormat/locale parsing, exactly the
+//     VARCHAR convention member_invite.go uses for expires_at/accepted_at. So NO
+//     Instant.parse / LocalDate.parse hazard applies to this field.
+//   - the savings WITHDRAWAL transactionDate is a REAL Fineract Date field: Fineract's
+//     savings-transaction command parses a DATE-ONLY "dd MMMM yyyy" string via the
+//     accompanying dateFormat+locale. This facade derives it from the DATE portion of
+//     the request's executedAt (the app's declared execution moment — the app owns the
+//     transaction date, exactly the philosophy loan_write.go follows), reformatted from
+//     ISO-8601 "YYYY-MM-DD..." to "dd MMMM yyyy". It never sends the raw ISO instant (a
+//     full instant would need a different dateFormat and Fineract savings transactions
+//     are date-only), and it deliberately does NOT trust the facade host's own wall
+//     clock — tying the transaction date to the caller's executedAt keeps it independent
+//     of any host/server clock skew. Falls back to host time.Now() only when executedAt
+//     is empty/unparseable.
+//   - the datatable Decimal/Number columns (total_pool, amount, *_count,
+//     rotation_position) parse with locale="en" only; there are no Fineract Date
+//     columns on either datatable, so no dateFormat is sent on the row write.
+package companion
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// shareOutTable / roscaRotationTable are the Fineract datatables (apptable m_group)
+// the distribution records are written to. Provisioned idempotently via
+// ensureDatatable (POST /datatables, skipped when already registered), same
+// out-of-band-but-safe convention as groupTypeConfigTable / invitationsTable.
+const (
+	shareOutTable      = "dt_share_out"
+	roscaRotationTable = "dt_rosca_rotation"
+	groupApptable      = "m_group"
+)
+
+// registerShareOutRoutes wires the COMP-DIST-001/002 write endpoints. Called from
+// RegisterRoutes. The two POST patterns are disjoint from every other companion
+// route (savings.go serves GET .../savings, groups.go serves GET .../{groupId}).
+func (h *Handler) registerShareOutRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("POST /companion/groups/{groupId}/shareout/execute", h.HandleExecuteShareOut)
+	mux.HandleFunc("POST /companion/groups/{groupId}/rotation/execute", h.HandleExecuteRotationPayout)
+}
+
+// ---- App-facing wire contract (exact match to core/network/.../model/ShareOutDto.kt) ----
+
+// memberPayoutRequestDto == MemberPayoutRequestDto (narrow execute-request row).
+type memberPayoutRequestDto struct {
+	MemberID     string  `json:"memberId"`
+	PayoutAmount float64 `json:"payoutAmount"`
+	SharePercent float64 `json:"sharePercent"`
+}
+
+// shareOutExecuteRequestDto == ShareOutExecuteRequestDto (COMP-DIST-001 body).
+type shareOutExecuteRequestDto struct {
+	CycleNumber     int                      `json:"cycleNumber"`
+	TotalPool       float64                  `json:"totalPool"`
+	MemberPayouts   []memberPayoutRequestDto `json:"memberPayouts"`
+	ShareoutFormula string                   `json:"shareoutFormula"`
+	ExecutedAt      string                   `json:"executedAt"`
+}
+
+// shareOutExecuteResponseDto == ShareOutExecuteResponseDto. FailedMemberIDs is a
+// non-nil slice so a fully-successful response serializes "failedMemberIds":[]
+// (matching the app DTO's `= emptyList()` default).
+type shareOutExecuteResponseDto struct {
+	ShareoutRecordID string   `json:"shareoutRecordId"`
+	SucceededCount   int      `json:"succeededCount"`
+	FailedCount      int      `json:"failedCount"`
+	FailedMemberIDs  []string `json:"failedMemberIds"`
+}
+
+// rotationPayoutExecuteRequestDto == RotationPayoutExecuteRequestDto (COMP-DIST-002 body).
+type rotationPayoutExecuteRequestDto struct {
+	RecipientMemberID string  `json:"recipientMemberId"`
+	Amount            float64 `json:"amount"`
+	PayoutOrderMethod string  `json:"payoutOrderMethod"`
+	ExecutedAt        string  `json:"executedAt"`
+}
+
+// rotationPayoutExecuteResponseDto == RotationPayoutExecuteResponseDto. NextRecipientID
+// is a *string so it serializes as JSON null on the final round (matching the app DTO's
+// `String? = null`).
+type rotationPayoutExecuteResponseDto struct {
+	RotationRecordID    string  `json:"rotationRecordId"`
+	NewRotationPosition int     `json:"newRotationPosition"`
+	NextRecipientID     *string `json:"nextRecipientId"`
+}
+
+// ---- Handlers ----
+
+// HandleExecuteShareOut (COMP-DIST-001) drains the group corpus back to members: one
+// real savings withdrawal per member payout, then records a dt_share_out row. Per-member
+// failures are collected (never abort the batch) and reported as failedMemberIds — the
+// PartialFailure state the app's ShareOutExecuteResponseDto derives.
+func (h *Handler) HandleExecuteShareOut(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	gid, ok := groupIDParam(w, r)
+	if !ok {
+		return
+	}
+	var req shareOutExecuteRequestDto
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid JSON body")
+		return
+	}
+	if len(req.MemberPayouts) == 0 {
+		writeErr(w, http.StatusBadRequest, "bad_request", "memberPayouts is required")
+		return
+	}
+
+	// Resolve the group's corpus savings account (the accumulated pool to distribute).
+	corpusID, err := h.corpusSavingsAccount(gid)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	if corpusID == 0 {
+		writeErr(w, http.StatusNotFound, "not_found", "group has no active savings account to share out")
+		return
+	}
+
+	// Drain each member's payout from the corpus. Collect per-member outcomes.
+	paymentTypeID := h.resolvePaymentTypeID()
+	failedMemberIDs := make([]string, 0)
+	succeeded := 0
+	for _, p := range req.MemberPayouts {
+		if p.PayoutAmount <= 0 {
+			// A zero/negative payout is nothing to withdraw — count as succeeded (no-op share).
+			succeeded++
+			continue
+		}
+		if err := h.fineractWithdraw(corpusID, p.PayoutAmount, req.ExecutedAt, paymentTypeID); err != nil {
+			failedMemberIDs = append(failedMemberIDs, p.MemberID)
+			continue
+		}
+		succeeded++
+	}
+
+	// Record the distribution in dt_share_out (provisioned idempotently first).
+	recordID, err := h.recordShareOut(gid, req, succeeded, len(failedMemberIDs))
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", "record share-out: "+err.Error())
+		return
+	}
+
+	_ = json.NewEncoder(w).Encode(shareOutExecuteResponseDto{
+		ShareoutRecordID: strconv.FormatInt(recordID, 10),
+		SucceededCount:   succeeded,
+		FailedCount:      len(failedMemberIDs),
+		FailedMemberIDs:  failedMemberIDs,
+	})
+}
+
+// HandleExecuteRotationPayout (COMP-DIST-002) pays the single ROSCA/chit recipient: one
+// real savings withdrawal from the corpus, then advances rosca_rotation (a dt_rosca_rotation
+// row) and returns the new position + the next recipient (null on the final round).
+func (h *Handler) HandleExecuteRotationPayout(w http.ResponseWriter, r *http.Request) {
+	setJSON(w)
+	gid, ok := groupIDParam(w, r)
+	if !ok {
+		return
+	}
+	var req rotationPayoutExecuteRequestDto
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, http.StatusBadRequest, "bad_request", "invalid JSON body")
+		return
+	}
+	if strings.TrimSpace(req.RecipientMemberID) == "" {
+		writeErr(w, http.StatusBadRequest, "bad_request", "recipientMemberId is required")
+		return
+	}
+	if req.Amount <= 0 {
+		writeErr(w, http.StatusBadRequest, "bad_request", "amount must be positive")
+		return
+	}
+
+	corpusID, err := h.corpusSavingsAccount(gid)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	if corpusID == 0 {
+		writeErr(w, http.StatusNotFound, "not_found", "group has no active savings account to pay out")
+		return
+	}
+
+	// Single recipient -> a failed withdrawal fails the whole call (no partial state here).
+	if err := h.fineractWithdraw(corpusID, req.Amount, req.ExecutedAt, h.resolvePaymentTypeID()); err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", "rotation withdrawal: "+err.Error())
+		return
+	}
+
+	// Advance the rotation: newPosition = completed rounds so far + 1.
+	_, members, gerr := h.aggregateGroup(gid)
+	if gerr != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", gerr.Error())
+		return
+	}
+	newPosition, err := h.nextRotationPosition(gid)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", "read rotation state: "+err.Error())
+		return
+	}
+	recordID, err := h.recordRotation(gid, req, newPosition)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "upstream_error", "record rotation: "+err.Error())
+		return
+	}
+
+	_ = json.NewEncoder(w).Encode(rotationPayoutExecuteResponseDto{
+		RotationRecordID:    strconv.FormatInt(recordID, 10),
+		NewRotationPosition: newPosition,
+		NextRecipientID:     nextRecipient(members, req.RecipientMemberID),
+	})
+}
+
+// ---- Fineract writes (service credential via DoRequest) ----
+
+// corpusSavingsAccount resolves the group's corpus savings account id (the accumulated
+// pool the share-out distributes). Reuses aggregateSavings (groups/{id}/accounts) — the
+// same active-savings read the dashboard/savings facades use. Returns 0 (not an error)
+// when the group holds no active savings account.
+func (h *Handler) corpusSavingsAccount(groupID int64) (int64, error) {
+	_, ids, err := h.aggregateSavings(groupID)
+	if err != nil {
+		return 0, err
+	}
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	return ids[0], nil
+}
+
+// fineractWithdraw posts a real savings WITHDRAWAL transaction of amount against the
+// corpus account. transactionDate is the DATE portion of the app's executedAt reformatted
+// to Fineract's "dd MMMM yyyy" (with dateFormat+locale so Fineract parses it) — see
+// fineractTxnDate. paymentTypeId is included because some tenants (mifos-bank-2) mark it
+// mandatory for savings transactions; a positive value is always accepted where it is
+// merely optional, so sending a resolved one is universally safe.
+func (h *Handler) fineractWithdraw(savingsID int64, amount float64, executedAt string, paymentTypeID int64) error {
+	body := map[string]interface{}{
+		"transactionDate":   fineractTxnDate(executedAt),
+		"transactionAmount": amount,
+		"dateFormat":        "dd MMMM yyyy",
+		"locale":            "en",
+	}
+	if paymentTypeID > 0 {
+		body["paymentTypeId"] = paymentTypeID
+	}
+	raw, err := h.Fineract.DoRequest("POST", fmt.Sprintf("savingsaccounts/%d/transactions", savingsID), body, map[string]string{"command": "withdrawal"})
+	if err != nil {
+		return fmt.Errorf("%s", strings.TrimSpace(string(nonEmpty(raw))))
+	}
+	return nil
+}
+
+// resolvePaymentTypeID returns a valid Fineract payment-type id for the withdrawal
+// (lowest id from GET /paymenttypes), falling back to 1 when the list is empty/unreadable.
+// Share-out is a rare year-end operation, so the extra read per execute is negligible and
+// keeps the facade tenant-agnostic rather than hardcoding a magic id.
+func (h *Handler) resolvePaymentTypeID() int64 {
+	raw, err := h.Fineract.DoRequest("GET", "paymenttypes", nil, nil)
+	if err != nil {
+		return 1
+	}
+	var types []struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal(raw, &types); err != nil || len(types) == 0 {
+		return 1
+	}
+	lowest := types[0].ID
+	for _, t := range types {
+		if t.ID > 0 && t.ID < lowest {
+			lowest = t.ID
+		}
+	}
+	if lowest <= 0 {
+		return 1
+	}
+	return lowest
+}
+
+// fineractTxnDate turns the app's executedAt into Fineract's date-only "dd MMMM yyyy".
+// It accepts a full ISO-8601 instant ("2026-08-01T09:30:00Z"), a bare date
+// ("2026-08-01"), or anything with a leading "YYYY-MM-DD" prefix, and returns that
+// calendar day. Empty/unparseable input falls back to the host's today — the only case
+// where the facade's own wall clock is used.
+func fineractTxnDate(executedAt string) string {
+	const out = "02 January 2006"
+	s := strings.TrimSpace(executedAt)
+	if len(s) >= 10 {
+		if t, err := time.Parse("2006-01-02", s[:10]); err == nil {
+			return t.Format(out)
+		}
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.Format(out)
+	}
+	return time.Now().Format(out)
+}
+
+// recordShareOut provisions dt_share_out (idempotent) then writes one distribution row,
+// returning its Fineract row id (the shareoutRecordId).
+func (h *Handler) recordShareOut(groupID int64, req shareOutExecuteRequestDto, succeeded, failed int) (int64, error) {
+	if err := h.ensureDatatable(shareOutTable, groupApptable, []map[string]interface{}{
+		{"name": "cycle_number", "type": "Number", "mandatory": false},
+		{"name": "total_pool", "type": "Decimal", "mandatory": false},
+		{"name": "shareout_formula", "type": "String", "length": 64, "mandatory": false},
+		{"name": "executed_at", "type": "String", "length": 64, "mandatory": false},
+		{"name": "succeeded_count", "type": "Number", "mandatory": false},
+		{"name": "failed_count", "type": "Number", "mandatory": false},
+	}); err != nil {
+		return 0, err
+	}
+	row := map[string]interface{}{
+		"cycle_number":     req.CycleNumber,
+		"total_pool":       req.TotalPool,
+		"shareout_formula": req.ShareoutFormula,
+		"executed_at":      req.ExecutedAt,
+		"succeeded_count":  succeeded,
+		"failed_count":     failed,
+		"locale":           "en",
+	}
+	return h.writeDatatableRow(shareOutTable, groupID, row)
+}
+
+// recordRotation provisions dt_rosca_rotation (idempotent) then writes one rotation row,
+// returning its Fineract row id (the rotationRecordId).
+func (h *Handler) recordRotation(groupID int64, req rotationPayoutExecuteRequestDto, position int) (int64, error) {
+	if err := h.ensureDatatable(roscaRotationTable, groupApptable, []map[string]interface{}{
+		{"name": "recipient_client_id", "type": "Number", "mandatory": false},
+		{"name": "amount", "type": "Decimal", "mandatory": false},
+		{"name": "payout_order_method", "type": "String", "length": 32, "mandatory": false},
+		{"name": "executed_at", "type": "String", "length": 64, "mandatory": false},
+		{"name": "rotation_position", "type": "Number", "mandatory": false},
+	}); err != nil {
+		return 0, err
+	}
+	recipientID, _ := strconv.ParseInt(req.RecipientMemberID, 10, 64)
+	row := map[string]interface{}{
+		"recipient_client_id": recipientID,
+		"amount":              req.Amount,
+		"payout_order_method": req.PayoutOrderMethod,
+		"executed_at":         req.ExecutedAt,
+		"rotation_position":   position,
+		"locale":              "en",
+	}
+	return h.writeDatatableRow(roscaRotationTable, groupID, row)
+}
+
+// nextRotationPosition returns the position for the NEXT rotation row = existing row
+// count + 1 (rounds completed so far, advanced by this payout).
+func (h *Handler) nextRotationPosition(groupID int64) (int, error) {
+	raw, err := h.Fineract.DoRequest("GET", fmt.Sprintf("datatables/%s/%d", roscaRotationTable, groupID), nil, nil)
+	if err != nil {
+		// A not-yet-provisioned datatable 400s on read — that just means zero prior rounds.
+		return 1, nil
+	}
+	var rows []json.RawMessage
+	if err := json.Unmarshal(raw, &rows); err != nil {
+		return 1, nil
+	}
+	return len(rows) + 1, nil
+}
+
+// writeDatatableRow inserts one row into the group's datatable and returns the new row id.
+func (h *Handler) writeDatatableRow(table string, groupID int64, row map[string]interface{}) (int64, error) {
+	raw, err := h.Fineract.DoRequest("POST", fmt.Sprintf("datatables/%s/%d", table, groupID), row, nil)
+	if err != nil {
+		return 0, fmt.Errorf("%s", strings.TrimSpace(string(nonEmpty(raw))))
+	}
+	var resp struct {
+		ResourceID int64 `json:"resourceId"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return 0, fmt.Errorf("decode datatable-write response: %w", err)
+	}
+	if resp.ResourceID == 0 {
+		return 0, fmt.Errorf("fineract returned no row id: %s", string(raw))
+	}
+	return resp.ResourceID, nil
+}
+
+// ensureDatatable registers a datatable against apptable idempotently. It first checks
+// the registered-datatable list; if absent it POSTs /datatables, and treats an
+// "already exists / registered / duplicate" upstream rejection as success (defence in
+// depth against a race or a list-field-name mismatch) — the same idempotent contract
+// group_create.go documents for its out-of-band datatable provisioning.
+func (h *Handler) ensureDatatable(name, apptable string, columns []map[string]interface{}) error {
+	if h.datatableExists(name) {
+		return nil
+	}
+	body := map[string]interface{}{
+		"datatableName": name,
+		"apptableName":  apptable,
+		"multiRow":      true,
+		"columns":       columns,
+	}
+	raw, err := h.Fineract.DoRequest("POST", "datatables", body, nil)
+	if err != nil {
+		msg := strings.ToLower(strings.TrimSpace(string(nonEmpty(raw))))
+		if strings.Contains(msg, "exist") || strings.Contains(msg, "already") ||
+			strings.Contains(msg, "registered") || strings.Contains(msg, "duplicate") ||
+			strings.Contains(msg, "unique") {
+			return nil // already provisioned — idempotent success
+		}
+		return fmt.Errorf("register %s: %s", name, msg)
+	}
+	return nil
+}
+
+// datatableExists reports whether a datatable is already registered. Fineract's
+// GET /datatables returns an array whose rows carry registeredTableName; a decode
+// failure or upstream error fails soft to false (the POST's already-exists guard then
+// keeps ensureDatatable idempotent).
+func (h *Handler) datatableExists(name string) bool {
+	raw, err := h.Fineract.DoRequest("GET", "datatables", nil, nil)
+	if err != nil {
+		return false
+	}
+	var tables []struct {
+		RegisteredTableName  string `json:"registeredTableName"`
+		ApplicationTableName string `json:"applicationTableName"`
+	}
+	if err := json.Unmarshal(raw, &tables); err != nil {
+		return false
+	}
+	for _, t := range tables {
+		if t.RegisteredTableName == name {
+			return true
+		}
+	}
+	return false
+}
+
+// ---- helpers ----
+
+// nextRecipient returns the memberId (client-id string) of the member AFTER recipientID
+// in the deterministic rotation order (member id ascending), or nil when the recipient is
+// the last member (the final round has no next recipient). An unknown recipient -> nil.
+func nextRecipient(members []memberRef, recipientID string) *string {
+	if len(members) == 0 {
+		return nil
+	}
+	ordered := make([]memberRef, len(members))
+	copy(ordered, members)
+	sort.SliceStable(ordered, func(i, j int) bool { return ordered[i].ID < ordered[j].ID })
+	for i, m := range ordered {
+		if strconv.FormatInt(m.ID, 10) == recipientID {
+			if i+1 < len(ordered) {
+				next := strconv.FormatInt(ordered[i+1].ID, 10)
+				return &next
+			}
+			return nil // recipient is last in the order -> final round
+		}
+	}
+	return nil
+}

--- a/go/server/http_server.go
+++ b/go/server/http_server.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"github.com/openMF/mcp-mifosx/go/companion"
 	"github.com/openMF/mcp-mifosx/go/tools"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -49,6 +50,10 @@ func (s *MifosHTTPServer) Serve() error {
 			s.handleRESTToolCall(w, r, d)
 		})
 	}
+
+	// COMP-AUTH companion facade (CommonPurse app login). Inherits CORS from the
+	// outer handler below since it registers on the same mux.
+	companion.New(s.McpServer.Registry.Fineract).RegisterRoutes(mux)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		log.Printf("[HTTP] %s %s from %s", r.Method, r.URL.Path, r.RemoteAddr)

--- a/python/mcp_server.py
+++ b/python/mcp_server.py
@@ -13,10 +13,12 @@ logger = logging.getLogger(__name__)
 
 # 2. Import all the available domain functions from the existing codebase
 from tools.domains.accounting import create_journal_entry, get_journal_entries, list_gl_accounts
-from tools.domains.charges import create_charge as create_charge_domain
-from tools.domains.charges import get_charge as get_charge_domain
-from tools.domains.charges import list_charges as list_charges_domain
-from tools.domains.charges import update_charge as update_charge_domain
+from tools.domains.charges import (
+    create_charge as create_charge_domain,
+    get_charge as get_charge_domain,
+    list_charges as list_charges_domain,
+    update_charge as update_charge_domain,
+)
 from tools.domains.clients import (
     activate_client,
     apply_client_charge,
@@ -33,22 +35,26 @@ from tools.domains.clients import (
     search_clients_by_name,
     update_client_mobile,
 )
-from tools.domains.codetables import get_code_values as get_code_values_domain
-from tools.domains.codetables import list_codes as list_codes_domain
-from tools.domains.codetables import list_datatables as list_datatables_domain
 from tools.domains.codetables import (
     create_datatable as create_datatable_domain,
-    get_datatable_entries as get_datatable_entries_domain,
     create_datatable_entry as create_datatable_entry_domain,
-    update_datatable_entry as update_datatable_entry_domain,
     delete_datatable_entry as delete_datatable_entry_domain,
+    get_code_values as get_code_values_domain,
+    get_datatable_entries as get_datatable_entries_domain,
+    list_codes as list_codes_domain,
+    list_datatables as list_datatables_domain,
+    update_datatable_entry as update_datatable_entry_domain,
 )
-from tools.domains.groups import activate_group as activate_group_domain
-from tools.domains.groups import add_group_member, list_centers, list_groups
-from tools.domains.groups import create_center as create_center_domain
-from tools.domains.groups import create_group as create_group_domain
-from tools.domains.groups import get_center as get_center_domain
-from tools.domains.groups import get_group as get_group_domain
+from tools.domains.groups import (
+    activate_group as activate_group_domain,
+    add_group_member,
+    create_center as create_center_domain,
+    create_group as create_group_domain,
+    get_center as get_center_domain,
+    get_group as get_group_domain,
+    list_centers,
+    list_groups,
+)
 from tools.domains.loans import (
     apply_late_fee,
     approve_and_disburse_loan,

--- a/python/mcp_server.py
+++ b/python/mcp_server.py
@@ -36,6 +36,13 @@ from tools.domains.clients import (
 from tools.domains.codetables import get_code_values as get_code_values_domain
 from tools.domains.codetables import list_codes as list_codes_domain
 from tools.domains.codetables import list_datatables as list_datatables_domain
+from tools.domains.codetables import (
+    create_datatable as create_datatable_domain,
+    get_datatable_entries as get_datatable_entries_domain,
+    create_datatable_entry as create_datatable_entry_domain,
+    update_datatable_entry as update_datatable_entry_domain,
+    delete_datatable_entry as delete_datatable_entry_domain,
+)
 from tools.domains.groups import activate_group as activate_group_domain
 from tools.domains.groups import add_group_member, list_centers, list_groups
 from tools.domains.groups import create_center as create_center_domain
@@ -704,6 +711,65 @@ def get_code_values(codeId: int) -> dict:
 def list_all_datatables() -> dict:
     """List all registered data tables (custom fields, additional data extensions)"""
     return list_datatables_domain.func()
+
+
+# --- DATATABLE CRUD ---
+
+@mcp.tool()
+def create_datatable(datatable_name: str, apptable_name: str, columns: list) -> dict:
+    """Create a new datatable (custom data extension) attached to a Fineract entity.
+    apptable_name: m_client, m_group, m_loan, m_savings_account, m_office, m_center
+    columns: list of dicts [{name, type, length?, mandatory?}]
+    type: string, int, decimal, boolean, date, datetime, text, dropdown"""
+    valid_apptables = ["m_client", "m_group", "m_loan", "m_savings_account", "m_office", "m_center"]
+    if apptable_name not in valid_apptables:
+        return {"error": f"Invalid apptable '{apptable_name}'. Must be one of: {valid_apptables}"}
+    if not columns or not isinstance(columns, list):
+        return {"error": "columns must be a non-empty list of dicts with 'name' and 'type' keys"}
+    for col in columns:
+        if not isinstance(col, dict) or "name" not in col:
+            return {"error": f"Each column must be a dict with at least 'name'. Got: {col}"}
+    return create_datatable_domain.func(datatable_name, apptable_name, columns)
+
+
+@mcp.tool()
+def get_datatable_entries(datatable_name: str, entity_id: int) -> dict:
+    """Read all datatable rows for a specific entity.
+    datatable_name: the registered datatable name (e.g., dt_group_meetings)
+    entity_id: the ID of the entity (clientId, groupId, loanId, etc.)"""
+    result = get_datatable_entries_domain.func(datatable_name, entity_id)
+    if isinstance(result, list):
+        return {"entries": result, "count": len(result)}
+    return result
+
+
+@mcp.tool()
+def create_datatable_entry(datatable_name: str, entity_id: int, data: dict) -> dict:
+    """Add a row to a datatable for a specific entity.
+    datatable_name: the registered datatable name
+    entity_id: the ID of the entity
+    data: column values, e.g. {"meeting_date": "2026-05-15", "status": "scheduled"}
+    For date columns include dateFormat and locale in data."""
+    if not data or not isinstance(data, dict):
+        return {"error": "data must be a non-empty dict of column values"}
+    return create_datatable_entry_domain.func(datatable_name, entity_id, data)
+
+
+@mcp.tool()
+def update_datatable_entry(datatable_name: str, entity_id: int, data: dict) -> dict:
+    """Update a datatable entry for a specific entity.
+    data: dict of column values to update."""
+    if not data or not isinstance(data, dict):
+        return {"error": "data must be a non-empty dict of column values to update"}
+    return update_datatable_entry_domain.func(datatable_name, entity_id, data)
+
+
+@mcp.tool()
+def delete_datatable_entry(datatable_name: str, entity_id: int) -> dict:
+    """Delete all datatable entries for a specific entity.
+    datatable_name: the registered datatable name
+    entity_id: the ID of the entity"""
+    return delete_datatable_entry_domain.func(datatable_name, entity_id)
 
 
 # 5. START SERVER

--- a/python/mcp_server.py
+++ b/python/mcp_server.py
@@ -15,8 +15,14 @@ logger = logging.getLogger(__name__)
 from tools.domains.accounting import create_journal_entry, get_journal_entries, list_gl_accounts
 from tools.domains.charges import (
     create_charge as create_charge_domain,
+)
+from tools.domains.charges import (
     get_charge as get_charge_domain,
+)
+from tools.domains.charges import (
     list_charges as list_charges_domain,
+)
+from tools.domains.charges import (
     update_charge as update_charge_domain,
 )
 from tools.domains.clients import (
@@ -37,23 +43,47 @@ from tools.domains.clients import (
 )
 from tools.domains.codetables import (
     create_datatable as create_datatable_domain,
+)
+from tools.domains.codetables import (
     create_datatable_entry as create_datatable_entry_domain,
+)
+from tools.domains.codetables import (
     delete_datatable_entry as delete_datatable_entry_domain,
+)
+from tools.domains.codetables import (
     get_code_values as get_code_values_domain,
+)
+from tools.domains.codetables import (
     get_datatable_entries as get_datatable_entries_domain,
+)
+from tools.domains.codetables import (
     list_codes as list_codes_domain,
+)
+from tools.domains.codetables import (
     list_datatables as list_datatables_domain,
+)
+from tools.domains.codetables import (
     update_datatable_entry as update_datatable_entry_domain,
 )
 from tools.domains.groups import (
     activate_group as activate_group_domain,
+)
+from tools.domains.groups import (
     add_group_member,
-    create_center as create_center_domain,
-    create_group as create_group_domain,
-    get_center as get_center_domain,
-    get_group as get_group_domain,
     list_centers,
     list_groups,
+)
+from tools.domains.groups import (
+    create_center as create_center_domain,
+)
+from tools.domains.groups import (
+    create_group as create_group_domain,
+)
+from tools.domains.groups import (
+    get_center as get_center_domain,
+)
+from tools.domains.groups import (
+    get_group as get_group_domain,
 )
 from tools.domains.loans import (
     apply_late_fee,

--- a/python/mcp_server.py
+++ b/python/mcp_server.py
@@ -4,6 +4,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import logging
+from functools import wraps
 
 from fastmcp import FastMCP
 
@@ -116,9 +117,74 @@ from tools.domains.savings import (
     withdraw_savings,
 )
 from tools.domains.staff import get_office_details, get_staff_details, list_offices, list_staff
+from tools.domains.self_service import (
+    authenticate as authenticate_domain,
+    get_self_client as get_self_client_domain,
+    list_self_loans as list_self_loans_domain,
+    list_self_savings as list_self_savings_domain,
+    self_authenticate as self_authenticate_domain,
+)
+from tools.domains.batch import send_batch as send_batch_domain
+from tools.domains.group_banking import (
+    add_loan_guarantor as add_loan_guarantor_domain,
+    advance_cycle as advance_cycle_domain,
+    assign_member_role as assign_member_role_domain,
+    create_invitation as create_invitation_domain,
+    get_group_config as get_group_config_domain,
+    get_group_corpus as get_group_corpus_domain,
+    get_loan_policy as get_loan_policy_domain,
+    get_loan_vote as get_loan_vote_domain,
+    get_member_ceiling as get_member_ceiling_domain,
+    get_member_role as get_member_role_domain,
+    get_social_fund as get_social_fund_domain,
+    get_sync_state as get_sync_state_domain,
+    list_attendance as list_attendance_domain,
+    list_invitations as list_invitations_domain,
+    list_loan_guarantors as list_loan_guarantors_domain,
+    list_loan_requests as list_loan_requests_domain,
+    list_meetings as list_meetings_domain,
+    list_notifications as list_notifications_domain,
+    list_share_outs as list_share_outs_domain,
+    push_notification as push_notification_domain,
+    record_attendance as record_attendance_domain,
+    record_loan_vote as record_loan_vote_domain,
+    record_meeting as record_meeting_domain,
+    record_share_out as record_share_out_domain,
+    set_loan_policy as set_loan_policy_domain,
+    set_member_ceiling as set_member_ceiling_domain,
+    submit_loan_request as submit_loan_request_domain,
+    update_group_corpus as update_group_corpus_domain,
+    update_social_fund as update_social_fund_domain,
+    update_sync_state as update_sync_state_domain,
+    upsert_group_config as upsert_group_config_domain,
+)
 
 # 3. Initialize the FastMCP Server
 mcp = FastMCP("Mifos-Banking-Agent")
+
+# FastMCP 3.x rejects bare list / scalar tool returns ("structured_content must
+# be a dict or None"). Many list_*/get_*_entries Fineract endpoints return JSON
+# arrays. Monkey-patch mcp.tool so any tool can keep returning whatever Fineract
+# gives back; we wrap it once at the boundary.
+_original_mcp_tool = mcp.tool
+
+def _safe_tool(*tool_args, **tool_kwargs):
+    decorator = _original_mcp_tool(*tool_args, **tool_kwargs)
+
+    def register(fn):
+        @wraps(fn)
+        def safe_fn(*args, **kwargs):
+            result = fn(*args, **kwargs)
+            if isinstance(result, list):
+                return {"items": result}
+            if result is not None and not isinstance(result, dict):
+                return {"value": result}
+            return result
+        return decorator(safe_fn)
+
+    return register
+
+mcp.tool = _safe_tool
 
 # --- Shared helpers ---
 
@@ -806,6 +872,249 @@ def delete_datatable_entry(datatable_name: str, entity_id: int) -> dict:
     datatable_name: the registered datatable name
     entity_id: the ID of the entity"""
     return delete_datatable_entry_domain.func(datatable_name, entity_id)
+
+
+# --- SELF-SERVICE & AUTH (TIER 1) ---
+
+@mcp.tool()
+def authenticate(username: str, password: str) -> dict:
+    """Authenticate as a Fineract staff user. Returns base64EncodedAuthenticationKey + roles."""
+    return authenticate_domain.func(username, password)
+
+
+@mcp.tool()
+def self_authenticate(username: str, password: str) -> dict:
+    """Authenticate as a self-service end-user (member). Returns base64 key + clientId + displayName."""
+    return self_authenticate_domain.func(username, password)
+
+
+@mcp.tool()
+def get_self_client(username: str = None, password: str = None) -> dict:
+    """Get the authenticated self-service user's own client profile."""
+    return get_self_client_domain.func(username, password)
+
+
+@mcp.tool()
+def list_self_savings(username: str = None, password: str = None) -> dict:
+    """List the authenticated self-service user's own savings accounts."""
+    return list_self_savings_domain.func(username, password)
+
+
+@mcp.tool()
+def list_self_loans(username: str = None, password: str = None) -> dict:
+    """List the authenticated self-service user's own loan accounts."""
+    return list_self_loans_domain.func(username, password)
+
+
+# --- BATCH API (TIER 1) ---
+
+@mcp.tool()
+def send_batch(operations: list, enclosing_transaction: bool = False) -> dict:
+    """Send a Fineract batch (up to 200 operations). enclosing_transaction=True for atomic batches.
+    operations: list of {requestId:int, method:str, relativeUrl:str, headers?:list, body?:dict}."""
+    if not operations or not isinstance(operations, list):
+        return {"error": "operations must be a non-empty list"}
+    return send_batch_domain.func(operations, enclosing_transaction)
+
+
+# --- GROUP BANKING / VSLA (TIER 2 — datatable wrappers) ---
+
+@mcp.tool()
+def get_group_config(centerId: int) -> dict:
+    """Get cycle config for a group (savings min/max, loan multiplier, fines, status)."""
+    return get_group_config_domain.func(centerId)
+
+
+@mcp.tool()
+def upsert_group_config(centerId: int, config: dict) -> dict:
+    """Create or update the dt_group_config row for a center."""
+    return upsert_group_config_domain.func(centerId, config)
+
+
+@mcp.tool()
+def advance_cycle(centerId: int, new_cycle_number: int, new_start_date: str, new_end_date: str) -> dict:
+    """Start a new cycle after share-out. Bumps cycle_number, resets cycle_status to 'active'."""
+    return advance_cycle_domain.func(centerId, new_cycle_number, new_start_date, new_end_date)
+
+
+@mcp.tool()
+def list_meetings(centerId: int) -> dict:
+    """List all dt_meeting_record entries for a center."""
+    return list_meetings_domain.func(centerId)
+
+
+@mcp.tool()
+def record_meeting(centerId: int, meeting: dict) -> dict:
+    """Append a meeting summary record to dt_meeting_record."""
+    return record_meeting_domain.func(centerId, meeting)
+
+
+@mcp.tool()
+def list_attendance(clientId: int) -> dict:
+    """List a member's attendance history from dt_meeting_attendance."""
+    return list_attendance_domain.func(clientId)
+
+
+@mcp.tool()
+def record_attendance(clientId: int, meeting_number: int, meeting_date: str, present: bool,
+                      late: bool = False, fine_applied: float = 0.0, fine_reason: str = None) -> dict:
+    """Record a member's attendance at one meeting."""
+    return record_attendance_domain.func(clientId, meeting_number, meeting_date, present,
+                                         late, fine_applied, fine_reason)
+
+
+@mcp.tool()
+def get_member_role(clientId: int) -> dict:
+    """Get a member's role within their group (chairperson | treasurer | secretary | member)."""
+    return get_member_role_domain.func(clientId)
+
+
+@mcp.tool()
+def assign_member_role(clientId: int, role: str, assigned_date: str, assigned_by: str = None) -> dict:
+    """Assign or change a member's role."""
+    return assign_member_role_domain.func(clientId, role, assigned_date, assigned_by)
+
+
+@mcp.tool()
+def list_share_outs(centerId: int) -> dict:
+    """List all share-out records for a center."""
+    return list_share_outs_domain.func(centerId)
+
+
+@mcp.tool()
+def record_share_out(centerId: int, share_out: dict) -> dict:
+    """Record a cycle's share-out distribution (preview or final)."""
+    return record_share_out_domain.func(centerId, share_out)
+
+
+@mcp.tool()
+def get_social_fund(centerId: int) -> dict:
+    """Get the social-fund balance + disbursement state for a center."""
+    return get_social_fund_domain.func(centerId)
+
+
+@mcp.tool()
+def update_social_fund(centerId: int, payload: dict) -> dict:
+    """Update the social-fund row for a center."""
+    return update_social_fund_domain.func(centerId, payload)
+
+
+@mcp.tool()
+def get_loan_vote(loanId: int) -> dict:
+    """Get the in-meeting vote record for a loan."""
+    return get_loan_vote_domain.func(loanId)
+
+
+@mcp.tool()
+def record_loan_vote(loanId: int, payload: dict) -> dict:
+    """Record an in-meeting vote on a loan (votes_for, votes_against, approved, etc.)."""
+    return record_loan_vote_domain.func(loanId, payload)
+
+
+@mcp.tool()
+def get_sync_state(centerId: int) -> dict:
+    """Get last-sync metadata for a center (timestamp, pending ops, conflicts, device)."""
+    return get_sync_state_domain.func(centerId)
+
+
+@mcp.tool()
+def update_sync_state(centerId: int, payload: dict) -> dict:
+    """Update sync metadata for a center."""
+    return update_sync_state_domain.func(centerId, payload)
+
+
+@mcp.tool()
+def list_loan_requests(clientId: int) -> dict:
+    """List a member's loan requests (pending or reviewed)."""
+    return list_loan_requests_domain.func(clientId)
+
+
+@mcp.tool()
+def submit_loan_request(clientId: int, requested_amount: float, purpose: str,
+                        desired_duration_weeks: int, request_date: str,
+                        eligibility_amount: float = None) -> dict:
+    """Submit a member's loan request from the personal dashboard. Status set to 'pending'."""
+    return submit_loan_request_domain.func(clientId, requested_amount, purpose,
+                                           desired_duration_weeks, request_date, eligibility_amount)
+
+
+@mcp.tool()
+def get_group_corpus(centerId: int) -> dict:
+    """Get the running corpus balance for a group."""
+    return get_group_corpus_domain.func(centerId)
+
+
+@mcp.tool()
+def update_group_corpus(centerId: int, payload: dict) -> dict:
+    """Update the corpus row after a meeting inflow/outflow."""
+    return update_group_corpus_domain.func(centerId, payload)
+
+
+@mcp.tool()
+def get_loan_policy(centerId: int) -> dict:
+    """Get the loan-ceiling policy for a group (flat | savings_multiplier | hybrid)."""
+    return get_loan_policy_domain.func(centerId)
+
+
+@mcp.tool()
+def set_loan_policy(centerId: int, payload: dict) -> dict:
+    """Configure or update the loan-ceiling policy for a group."""
+    return set_loan_policy_domain.func(centerId, payload)
+
+
+@mcp.tool()
+def get_member_ceiling(clientId: int) -> dict:
+    """Get a member's ceiling override (if any)."""
+    return get_member_ceiling_domain.func(clientId)
+
+
+@mcp.tool()
+def set_member_ceiling(clientId: int, override_pct: float, reason: str,
+                       granted_by: str, granted_at: str) -> dict:
+    """Grant or update a member's ceiling override."""
+    return set_member_ceiling_domain.func(clientId, override_pct, reason, granted_by, granted_at)
+
+
+@mcp.tool()
+def list_loan_guarantors(loanId: int) -> dict:
+    """List all guarantors backing a loan + their pro-rata shares."""
+    return list_loan_guarantors_domain.func(loanId)
+
+
+@mcp.tool()
+def add_loan_guarantor(loanId: int, guarantor_client_id: int, share_pct: float) -> dict:
+    """Add a guarantor to a loan with a pro-rata share. signed=False until in-meeting confirmation."""
+    return add_loan_guarantor_domain.func(loanId, guarantor_client_id, share_pct)
+
+
+@mcp.tool()
+def list_notifications(clientId: int) -> dict:
+    """List notifications for a member (full feed, read + unread)."""
+    return list_notifications_domain.func(clientId)
+
+
+@mcp.tool()
+def push_notification(clientId: int, event_type: str, title: str, body: str,
+                      event_created_at: str, priority: str = "normal",
+                      delivered_via: str = "in-app", payload_json: str = None) -> dict:
+    """Push an in-app notification to a member. priority: low|normal|high. delivered_via: in-app|fcm|sms.
+    event_created_at is the app-level event timestamp (Fineract row metadata is separate)."""
+    return push_notification_domain.func(clientId, event_type, title, body, event_created_at,
+                                         priority, delivered_via, payload_json)
+
+
+@mcp.tool()
+def list_invitations(clientId: int) -> dict:
+    """List invitations issued by a member (stewardship codes)."""
+    return list_invitations_domain.func(clientId)
+
+
+@mcp.tool()
+def create_invitation(clientId: int, stewardship_code: str, invited_at: str, expires_at: str,
+                      target_center_id: int, channel: str = "sms") -> dict:
+    """Issue a one-time member-invitation code (6-char, single-use, 7-day default expiry)."""
+    return create_invitation_domain.func(clientId, stewardship_code, invited_at, expires_at,
+                                         target_center_id, channel)
 
 
 # 5. START SERVER

--- a/python/tools/domains/batch.py
+++ b/python/tools/domains/batch.py
@@ -1,0 +1,24 @@
+# Copyright since 2025 Mifos Initiative
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from langchain_core.tools import tool
+
+from tools.mcp_adapter import fineract_client
+
+
+# --- T1-6 BATCH API ---
+
+@tool
+def send_batch(operations: list, enclosing_transaction: bool = False):
+    """Answers: 'Drain the offline outbox via Fineract Batch API'.
+    operations: list of {requestId:int, method:str, relativeUrl:str, headers?:list, body?:dict}.
+    Up to 200 ops/request. Set enclosing_transaction=True for atomic batches (any failure rolls
+    back the whole batch). Returns list of {requestId, statusCode, body} per op, in submission order."""
+    print(f"[Tool] Sending batch of {len(operations)} operation(s) "
+          f"(transactional={enclosing_transaction})...")
+    endpoint = "batches"
+    if enclosing_transaction:
+        endpoint += "?enclosingTransaction=true"
+    return fineract_client.execute_post(endpoint, operations)

--- a/python/tools/domains/codetables.py
+++ b/python/tools/domains/codetables.py
@@ -29,3 +29,94 @@ def list_datatables():
     Returns all registered data tables (custom fields, additional data extensions)."""
     print("[Tool] Fetching all datatables...")
     return fineract_client.execute_get("datatables")
+
+
+# --- DATATABLE CRUD OPERATIONS ---
+
+def _map_column_type(col_type: str) -> str:
+    """Map user-friendly column types to Fineract's internal type names."""
+    type_map = {
+        "string": "String",
+        "int": "Integer",
+        "integer": "Integer",
+        "decimal": "Decimal",
+        "boolean": "Boolean",
+        "bool": "Boolean",
+        "date": "Date",
+        "datetime": "DateTime",
+        "text": "Text",
+        "dropdown": "Dropdown",
+    }
+    return type_map.get(col_type.lower(), "String")
+
+
+@tool
+def create_datatable(datatable_name: str, apptable_name: str, columns: list):
+    """Create a new datatable (custom data extension) attached to a Fineract entity.
+    apptable_name: m_client, m_group, m_loan, m_savings_account, m_office, m_center
+    columns: list of dicts with keys: name, type, length (optional), mandatory (optional)
+    type values: string, int, decimal, boolean, date, datetime, text, dropdown
+    Example: [{"name": "meeting_date", "type": "date", "mandatory": true}]"""
+    print(f"[Tool] Creating datatable '{datatable_name}' on '{apptable_name}'...")
+    payload = {
+        "datatableName": datatable_name,
+        "apptableName": apptable_name,
+        "multiRow": True,
+        "columns": [
+            {
+                "name": col["name"],
+                "type": _map_column_type(col.get("type", "string")),
+                "length": col.get("length", 100),
+                "mandatory": col.get("mandatory", False),
+                "code": col.get("code", ""),
+            }
+            for col in columns
+        ],
+    }
+    return fineract_client.execute_post("datatables", payload)
+
+
+@tool
+def get_datatable_entries(datatable_name: str, entity_id: int):
+    """Read all datatable rows for a specific entity (client, group, loan, etc.).
+    datatable_name: the registered datatable name (e.g., dt_group_meetings)
+    entity_id: the ID of the entity the datatable is attached to"""
+    print(f"[Tool] Fetching entries from '{datatable_name}' for entity {entity_id}...")
+    return fineract_client.execute_get(f"datatables/{datatable_name}/{entity_id}")
+
+
+@tool
+def create_datatable_entry(datatable_name: str, entity_id: int, data: dict):
+    """Add a row to a datatable for a specific entity.
+    datatable_name: the registered datatable name
+    entity_id: the ID of the entity
+    data: dict of column values, e.g. {"meeting_date": "2026-05-15", "status": "scheduled"}
+    Date format: yyyy-MM-dd. Include dateFormat and locale in data for date columns."""
+    print(f"[Tool] Creating entry in '{datatable_name}' for entity {entity_id}...")
+    if "locale" not in data:
+        data["locale"] = "en"
+    if "dateFormat" not in data:
+        data["dateFormat"] = "yyyy-MM-dd"
+    return fineract_client.execute_post(f"datatables/{datatable_name}/{entity_id}", data)
+
+
+@tool
+def update_datatable_entry(datatable_name: str, entity_id: int, data: dict):
+    """Update a datatable entry for a specific entity.
+    For multiRow datatables, updates the entry matching entity_id.
+    data: dict of column values to update."""
+    print(f"[Tool] Updating entry in '{datatable_name}' for entity {entity_id}...")
+    if "locale" not in data:
+        data["locale"] = "en"
+    if "dateFormat" not in data:
+        data["dateFormat"] = "yyyy-MM-dd"
+    return fineract_client.execute_put(f"datatables/{datatable_name}/{entity_id}", data)
+
+
+@tool
+def delete_datatable_entry(datatable_name: str, entity_id: int):
+    """Delete all datatable entries for a specific entity.
+    datatable_name: the registered datatable name
+    entity_id: the ID of the entity"""
+    print(f"[Tool] Deleting entries from '{datatable_name}' for entity {entity_id}...")
+    return fineract_client.execute_delete(f"datatables/{datatable_name}/{entity_id}")

--- a/python/tools/domains/group_banking.py
+++ b/python/tools/domains/group_banking.py
@@ -1,0 +1,431 @@
+# Copyright since 2025 Mifos Initiative
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""VSLA / group-banking domain wrappers — TIER 2 datatable extensions.
+
+Each datatable is created via /mifos-bridge once; these wrappers expose
+CRUD-style domain functions over the generic datatable API so consumers
+(and AI agents) can speak in domain terms (record_attendance, push_notification)
+instead of raw datatable JSON.
+
+All 15 datatables and their wrappers are scoped to `mifos-x-group-banking`.
+"""
+
+from langchain_core.tools import tool
+
+from tools.mcp_adapter import fineract_client
+
+# --- Helpers ---
+
+DATE_FMT = {"dateFormat": "yyyy-MM-dd", "locale": "en"}
+DATETIME_FMT = {"dateFormat": "yyyy-MM-dd HH:mm:ss", "locale": "en"}
+
+
+def _entries(table: str, entity_id: int):
+    return fineract_client.execute_get(f"datatables/{table}/{entity_id}")
+
+
+def _create_entry(table: str, entity_id: int, data: dict, with_dates: bool = False):
+    payload = dict(data)
+    if with_dates:
+        payload.update(DATE_FMT)
+    return fineract_client.execute_post(f"datatables/{table}/{entity_id}", payload)
+
+
+def _update_entry(table: str, entity_id: int, data: dict, with_dates: bool = False):
+    payload = dict(data)
+    if with_dates:
+        payload.update(DATE_FMT)
+    return fineract_client.execute_put(f"datatables/{table}/{entity_id}", payload)
+
+
+# ════════════════════════════════════════════════════════════════════
+# T2-1  dt_group_config  (m_center, single-row)
+# ════════════════════════════════════════════════════════════════════
+
+@tool
+def get_group_config(center_id: int):
+    """Answers: 'Show the cycle rules for group #N' — savings min/max, loan multiplier, fines, status."""
+    print(f"[Tool] Fetching dt_group_config for center #{center_id}...")
+    return _entries("dt_group_config", center_id)
+
+
+@tool
+def upsert_group_config(center_id: int, config: dict):
+    """Answers: 'Save the group's cycle rules'. config keys match dt_group_config columns
+    (cycle_number, cycle_length_months, contribution_min/max, loan_multiplier, ...)."""
+    print(f"[Tool] Upserting dt_group_config for center #{center_id}...")
+    existing = _entries("dt_group_config", center_id)
+    if isinstance(existing, list) and len(existing) > 0:
+        return _update_entry("dt_group_config", center_id, config, with_dates=True)
+    return _create_entry("dt_group_config", center_id, config, with_dates=True)
+
+
+@tool
+def advance_cycle(center_id: int, new_cycle_number: int, new_start_date: str, new_end_date: str):
+    """Answers: 'Start a new cycle for group #N after share-out'. Increments cycle_number,
+    sets new dates, resets cycle_status to 'active'."""
+    print(f"[Tool] Advancing center #{center_id} to cycle #{new_cycle_number}...")
+    return _update_entry("dt_group_config", center_id, {
+        "cycle_number": new_cycle_number,
+        "cycle_start_date": new_start_date,
+        "cycle_end_date": new_end_date,
+        "cycle_status": "active",
+    }, with_dates=True)
+
+
+# ════════════════════════════════════════════════════════════════════
+# T2-2  dt_meeting_record  (m_center, multi-row)
+# ════════════════════════════════════════════════════════════════════
+
+@tool
+def list_meetings(center_id: int):
+    """Answers: 'Show all meeting records for group #N'."""
+    print(f"[Tool] Fetching meeting records for center #{center_id}...")
+    return _entries("dt_meeting_record", center_id)
+
+
+@tool
+def record_meeting(center_id: int, meeting: dict):
+    """Answers: 'Save a meeting summary'. meeting keys: meeting_number, meeting_date, status,
+    members_present, members_absent, total_savings_collected, total_fines_collected,
+    loans_approved_count, loans_approved_amount, notes."""
+    print(f"[Tool] Recording meeting for center #{center_id}...")
+    return _create_entry("dt_meeting_record", center_id, meeting, with_dates=True)
+
+
+# ════════════════════════════════════════════════════════════════════
+# T2-3  dt_meeting_attendance  (m_client, multi-row)
+# ════════════════════════════════════════════════════════════════════
+
+@tool
+def list_attendance(client_id: int):
+    """Answers: 'Show member #N's attendance history'."""
+    print(f"[Tool] Fetching attendance for client #{client_id}...")
+    return _entries("dt_meeting_attendance", client_id)
+
+
+@tool
+def record_attendance(
+    client_id: int,
+    meeting_number: int,
+    meeting_date: str,
+    present: bool,
+    late: bool = False,
+    fine_applied: float = 0.0,
+    fine_reason: str = None,
+):
+    """Answers: 'Mark member #N present/absent at meeting M'. fine_reason is the audit string
+    when a fine is applied (e.g. 'late', 'absent_unexcused')."""
+    print(f"[Tool] Recording attendance for client #{client_id}, meeting #{meeting_number}...")
+    return _create_entry("dt_meeting_attendance", client_id, {
+        "meeting_number": meeting_number,
+        "meeting_date": meeting_date,
+        "present": present,
+        "late": late,
+        "fine_applied": fine_applied,
+        "fine_reason": fine_reason,
+    }, with_dates=True)
+
+
+# ════════════════════════════════════════════════════════════════════
+# T2-4  dt_member_role  (m_client, single-row)
+# ════════════════════════════════════════════════════════════════════
+
+@tool
+def get_member_role(client_id: int):
+    """Answers: 'What role does member #N hold?' — chairperson, treasurer, secretary, member."""
+    print(f"[Tool] Fetching role for client #{client_id}...")
+    return _entries("dt_member_role", client_id)
+
+
+@tool
+def assign_member_role(client_id: int, role: str, assigned_date: str, assigned_by: str = None):
+    """Answers: 'Make member #N the chairperson'. role: chairperson | treasurer | secretary | member."""
+    print(f"[Tool] Assigning role '{role}' to client #{client_id}...")
+    payload = {"role": role, "assigned_date": assigned_date, "assigned_by": assigned_by}
+    existing = _entries("dt_member_role", client_id)
+    if isinstance(existing, list) and len(existing) > 0:
+        return _update_entry("dt_member_role", client_id, payload, with_dates=True)
+    return _create_entry("dt_member_role", client_id, payload, with_dates=True)
+
+
+# ════════════════════════════════════════════════════════════════════
+# T2-5  dt_share_out  (m_center, multi-row)
+# ════════════════════════════════════════════════════════════════════
+
+@tool
+def list_share_outs(center_id: int):
+    """Answers: 'Show all share-out records for group #N'."""
+    print(f"[Tool] Fetching share-outs for center #{center_id}...")
+    return _entries("dt_share_out", center_id)
+
+
+@tool
+def record_share_out(center_id: int, share_out: dict):
+    """Answers: 'Record this cycle's share-out distribution'. share_out keys: cycle_number,
+    share_out_date, total_pool, total_interest_earned, total_fines_collected, members_count,
+    distribution_json, status."""
+    print(f"[Tool] Recording share-out for center #{center_id}...")
+    return _create_entry("dt_share_out", center_id, share_out, with_dates=True)
+
+
+# ════════════════════════════════════════════════════════════════════
+# T2-6  dt_social_fund  (m_center, single-row)
+# ════════════════════════════════════════════════════════════════════
+
+@tool
+def get_social_fund(center_id: int):
+    """Answers: 'How much is in the social fund for group #N?'"""
+    print(f"[Tool] Fetching social fund for center #{center_id}...")
+    return _entries("dt_social_fund", center_id)
+
+
+@tool
+def update_social_fund(center_id: int, payload: dict):
+    """Answers: 'Update the group's social-fund balance / disbursement state'."""
+    print(f"[Tool] Updating social fund for center #{center_id}...")
+    existing = _entries("dt_social_fund", center_id)
+    if isinstance(existing, list) and len(existing) > 0:
+        return _update_entry("dt_social_fund", center_id, payload, with_dates=True)
+    return _create_entry("dt_social_fund", center_id, payload, with_dates=True)
+
+
+# ════════════════════════════════════════════════════════════════════
+# T2-7  dt_loan_vote  (m_loan, single-row)
+# ════════════════════════════════════════════════════════════════════
+
+@tool
+def get_loan_vote(loan_id: int):
+    """Answers: 'How did the group vote on loan #N?'"""
+    print(f"[Tool] Fetching vote record for loan #{loan_id}...")
+    return _entries("dt_loan_vote", loan_id)
+
+
+@tool
+def record_loan_vote(loan_id: int, payload: dict):
+    """Answers: 'Save the in-meeting vote for loan #N'. payload keys: meeting_number, votes_for,
+    votes_against, approved, approved_by_chairperson, notes."""
+    print(f"[Tool] Recording vote for loan #{loan_id}...")
+    existing = _entries("dt_loan_vote", loan_id)
+    if isinstance(existing, list) and len(existing) > 0:
+        return _update_entry("dt_loan_vote", loan_id, payload)
+    return _create_entry("dt_loan_vote", loan_id, payload)
+
+
+# ════════════════════════════════════════════════════════════════════
+# T2-8  dt_sync_metadata  (m_center, single-row)
+# ════════════════════════════════════════════════════════════════════
+
+@tool
+def get_sync_state(center_id: int):
+    """Answers: 'When did group #N last sync, and how many ops are pending?'"""
+    print(f"[Tool] Fetching sync state for center #{center_id}...")
+    return _entries("dt_sync_metadata", center_id)
+
+
+@tool
+def update_sync_state(center_id: int, payload: dict):
+    """Answers: 'Update the device's sync metadata for group #N'."""
+    print(f"[Tool] Updating sync state for center #{center_id}...")
+    existing = _entries("dt_sync_metadata", center_id)
+    if isinstance(existing, list) and len(existing) > 0:
+        return _update_entry("dt_sync_metadata", center_id, payload, with_dates=True)
+    return _create_entry("dt_sync_metadata", center_id, payload, with_dates=True)
+
+
+# ════════════════════════════════════════════════════════════════════
+# T2-9  dt_loan_request  (m_client, multi-row)
+# ════════════════════════════════════════════════════════════════════
+
+@tool
+def list_loan_requests(client_id: int):
+    """Answers: 'Show member #N's loan requests'."""
+    print(f"[Tool] Fetching loan requests for client #{client_id}...")
+    return _entries("dt_loan_request", client_id)
+
+
+@tool
+def submit_loan_request(
+    client_id: int,
+    requested_amount: float,
+    purpose: str,
+    desired_duration_weeks: int,
+    request_date: str,
+    eligibility_amount: float = None,
+):
+    """Answers: 'Submit a loan request from member #N'. status auto-set to 'pending'."""
+    print(f"[Tool] Submitting loan request for client #{client_id}...")
+    return _create_entry("dt_loan_request", client_id, {
+        "requested_amount": requested_amount,
+        "purpose": purpose,
+        "desired_duration_weeks": desired_duration_weeks,
+        "eligibility_amount": eligibility_amount,
+        "request_date": request_date,
+        "status": "pending",
+    }, with_dates=True)
+
+
+# ════════════════════════════════════════════════════════════════════
+# T2-10  dt_group_corpus  (m_center, single-row)
+# ════════════════════════════════════════════════════════════════════
+
+@tool
+def get_group_corpus(center_id: int):
+    """Answers: 'What's the running corpus balance for group #N?'"""
+    print(f"[Tool] Fetching corpus for center #{center_id}...")
+    return _entries("dt_group_corpus", center_id)
+
+
+@tool
+def update_group_corpus(center_id: int, payload: dict):
+    """Answers: 'Update the running corpus after a meeting inflow/outflow'."""
+    print(f"[Tool] Updating corpus for center #{center_id}...")
+    existing = _entries("dt_group_corpus", center_id)
+    if isinstance(existing, list) and len(existing) > 0:
+        return _update_entry("dt_group_corpus", center_id, payload, with_dates=True)
+    return _create_entry("dt_group_corpus", center_id, payload, with_dates=True)
+
+
+# ════════════════════════════════════════════════════════════════════
+# T2-11  dt_group_loan_policy  (m_center, single-row)
+# ════════════════════════════════════════════════════════════════════
+
+@tool
+def get_loan_policy(center_id: int):
+    """Answers: 'What's the loan-ceiling policy for group #N?' — flat | savings_multiplier | hybrid."""
+    print(f"[Tool] Fetching loan policy for center #{center_id}...")
+    return _entries("dt_group_loan_policy", center_id)
+
+
+@tool
+def set_loan_policy(center_id: int, payload: dict):
+    """Answers: 'Configure the group's loan ceiling rule'. payload: ceiling_rule, flat_cap,
+    savings_multiplier, hybrid_minimum."""
+    print(f"[Tool] Setting loan policy for center #{center_id}...")
+    existing = _entries("dt_group_loan_policy", center_id)
+    if isinstance(existing, list) and len(existing) > 0:
+        return _update_entry("dt_group_loan_policy", center_id, payload, with_dates=True)
+    return _create_entry("dt_group_loan_policy", center_id, payload, with_dates=True)
+
+
+# ════════════════════════════════════════════════════════════════════
+# T2-12  dt_member_ceiling_override  (m_client, single-row)
+# ════════════════════════════════════════════════════════════════════
+
+@tool
+def get_member_ceiling(client_id: int):
+    """Answers: 'Does member #N have a ceiling override?' — returns override_pct, reason, granted_by."""
+    print(f"[Tool] Fetching ceiling override for client #{client_id}...")
+    return _entries("dt_member_ceiling_override", client_id)
+
+
+@tool
+def set_member_ceiling(client_id: int, override_pct: float, reason: str, granted_by: str, granted_at: str):
+    """Answers: 'Grant member #N a +20% ceiling override'."""
+    print(f"[Tool] Setting ceiling override for client #{client_id}...")
+    payload = {"override_pct": override_pct, "reason": reason,
+               "granted_by": granted_by, "granted_at": granted_at}
+    existing = _entries("dt_member_ceiling_override", client_id)
+    if isinstance(existing, list) and len(existing) > 0:
+        return _update_entry("dt_member_ceiling_override", client_id, payload, with_dates=True)
+    return _create_entry("dt_member_ceiling_override", client_id, payload, with_dates=True)
+
+
+# ════════════════════════════════════════════════════════════════════
+# T2-13  dt_loan_guarantor  (m_loan, multi-row)
+# ════════════════════════════════════════════════════════════════════
+
+@tool
+def list_loan_guarantors(loan_id: int):
+    """Answers: 'Who is guaranteeing loan #N and what's their pro-rata share?'"""
+    print(f"[Tool] Fetching guarantors for loan #{loan_id}...")
+    return _entries("dt_loan_guarantor", loan_id)
+
+
+@tool
+def add_loan_guarantor(loan_id: int, guarantor_client_id: int, share_pct: float):
+    """Answers: 'Add member #N as guarantor for X% of loan #M'. signed=False until they
+    confirm in-meeting. deducted_at_share_out tracks default-recovery state."""
+    print(f"[Tool] Adding guarantor #{guarantor_client_id} to loan #{loan_id}...")
+    return _create_entry("dt_loan_guarantor", loan_id, {
+        "guarantor_client_id": guarantor_client_id,
+        "share_pct": share_pct,
+        "signed": False,
+        "deducted_at_share_out": False,
+        "deducted_amount": 0,
+    })
+
+
+# ════════════════════════════════════════════════════════════════════
+# T2-14  dt_notification  (m_client, multi-row)
+# ════════════════════════════════════════════════════════════════════
+
+@tool
+def list_notifications(client_id: int):
+    """Answers: 'What notifications does member #N have?' Returns full list with read/unread state."""
+    print(f"[Tool] Fetching notifications for client #{client_id}...")
+    return _entries("dt_notification", client_id)
+
+
+@tool
+def push_notification(
+    client_id: int,
+    event_type: str,
+    title: str,
+    body: str,
+    event_created_at: str,
+    priority: str = "normal",
+    delivered_via: str = "in-app",
+    payload_json: str = None,
+):
+    """Answers: 'Send notification to member #N'. event_type tags ('loan_approved', 'meeting_t1h', etc.).
+    priority: low | normal | high. delivered_via: in-app | fcm | sms.
+    event_created_at: app-level event timestamp (Fineract auto-tracks db row created_at separately)."""
+    print(f"[Tool] Pushing notification to client #{client_id}: {event_type}...")
+    return _create_entry("dt_notification", client_id, {
+        "event_type": event_type,
+        "title": title,
+        "body": body,
+        "payload_json": payload_json,
+        "event_created_at": event_created_at,
+        "read": False,
+        "priority": priority,
+        "delivered_via": delivered_via,
+    }, with_dates=True)
+
+
+# ════════════════════════════════════════════════════════════════════
+# T2-15  dt_member_invitation  (m_client, multi-row)
+# ════════════════════════════════════════════════════════════════════
+
+@tool
+def list_invitations(client_id: int):
+    """Answers: 'Show invitations issued by member #N'."""
+    print(f"[Tool] Fetching invitations issued by client #{client_id}...")
+    return _entries("dt_member_invitation", client_id)
+
+
+@tool
+def create_invitation(
+    client_id: int,
+    stewardship_code: str,
+    invited_at: str,
+    expires_at: str,
+    target_center_id: int,
+    channel: str = "sms",
+):
+    """Answers: 'Issue an invitation code from member #N'. stewardship_code is a 6-char one-time code;
+    channel: sms | email."""
+    print(f"[Tool] Creating invitation from client #{client_id} (code={stewardship_code})...")
+    return _create_entry("dt_member_invitation", client_id, {
+        "stewardship_code": stewardship_code,
+        "invited_at": invited_at,
+        "expires_at": expires_at,
+        "used": False,
+        "used_at": None,
+        "target_center_id": target_center_id,
+        "channel": channel,
+    }, with_dates=True)

--- a/python/tools/domains/self_service.py
+++ b/python/tools/domains/self_service.py
@@ -1,0 +1,115 @@
+# Copyright since 2025 Mifos Initiative
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+
+import requests
+from langchain_core.tools import tool
+
+from tools.mcp_adapter import fineract_client
+
+# Self-service endpoints (/self/*) accept any user's credentials, not just the
+# staff user baked into FineractAdapter via .env. Each tool below takes
+# optional username/password; when omitted, the env staff credentials are used
+# so the tool still functions for AI-assistant flows that authenticate as staff.
+
+
+def _resolve_credentials(username: str = None, password: str = None):
+    return (
+        username or os.getenv("MIFOSX_USERNAME"),
+        password or os.getenv("MIFOSX_PASSWORD"),
+    )
+
+
+def _self_get(endpoint: str, username: str = None, password: str = None):
+    url = f"{fineract_client.base_url}/{endpoint}"
+    user, pw = _resolve_credentials(username, password)
+    try:
+        response = requests.get(
+            url,
+            headers={
+                "Fineract-Platform-TenantId": fineract_client.tenant_id,
+                "Content-Type": "application/json",
+            },
+            auth=(user, pw),
+            verify=False,
+        )
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.RequestException as e:
+        if e.response is not None:
+            return {"error": fineract_client._parse_fineract_error(e.response)}
+        return {"error": f"Connection failed: {str(e)}"}
+
+
+def _self_post(endpoint: str, payload: dict, username: str = None, password: str = None):
+    url = f"{fineract_client.base_url}/{endpoint}"
+    user, pw = _resolve_credentials(username, password)
+    try:
+        response = requests.post(
+            url,
+            headers={
+                "Fineract-Platform-TenantId": fineract_client.tenant_id,
+                "Content-Type": "application/json",
+            },
+            auth=(user, pw),
+            json=payload,
+            verify=False,
+        )
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.RequestException as e:
+        if e.response is not None:
+            return {"error": fineract_client._parse_fineract_error(e.response)}
+        return {"error": f"Connection failed: {str(e)}"}
+
+
+# --- T1-1 STAFF AUTHENTICATION ---
+
+@tool
+def authenticate(username: str, password: str):
+    """Answers: 'Authenticate as staff user'. Returns a base64 auth key plus role info.
+    Use the returned key in subsequent calls; this is what the consumer Kotlin client caches."""
+    print(f"[Tool] Authenticating staff user '{username}'...")
+    payload = {"username": username, "password": password}
+    return _self_post("authentication", payload, username, password)
+
+
+# --- T1-2 SELF-SERVICE AUTHENTICATION ---
+
+@tool
+def self_authenticate(username: str, password: str):
+    """Answers: 'Authenticate as a self-service end-user'. Returns a base64 auth key + clientId.
+    Distinct from staff /authentication: the user must be a self-service-enabled client."""
+    print(f"[Tool] Self-authenticating end-user '{username}'...")
+    payload = {"username": username, "password": password}
+    return _self_post("self/authentication", payload, username, password)
+
+
+# --- T1-3 GET SELF CLIENT PROFILE ---
+
+@tool
+def get_self_client(username: str = None, password: str = None):
+    """Answers: 'Show my own client profile'. Self-service users only see themselves."""
+    print("[Tool] Fetching self client profile...")
+    return _self_get("self/clients", username, password)
+
+
+# --- T1-4 LIST SELF SAVINGS ACCOUNTS ---
+
+@tool
+def list_self_savings(username: str = None, password: str = None):
+    """Answers: 'List my own savings accounts'."""
+    print("[Tool] Fetching self savings accounts...")
+    return _self_get("self/savingsaccounts", username, password)
+
+
+# --- T1-5 LIST SELF LOAN ACCOUNTS ---
+
+@tool
+def list_self_loans(username: str = None, password: str = None):
+    """Answers: 'List my own loan accounts'."""
+    print("[Tool] Fetching self loan accounts...")
+    return _self_get("self/loans", username, password)

--- a/python/tools/registry.py
+++ b/python/tools/registry.py
@@ -57,6 +57,47 @@ from tools.domains.savings import (
     withdraw_savings,
 )
 from tools.domains.staff import get_office_details, get_staff_details, list_offices, list_staff
+from tools.domains.self_service import (
+    authenticate,
+    get_self_client,
+    list_self_loans,
+    list_self_savings,
+    self_authenticate,
+)
+from tools.domains.batch import send_batch
+from tools.domains.group_banking import (
+    add_loan_guarantor,
+    advance_cycle,
+    assign_member_role,
+    create_invitation,
+    get_group_config,
+    get_group_corpus,
+    get_loan_policy,
+    get_loan_vote,
+    get_member_ceiling,
+    get_member_role,
+    get_social_fund,
+    get_sync_state,
+    list_attendance,
+    list_invitations,
+    list_loan_guarantors,
+    list_loan_requests,
+    list_meetings,
+    list_notifications,
+    list_share_outs,
+    push_notification,
+    record_attendance,
+    record_loan_vote,
+    record_meeting,
+    record_share_out,
+    set_loan_policy,
+    set_member_ceiling,
+    submit_loan_request,
+    update_group_corpus,
+    update_social_fund,
+    update_sync_state,
+    upsert_group_config,
+)
 
 
 class DomainRegistry:
@@ -128,6 +169,30 @@ class DomainRegistry:
             ],
             "codetables": [
                 list_codes, get_code_values, list_datatables
+            ],
+            "self_service": [
+                authenticate, self_authenticate, get_self_client,
+                list_self_savings, list_self_loans
+            ],
+            "batch": [
+                send_batch
+            ],
+            "group_banking": [
+                get_group_config, upsert_group_config, advance_cycle,
+                list_meetings, record_meeting,
+                list_attendance, record_attendance,
+                get_member_role, assign_member_role,
+                list_share_outs, record_share_out,
+                get_social_fund, update_social_fund,
+                get_loan_vote, record_loan_vote,
+                get_sync_state, update_sync_state,
+                list_loan_requests, submit_loan_request,
+                get_group_corpus, update_group_corpus,
+                get_loan_policy, set_loan_policy,
+                get_member_ceiling, set_member_ceiling,
+                list_loan_guarantors, add_loan_guarantor,
+                list_notifications, push_notification,
+                list_invitations, create_invitation,
             ]
         }
 
@@ -212,6 +277,22 @@ class DomainRegistry:
         # Code Tables
         if matches_keyword(["code", "dropdown", "code value", "gender", "id type", "datatable", "custom field"]):
             active_domains.add("codetables")
+
+        # Self-service / End-user auth
+        if matches_keyword(["self", "self-service", "my profile", "my savings", "my loans",
+                            "authenticate", "login", "sign in"]):
+            active_domains.add("self_service")
+
+        # Batch
+        if matches_keyword(["batch", "bulk", "outbox", "drain", "queue"]):
+            active_domains.add("batch")
+
+        # Group banking / VSLA
+        if matches_keyword(["meeting", "attendance", "share-out", "share out", "cycle",
+                            "corpus", "social fund", "guarantor", "ceiling", "policy",
+                            "invitation", "stewardship", "notification", "vote",
+                            "vsla", "rosca", "group banking"]):
+            active_domains.add("group_banking")
 
         # Default: return clients for basic lookup if nothing matched
         if not active_domains:


### PR DESCRIPTION
## Summary

This PR extends **mcp-mifosx** to fully back the openMF **CommonPurse** (mifos-x-group-banking) KMP app on top of Fineract, in two layers:

- **A — Python MCP tools** (`python/`): datatable CRUD + VSLA/group-banking + self-service operations that expose the Fineract capabilities the app needs as MCP tools.
- **B — Go companion REST facade** (`go/companion/`): a thin `/companion/*` HTTP layer the app talks to directly, reshaping Fineract responses into the app's DTO contracts and aggregating the multi-call reads it fans in.

---

## Part A — Python MCP tools (`python/`)

- Add 5 MCP tools for Fineract datatable CRUD (`create_datatable`, `get_datatable_entries`, `create_datatable_entry`, `update_datatable_entry`, `delete_datatable_entry`) — domain functions in `codetables.py` with a `_map_column_type` helper; registrations in `mcp_server.py` with input validation (apptable whitelist, column-format checks, list→dict response wrapping).
- Group-banking / VSLA operations (`group_banking.py`), self-service auth + profile (`self_service.py`), and batch submission (`batch.py`).
- Foundation for TIER-2 API extensions — lets KMP consumer apps extend Fineract via datatables where native APIs don't exist.

## Part B — Go companion REST facade (`go/companion/`)

A `/companion/*` REST facade the CommonPurse app consumes directly. It sits in front of Fineract, forwards the end-user credential to `POST /authentication` (so a wrong password is a real 401, not masked by the service credential), and aggregates/reshapes reads + writes into the app's DTOs. The only server change is one wiring line in `server/http_server.go` (`companion.New(fineract).RegisterRoutes(mux)` after the existing `/api/<tool>` loop); no existing tool files are touched. It pairs with Part A — the write endpoints provision + write the `dt_group_type_config` / `dt_companion_invitations` / `dt_share_out` / `dt_rosca_rotation` datatables.

Endpoints:

| Group | Routes |
|---|---|
| **auth** | `POST /companion/auth/{login,self-register}`, `GET /companion/auth/me` |
| **groups** | `GET /companion/groups{,/mine,/{id},/{id}/{my-role,corpus,accounts,members,dashboard}}` (read + 4-way dashboard fan-in) |
| **organizer** | `GET /companion/organizer/dashboard` (KPI aggregation) |
| **members** | member-list, savings (group/individual/member-detail), `GET /companion/member/dashboard` |
| **loans** | loan-list + loan-detail reads; `POST` apply / repayment / writeoff |
| **group-create** | `POST /companion/groups` (create + activate + `dt_group_type_config` row) |
| **invites** | generate / list / revoke over `dt_companion_invitations` |
| **share-out** | preview compute; `POST` `.../shareout/execute` + `.../rotation/execute` (per-member savings withdrawals + `dt_share_out` / `dt_rosca_rotation`) |
| **catalogue** | `GET /companion/datatables/group_type_config` (9 VSLA archetypes) |
| **passthrough** | `GET /offices` |

**Date-format handling:** fields the app parses with kotlinx `Instant.parse` (auth `joinedAt` / `tokenExpiresAt`) are emitted as full ISO-8601 (`fmtFineractInstant`); `LocalDate.parse` fields as `YYYY-MM-DD` (`fmtFineractDate`); datatable string columns round-trip verbatim (no Fineract `dateFormat`).

**Verified live** against a self-service-enabled Fineract instance: real login, group creation, member invite, loan repayment, and share-out all execute and persist end to end. `go build ./...` and `go vet ./companion/...` clean.

---

## Test plan

**Python tools**
- [ ] Restart MCP server and verify the new tools appear in the tool listing
- [ ] `create_datatable` with valid apptable (`m_group`) + columns; and with an invalid apptable → error response
- [ ] `create_datatable_entry` / `get_datatable_entries` / `update_datatable_entry` / `delete_datatable_entry` lifecycle
- [ ] Verify list→dict wrapping for `get_datatable_entries`

**Go companion facade**
- [ ] `PORT=8080 go run .` → `GET /health` UP; `go build ./...` + `go vet ./companion/...` clean
- [ ] `POST /companion/auth/login` valid → 200 + `groupMemberships`; wrong password → 401
- [ ] `GET /companion/organizer/dashboard` + `/companion/groups/{id}/dashboard` return aggregated real data
- [ ] `POST /companion/groups` creates + activates a real group + `dt_group_type_config` row
- [ ] invite generate/list/revoke; loan repayment reduces outstanding; share-out execute distributes the corpus

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added companion authentication, registration, session, group, member, savings, loan, dashboard, organizer, and office endpoints.
  * Added group creation, invitations, share-out previews and execution, member management, group-type catalogues, and meeting lifecycle support.
  * Added datatable management, batch operation submission, group banking and VSLA tools, and self-service account access.
  * Improved tool responses with consistent value and list formatting.
* **Bug Fixes**
  * Added validation and clearer error handling for invalid requests and upstream failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->