### PR TITLE
refactor(python): centralize Fineract date formatting helper

### DIFF
--- a/python/tools/domains/clients.py
+++ b/python/tools/domains/clients.py
@@ -3,12 +3,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import datetime
 from typing import Optional
 
 from langchain_core.tools import tool
 
 from tools.mcp_adapter import fineract_client
+from tools.utils import get_fineract_today
 
 # --- CLIENT SEARCH & READ OPERATIONS ---
 
@@ -38,7 +38,7 @@ def get_client_accounts(client_id: int):
 def create_client(firstname: str, lastname: str, mobile_no: str = None, office_id: int = 1, is_active: bool = True):
     """Answers: 'Create a new client named John Doe'"""
     print(f"[Tool] Creating client: {firstname} {lastname}...")
-    today = datetime.datetime.now().strftime("%d %B %Y")
+    today = get_fineract_today()
 
     payload = {
         "officeId": office_id,
@@ -63,7 +63,7 @@ def create_client(firstname: str, lastname: str, mobile_no: str = None, office_i
 def activate_client(client_id: int):
     """Answers: 'Activate this pending client profile'"""
     print(f"[Tool] Activating Client #{client_id}...")
-    today = datetime.datetime.now().strftime("%d %B %Y")
+    today = get_fineract_today()
 
     payload = {
         "activationDate": today,
@@ -86,7 +86,7 @@ def update_client_mobile(client_id: int, new_mobile_no: str):
 def close_client(client_id: int, closure_reason_id: int = 17):
     """Answers: 'Close this client's profile, they are leaving the bank'"""
     print(f"[Tool] Closing Client #{client_id}...")
-    today = datetime.datetime.now().strftime("%d %B %Y")
+    today = get_fineract_today()
 
     payload = {
         "closureDate": today,
@@ -103,7 +103,7 @@ def close_client(client_id: int, closure_reason_id: int = 17):
 def create_group(name: str, office_id: int = 1, client_members: list = None):
     """Answers: 'Create a new lending group called The Innovators'"""
     print(f"[Tool] Creating Group: {name}...")
-    today = datetime.datetime.now().strftime("%d %B %Y")
+    today = get_fineract_today()
 
     payload = {
         "officeId": office_id,
@@ -163,7 +163,7 @@ def get_client_charges(client_id: int):
 def apply_client_charge(client_id: int, charge_id: int, amount: float):
     """Answers: 'Apply a one-time onboarding fee of $50 to this client'"""
     print(f"[Tool] Applying charge {charge_id} to Client #{client_id}...")
-    today = datetime.datetime.now().strftime("%d %B %Y")
+    today = get_fineract_today()
     payload = {
         "chargeId": charge_id,
         "amount": amount,

--- a/python/tools/domains/groups.py
+++ b/python/tools/domains/groups.py
@@ -3,11 +3,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import datetime
 
 from langchain_core.tools import tool
 
 from tools.mcp_adapter import fineract_client
+from tools.utils import get_fineract_today
 
 # --- GROUP OPERATIONS ---
 
@@ -42,7 +42,7 @@ def create_group(name: str, office_id: int, external_id: str = None):
 def activate_group(group_id: int):
     """Answers: 'Activate this pending group'"""
     print(f"[Tool] Activating Group #{group_id}...")
-    today = datetime.datetime.now().strftime("%d %B %Y")
+    today = get_fineract_today()
     payload = {
         "activationDate": today,
         "dateFormat": "dd MMMM yyyy",

--- a/python/tools/domains/loans.py
+++ b/python/tools/domains/loans.py
@@ -3,12 +3,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import datetime
 from typing import Optional
 
 from langchain_core.tools import tool
 
 from tools.mcp_adapter import fineract_client
+from tools.utils import get_fineract_today
 
 # --- LOAN READ OPERATIONS ---
 
@@ -118,7 +118,7 @@ def get_overdue_loans(client_id: int):
 def create_loan(client_id: int, principal: float, months: int, product_id: int = 1):
     """Answers: 'Create a new loan for Client X for MXN 20,000 over 12 months'"""
     print(f"[Tool] Creating {principal} loan for Client #{client_id}...")
-    today = datetime.datetime.now().strftime("%d %B %Y")
+    today = get_fineract_today()
 
     payload = {
         "clientId": client_id,
@@ -146,7 +146,7 @@ def create_loan(client_id: int, principal: float, months: int, product_id: int =
 def create_group_loan(group_id: int, principal: float, months: int, product_id: int = 1):
     """Answers: 'Create a group loan for Group #5 for $10,000 over 6 months'"""
     print(f"[Tool] Creating {principal} group loan for Group #{group_id}...")
-    today = datetime.datetime.now().strftime("%d %B %Y")
+    today = get_fineract_today()
 
     payload = {
         "groupId": group_id,
@@ -173,7 +173,7 @@ def create_group_loan(group_id: int, principal: float, months: int, product_id: 
 @tool
 def approve_and_disburse_loan(loan_id: int, amount: float = None):
     """Answers: 'Approve this loan and disburse today'"""
-    today = datetime.datetime.now().strftime("%d %B %Y")
+    today = get_fineract_today()
     base_payload = {"dateFormat": "dd MMMM yyyy", "locale": "en"}
 
     # Step 1: Approve
@@ -193,7 +193,7 @@ def approve_and_disburse_loan(loan_id: int, amount: float = None):
 def reject_loan_application(loan_id: int, note: str = "Rejected via AI Agent due to risk profile"):
     """Answers: 'Reject this loan application'"""
     print(f"[Tool] Rejecting Loan #{loan_id}...")
-    today = datetime.datetime.now().strftime("%d %B %Y")
+    today = get_fineract_today()
 
     payload = {
         "rejectedOnDate": today,
@@ -210,7 +210,7 @@ def reject_loan_application(loan_id: int, note: str = "Rejected via AI Agent due
 def make_loan_repayment(loan_id: int, amount: float):
     """Answers: 'The client just paid $150 towards their loan.'"""
     print(f"[Tool] Logging repayment of {amount} on Loan #{loan_id}...")
-    today = datetime.datetime.now().strftime("%d %B %Y")
+    today = get_fineract_today()
 
     payload = {
         "transactionDate": today,
@@ -225,7 +225,7 @@ def make_loan_repayment(loan_id: int, amount: float):
 def apply_late_fee(loan_id: int, fee_amount: float, charge_id: int = 2):
     """Answers: 'Apply a late fee to the last missed installment'"""
     print(f"[Tool] Applying late fee of {fee_amount} to Loan #{loan_id}...")
-    today = datetime.datetime.now().strftime("%d %B %Y")
+    today = get_fineract_today()
 
     payload = {
         "chargeId": charge_id,
@@ -240,7 +240,7 @@ def apply_late_fee(loan_id: int, fee_amount: float, charge_id: int = 2):
 def waive_interest(loan_id: int, amount: float, note: str = "AI Authorized Waiver"):
     """Answers: 'Waive $50 of interest on this loan to help the client'"""
     print(f"[Tool] Waiving interest of {amount} on Loan #{loan_id}...")
-    today = datetime.datetime.now().strftime("%d %B %Y")
+    today = get_fineract_today()
 
     payload = {
         "transactionDate": today,
@@ -290,7 +290,7 @@ def reschedule_loan(loan_id: int, reschedule_from_date: str, adjusted_due_date: 
     Submits a loan reschedule request. Dates must be in 'dd MMMM yyyy' format (e.g. '15 March 2026').
     At least one modification (adjusted_due_date, new_interest_rate, grace_on_principal, or extra_terms) is required."""
     print(f"[Tool] Submitting reschedule request for Loan #{loan_id}...")
-    today = datetime.datetime.now().strftime("%d %B %Y")
+    today = get_fineract_today()
 
     payload = {
         "loanId": loan_id,

--- a/python/tools/domains/savings.py
+++ b/python/tools/domains/savings.py
@@ -3,11 +3,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import datetime
 
 from langchain_core.tools import tool
 
 from tools.mcp_adapter import fineract_client
+from tools.utils import get_fineract_today
 
 # --- SAVINGS READ & SEARCH OPERATIONS ---
 
@@ -33,7 +33,7 @@ def get_savings_transactions(account_id: int):
 def create_savings_account(client_id: int, product_id: int = 1):
     """Answers: 'Open a new savings account for this client'"""
     print(f"[Tool] Opening Savings Account for Client #{client_id}...")
-    today = datetime.datetime.now().strftime("%d %B %Y")
+    today = get_fineract_today()
 
     payload = {
         "clientId": client_id,
@@ -48,7 +48,7 @@ def create_savings_account(client_id: int, product_id: int = 1):
 def approve_and_activate_savings(account_id: int):
     """Answers: 'Approve and activate this pending savings account'"""
     print(f"[Tool] Approving & Activating Savings Account #{account_id}...")
-    today = datetime.datetime.now().strftime("%d %B %Y")
+    today = get_fineract_today()
     base_payload = {"dateFormat": "dd MMMM yyyy", "locale": "en"}
 
     # Step 1: Approve
@@ -64,7 +64,7 @@ def approve_and_activate_savings(account_id: int):
 def close_savings_account(account_id: int):
     """Answers: 'Close this savings account'"""
     print(f"[Tool] Closing Savings Account #{account_id}...")
-    today = datetime.datetime.now().strftime("%d %B %Y")
+    today = get_fineract_today()
 
     payload = {
         "closedOnDate": today,
@@ -80,7 +80,7 @@ def close_savings_account(account_id: int):
 def deposit_savings(account_id: int, amount: float):
     """Answers: 'Deposit $500 into this savings account'"""
     print(f"[Tool] Depositing {amount} into Savings Account #{account_id}...")
-    today = datetime.datetime.now().strftime("%d %B %Y")
+    today = get_fineract_today()
 
     payload = {
         "transactionDate": today,
@@ -95,7 +95,7 @@ def deposit_savings(account_id: int, amount: float):
 def withdraw_savings(account_id: int, amount: float):
     """Answers: 'Withdraw $100 from this savings account'"""
     print(f"[Tool] Withdrawing {amount} from Savings Account #{account_id}...")
-    today = datetime.datetime.now().strftime("%d %B %Y")
+    today = get_fineract_today()
 
     payload = {
         "transactionDate": today,
@@ -110,7 +110,7 @@ def withdraw_savings(account_id: int, amount: float):
 def apply_savings_charge(account_id: int, amount: float, charge_id: int = 1):
     """Answers: 'Deduct a $15 account maintenance fee from this savings account'"""
     print(f"[Tool] Applying charge of {amount} to Savings Account #{account_id}...")
-    today = datetime.datetime.now().strftime("%d %B %Y")
+    today = get_fineract_today()
 
     payload = {
         "chargeId": charge_id,

--- a/python/tools/utils.py
+++ b/python/tools/utils.py
@@ -5,6 +5,12 @@
 
 import datetime
 
+_ENGLISH_MONTHS = (
+    "", "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December"
+)
+
 def get_fineract_today() -> str:
     """Returns today's date formatted as expected by Fineract (e.g., '14 March 2026')."""
-    return datetime.datetime.now().strftime("%d %B %Y")
+    now = datetime.datetime.now()
+    return f"{now.day:02d} {_ENGLISH_MONTHS[now.month]} {now.year}"

--- a/python/tools/utils.py
+++ b/python/tools/utils.py
@@ -1,0 +1,10 @@
+# Copyright since 2025 Mifos Initiative
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import datetime
+
+def get_fineract_today() -> str:
+    """Returns today's date formatted as expected by Fineract (e.g., '14 March 2026')."""
+    return datetime.datetime.now().strftime("%d %B %Y")


### PR DESCRIPTION
This PR centralizes duplicated Fineract date formatting logic in the Python implementation.

Previously, multiple domain modules repeated:

```python
datetime.datetime.now().strftime("%d %B %Y")
```

This logic is now extracted into a reusable helper:

```python
get_fineract_today()
```

### Changes

* Added `tools.utils.get_fineract_today`
* Replaced duplicated date formatting usages across:

  * `clients.py`
  * `groups.py`
  * `loans.py`
  * `savings.py`
* Removed unused `datetime` imports where applicable

This improves maintainability and keeps date formatting logic centralized while preserving existing behavior unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized date handling across client, group, loan, and savings domain modules by centralizing date formatting logic. This improves consistency and maintainability of date operations throughout the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/mcp-mifosx/pull/377?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->