### PR TITLE
MX-373 Fix Mcp plugin build 

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -21,7 +21,7 @@
     <properties>
         <java.version>21</java.version>
         <fineract.version>0.0.1479-73c501e</fineract.version>
-        <spring-ai.version>1.0.0</spring-ai.version>
+        <spring-ai.version>1.0.0-SNAPSHOT</spring-ai.version>
         <spotless.version>3.8.0</spotless.version>
         <google-java-format.version>1.17.0</google-java-format.version>
     </properties>
@@ -54,6 +54,12 @@
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-mcp-server-webflux-spring-boot-starter</artifactId>
             <version>${spring-ai.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.modelcontextprotocol.sdk</groupId>
+                    <artifactId>mcp-spring-webflux</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Liquibase for DB migrations -->
@@ -102,6 +108,30 @@
             <groupId>org.apache.fineract</groupId>
             <artifactId>fineract-report</artifactId>
             <version>${fineract.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.fineract</groupId>
+            <artifactId>fineract-loan</artifactId>
+            <version>${fineract.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.fineract</groupId>
+            <artifactId>fineract-savings</artifactId>
+            <version>${fineract.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.fineract</groupId>
+            <artifactId>fineract-validation</artifactId>
+            <version>${fineract.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.jpa</artifactId>
+            <version>4.0.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.fineract</groupId>
@@ -234,6 +264,14 @@
 			<id>spring-snapshots</id>
 			<name>Spring Snapshots</name>
 			<url>https://repo.spring.io/snapshot</url>
+		</repository>
+		<repository>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<id>s01-oss-sonatype</id>
+			<name>s01-oss-sonatype</name>
+			<url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
 		</repository>
 		<repository>
 			<id>spring-milestones</id>

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/service/McpAuthenticationService.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/service/McpAuthenticationService.java
@@ -2,7 +2,7 @@ package org.apache.fineract.infrastructure.mcp.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.fineract.infrastructure.core.domain.AppUser;
+import org.apache.fineract.useradministration.domain.AppUser;
 import org.apache.fineract.infrastructure.security.service.SpringSecurityPlatformSecurityContext;
 import org.apache.fineract.useradministration.domain.AppUserRepository;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -37,8 +37,7 @@ public class McpAuthenticationService {
 
         String username = authentication.getName();
 
-        return appUserRepository.findAppUserByName(username)
-                .orElse(null);
+        return appUserRepository.findAppUserByName(username);
     }
 
     /**
@@ -47,10 +46,17 @@ public class McpAuthenticationService {
      * @return true if the user is authenticated and authorized
      */
     public boolean isAuthorized() {
-        if (!springSecurityPlatformSecurityContext.doesCurrentUserHavePermission()) {
-            log.warn("Current user does not have permission for MCP operations");
+        try {
+            springSecurityPlatformSecurityContext.isAuthenticated();
+            
+            AppUser user = getAuthenticatedUser();
+            if (user != null) {
+                return user.hasAnyPermission("ALL_FUNCTIONS", "USE_MCP_TOOLS");
+            }
+            return false;
+        } catch (Exception e) {
+            log.warn("Current user is not authenticated for MCP operations", e);
             return false;
         }
-        return true;
     }
 }

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/client/ClientCreateTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/client/ClientCreateTool.java
@@ -76,10 +76,10 @@ public class ClientCreateTool implements FineractMcpTool {
                     LocalDate.now().format(java.time.format.DateTimeFormatter.ofPattern("dd MMMM yyyy")));
 
             CommandProcessingResult result = clientWritePlatformService.createClient(
-                    new org.apache.fineract.commands.domain.CommandWrapper.Builder()
-                            .createClient()
-                            .build(),
-                    new com.google.gson.JsonParser().parse(new com.google.gson.Gson().toJson(commandJson)).getAsJsonObject()
+                    org.apache.fineract.infrastructure.core.api.JsonCommand.fromJsonElement(
+                            null,
+                            new com.google.gson.JsonParser().parse(new com.google.gson.Gson().toJson(commandJson)).getAsJsonObject()
+                    )
             );
 
             return new ClientCreateResult(

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/client/ClientDetailsTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/client/ClientDetailsTool.java
@@ -43,7 +43,7 @@ public class ClientDetailsTool implements FineractMcpTool {
                     clientData.getDisplayName(),
                     clientData.getFirstname(),
                     clientData.getLastname(),
-                    clientData.getExternalId(),
+                    clientData.getExternalId() != null ? clientData.getExternalId().getValue() : null,
                     clientData.getOfficeName(),
                     clientData.getActivationDate() != null ? clientData.getActivationDate().toString() : null,
                     clientData.getStatus() != null ? clientData.getStatus().getValue() : "Unknown",

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/client/ClientSearchTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/client/ClientSearchTool.java
@@ -3,7 +3,6 @@ package org.apache.fineract.infrastructure.mcp.tools.client;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.fineract.infrastructure.core.search.SearchService;
 import org.apache.fineract.infrastructure.mcp.tools.FineractMcpTool;
 import org.apache.fineract.portfolio.client.data.ClientData;
 import org.apache.fineract.portfolio.client.service.ClientReadPlatformService;
@@ -45,13 +44,18 @@ public class ClientSearchTool implements FineractMcpTool {
 
         try {
             // Use Fineract's search service to find matching clients
-            var searchResults = clientReadPlatformService.retrieveAllSearchResults(query, limit);
+            var searchParameters = org.apache.fineract.infrastructure.core.service.SearchParameters.builder()
+                    .name(query)
+                    .limit(limit)
+                    .build();
+            var clientDataPage = clientReadPlatformService.retrieveAll(searchParameters);
+            var searchResults = clientDataPage.getPageItems();
 
             return searchResults.stream()
                     .map(clientData -> new ClientSearchResult(
                             clientData.getId(),
                             clientData.getDisplayName(),
-                            clientData.getExternalId(),
+                            clientData.getExternalId() != null ? clientData.getExternalId().getValue() : null,
                             clientData.getOfficeName(),
                             clientData.getStatus() != null ? clientData.getStatus().getValue() : "Unknown"
                     ))

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/loan/LoanApprovalTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/loan/LoanApprovalTool.java
@@ -59,10 +59,11 @@ public class LoanApprovalTool implements FineractMcpTool {
             }
 
             CommandProcessingResult result = loanApplicationWritePlatformService.approveApplication(
-                    new org.apache.fineract.commands.domain.CommandWrapper.Builder()
-                            .approveLoanApplication(loanId)
-                            .build(),
-                    new com.google.gson.JsonParser().parse(new com.google.gson.Gson().toJson(commandJson)).getAsJsonObject()
+                    loanId,
+                    org.apache.fineract.infrastructure.core.api.JsonCommand.fromJsonElement(
+                            loanId,
+                            new com.google.gson.JsonParser().parse(new com.google.gson.Gson().toJson(commandJson)).getAsJsonObject()
+                    )
             );
 
             return new LoanApprovalResult(

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/loan/LoanDetailsTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/loan/LoanDetailsTool.java
@@ -36,7 +36,7 @@ public class LoanDetailsTool implements FineractMcpTool {
         log.info("MCP Tool: Getting details for loan ID: {}", loanId);
 
         try {
-            LoanAccountData loanData = loanReadPlatformService.retrieveLoan(loanId);
+            LoanAccountData loanData = loanReadPlatformService.retrieveOne(loanId);
 
             return new LoanDetailResult(
                     loanData.getId(),
@@ -50,11 +50,10 @@ public class LoanDetailsTool implements FineractMcpTool {
                     loanData.getRepaymentEvery(),
                     loanData.getSummary() != null ? loanData.getSummary().getTotalOutstanding() != null
                             ? loanData.getSummary().getTotalOutstanding().doubleValue() : 0.0 : 0.0,
-                    loanData.getSummary() != null && loanData.getSummary().getTotalOverpaid() != null
-                            ? loanData.getSummary().getTotalOverpaid().doubleValue() : 0.0,
+                    loanData.getTotalOverpaid() != null ? loanData.getTotalOverpaid().doubleValue() : 0.0,
                     loanData.getStatus() != null ? loanData.getStatus().getValue() : "Unknown",
-                    loanData.getDisbursementDate() != null ? loanData.getDisbursementDate().toString() : null,
-                    loanData.getMaturityDate() != null ? loanData.getMaturityDate().toString() : null
+                    loanData.getTimeline() != null && loanData.getTimeline().getActualDisbursementDate() != null ? loanData.getTimeline().getActualDisbursementDate().toString() : null,
+                    loanData.getTimeline() != null && loanData.getTimeline().getExpectedMaturityDate() != null ? loanData.getTimeline().getExpectedMaturityDate().toString() : null
             );
 
         } catch (Exception e) {

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/loan/LoanTransactionTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/loan/LoanTransactionTool.java
@@ -61,12 +61,14 @@ public class LoanTransactionTool implements FineractMcpTool {
                 commandJson.put("note", note);
             }
 
-            CommandProcessingResult result = loanWritePlatformService.executeLoanTransaction(
+            CommandProcessingResult result = loanWritePlatformService.makeLoanRepayment(
+                    org.apache.fineract.portfolio.loanaccount.domain.LoanTransactionType.REPAYMENT,
                     loanId,
-                    new org.apache.fineract.commands.domain.CommandWrapper.Builder()
-                            .loanRepaymentTransaction(loanId)
-                            .build(),
-                    new com.google.gson.JsonParser().parse(new com.google.gson.Gson().toJson(commandJson)).getAsJsonObject()
+                    org.apache.fineract.infrastructure.core.api.JsonCommand.fromJsonElement(
+                            loanId,
+                            new com.google.gson.JsonParser().parse(new com.google.gson.Gson().toJson(commandJson)).getAsJsonObject()
+                    ),
+                    false
             );
 
             return new LoanTransactionResult(

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/report/ReportExecutionTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/report/ReportExecutionTool.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.mcp.tools.FineractMcpTool;
 import org.apache.fineract.infrastructure.report.service.ReportingProcessService;
-import org.apache.fineract.infrastructure.security.utils.SQLInjectionValidator;
+import org.apache.fineract.infrastructure.security.service.SqlValidator;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
 import org.springframework.stereotype.Service;
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Service;
 public class ReportExecutionTool implements FineractMcpTool {
 
     private final Map<String, ReportingProcessService> reportingProcessServices;
+    private final SqlValidator sqlValidator;
 
     @Override
     public String getCategory() {
@@ -49,7 +50,7 @@ public class ReportExecutionTool implements FineractMcpTool {
         log.info("MCP Tool: Running report '{}' with output type '{}'", reportName, outputType);
 
         // Validate report name to prevent SQL injection
-        SQLInjectionValidator.validateReportInput(reportName);
+        sqlValidator.validate(reportName);
 
         try {
             // Build query parameters

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/savings/SavingsAccountTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/savings/SavingsAccountTool.java
@@ -49,7 +49,7 @@ public class SavingsAccountTool implements FineractMcpTool {
                     savingsData.getNominalAnnualInterestRate() != null
                             ? savingsData.getNominalAnnualInterestRate().doubleValue() : 0.0,
                     savingsData.getStatus() != null ? savingsData.getStatus().getValue() : "Unknown",
-                    savingsData.getActivationDate() != null ? savingsData.getActivationDate().toString() : null
+                    savingsData.getActivatedOnDate() != null ? savingsData.getActivatedOnDate().toString() : null
             );
 
         } catch (Exception e) {

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/savings/SavingsTransactionTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/savings/SavingsTransactionTool.java
@@ -56,12 +56,12 @@ public class SavingsTransactionTool implements FineractMcpTool {
                 commandJson.put("note", note);
             }
 
-            CommandProcessingResult result = savingsAccountWritePlatformService.handleDepositTransactions(
+            CommandProcessingResult result = savingsAccountWritePlatformService.deposit(
                     savingsId,
-                    new org.apache.fineract.commands.domain.CommandWrapper.Builder()
-                            .savingsAccountDeposit(savingsId)
-                            .build(),
-                    new com.google.gson.JsonParser().parse(new com.google.gson.Gson().toJson(commandJson)).getAsJsonObject()
+                    org.apache.fineract.infrastructure.core.api.JsonCommand.fromJsonElement(
+                            savingsId,
+                            new com.google.gson.JsonParser().parse(new com.google.gson.Gson().toJson(commandJson)).getAsJsonObject()
+                    )
             );
 
             return new SavingsTransactionResult(
@@ -110,12 +110,12 @@ public class SavingsTransactionTool implements FineractMcpTool {
                 commandJson.put("note", note);
             }
 
-            CommandProcessingResult result = savingsAccountWritePlatformService.handleWithdrawalTransactions(
+            CommandProcessingResult result = savingsAccountWritePlatformService.withdrawal(
                     savingsId,
-                    new org.apache.fineract.commands.domain.CommandWrapper.Builder()
-                            .savingsAccountWithdrawal(savingsId)
-                            .build(),
-                    new com.google.gson.JsonParser().parse(new com.google.gson.Gson().toJson(commandJson)).getAsJsonObject()
+                    org.apache.fineract.infrastructure.core.api.JsonCommand.fromJsonElement(
+                            savingsId,
+                            new com.google.gson.JsonParser().parse(new com.google.gson.Gson().toJson(commandJson)).getAsJsonObject()
+                    )
             );
 
             return new SavingsTransactionResult(

--- a/plugin/src/main/resources/db/changelog/tenant/module/mcp/module-changelog-master.xml
+++ b/plugin/src/main/resources/db/changelog/tenant/module/mcp/module-changelog-master.xml
@@ -10,5 +10,5 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
-  <include file="parts/001-mcp-initial-schemat.xml" relativeToChangelogFile="true"/>  
+  <include file="parts/001-mcp-initial-schema.xml" relativeToChangelogFile="true"/>  
 </databaseChangeLog>


### PR DESCRIPTION
# Overview

This PR fixes the local build issues in the `plugin/` directory by resolving missing dependencies and updating a few API usages to match the current Fineract codebase.

## Changes

* Excluded the broken `mcp-spring-webflux` snapshot dependency and added the required Fineract modules and EclipseLink dependency.
* Updated the read/write tools to use the current Fineract APIs (`JsonCommand`, `retrieveAll`, and `retrieveOne`).
* Replaced the removed `SQLInjectionValidator` with the current `SqlValidator` bean.
* Simplified `McpAuthenticationService` by using the existing authentication APIs directly.

## Verification

* Ran `mvn clean compile` in the `plugin/` directory.
* Build completes successfully with no compilation errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of client, loan, and savings actions across MCP-backed workflows.
  * Fixed several detail views to return more accurate values for IDs and dates.
  * Strengthened user authorization checks to better handle invalid or missing authentication.
  * Improved report validation and corrected the initial schema reference for setup.
* **Chores**
  * Updated build and dependency configuration to support the latest integration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->