### PR TITLE
MX-374 Add centralized error sanitization for MCP tools

### DIFF
--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/service/McpErrorSanitizer.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/service/McpErrorSanitizer.java
@@ -1,0 +1,114 @@
+package org.apache.fineract.infrastructure.mcp.service;
+
+import java.util.Set;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * Centralized error sanitizer for MCP tool responses.
+ *
+ * <p>Intercepts all exceptions thrown by Fineract backend services and produces
+ * a clean, safe error message suitable for returning to the MCP client (LLM agent).
+ *
+ * <p>Security guarantees:
+ * <ul>
+ *   <li>SQL queries and fragments are never exposed</li>
+ *   <li>Absolute file/class paths are never exposed</li>
+ *   <li>Only whitelisted domain exception messages pass through</li>
+ *   <li>Unknown/fatal exceptions produce a generic safe fallback</li>
+ * </ul>
+ */
+@Service
+@Slf4j
+public class McpErrorSanitizer {
+
+    private static final String GENERIC_ERROR_MESSAGE =
+            "An internal error occurred while processing the request.";
+
+    /**
+     * Whitelisted exception class name suffixes. Only exceptions whose simple class name
+     * ends with one of these suffixes will have their original message passed through.
+     */
+    private static final Set<String> WHITELISTED_EXCEPTION_SUFFIXES = Set.of(
+            "NotFoundException",
+            "AccessDeniedException",
+            "PlatformApiDataValidationException",
+            "InvalidParameterException",
+            "UnsupportedParameterException",
+            "PlatformDataIntegrityException",
+            "PlatformServiceUnavailableException",
+            "UnrecognizedQueryParamException",
+            "InsufficientAccountBalanceException",
+            "LoanTransactionProcessingException",
+            "IllegalArgumentException"
+    );
+
+    // Patterns that indicate SQL content leaking through
+    private static final Pattern SQL_PATTERN = Pattern.compile(
+            "(?i)(SELECT\\s|INSERT\\s|UPDATE\\s|DELETE\\s|DROP\\s|ALTER\\s|CREATE\\s|TRUNCATE\\s"
+                    + "|FROM\\s+\\w+\\.\\w+|JOIN\\s|WHERE\\s|GROUP\\s+BY|ORDER\\s+BY|HAVING\\s"
+                    + "|sql|jdbc|hibernate|prepared\\s*statement)",
+            Pattern.CASE_INSENSITIVE
+    );
+
+    // Patterns that indicate absolute file paths or Java class paths
+    private static final Pattern PATH_PATTERN = Pattern.compile(
+            "(/[a-zA-Z0-9_.-]+){3,}|([a-zA-Z]:\\\\[^\\s]+)"
+                    + "|([a-zA-Z_$][a-zA-Z0-9_$]*\\.){3,}[a-zA-Z_$][a-zA-Z0-9_$]*"
+    );
+
+    // Patterns that indicate stack trace fragments
+    private static final Pattern STACK_TRACE_PATTERN = Pattern.compile(
+            "at\\s+[a-zA-Z0-9_$.]+\\([^)]*\\)|Caused\\s+by:|Exception\\s+in\\s+thread"
+    );
+
+    /**
+     * Sanitizes an exception into a safe error message for MCP responses.
+     *
+     * @param e        the exception to sanitize
+     * @param toolName a short label for the tool (used in logging only, never exposed)
+     * @return a sanitized error string safe to return to the MCP client
+     */
+    public String sanitize(Exception e, String toolName) {
+        if (e == null) {
+            log.error("MCP tool '{}' encountered a null exception", toolName);
+            return GENERIC_ERROR_MESSAGE;
+        }
+
+        // Log safe details at ERROR level, and keep the full trace at DEBUG to prevent PII leaks in standard logs
+        log.error("MCP tool '{}' encountered an error of type: {}", toolName, e.getClass().getSimpleName());
+        log.debug("Full exception trace for MCP tool '{}'", toolName, e);
+
+        // Check if the exception type is whitelisted
+        String exceptionClassName = e.getClass().getSimpleName();
+        boolean isWhitelisted = WHITELISTED_EXCEPTION_SUFFIXES.stream()
+                .anyMatch(exceptionClassName::endsWith);
+
+        if (!isWhitelisted) {
+            return GENERIC_ERROR_MESSAGE;
+        }
+
+        // The exception type is whitelisted — scrub the message content
+        String message = e.getMessage();
+        if (message == null || message.isBlank()) {
+            return GENERIC_ERROR_MESSAGE;
+        }
+
+        // Even for whitelisted exceptions, scrub SQL/path/stack-trace content
+        if (SQL_PATTERN.matcher(message).find()) {
+            log.warn("Scrubbed SQL content from whitelisted exception in tool '{}'", toolName);
+            return GENERIC_ERROR_MESSAGE;
+        }
+        if (PATH_PATTERN.matcher(message).find()) {
+            log.warn("Scrubbed path/class content from whitelisted exception in tool '{}'", toolName);
+            return GENERIC_ERROR_MESSAGE;
+        }
+        if (STACK_TRACE_PATTERN.matcher(message).find()) {
+            log.warn("Scrubbed stack trace content from whitelisted exception in tool '{}'", toolName);
+            return GENERIC_ERROR_MESSAGE;
+        }
+
+        return message;
+    }
+}

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/client/ClientCreateTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/client/ClientCreateTool.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.mcp.service.McpErrorSanitizer;
 import org.apache.fineract.infrastructure.mcp.tools.FineractMcpTool;
 import org.apache.fineract.portfolio.client.api.ClientApiConstants;
 import org.apache.fineract.portfolio.client.service.ClientWritePlatformService;
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Service;
 public class ClientCreateTool implements FineractMcpTool {
 
     private final ClientWritePlatformService clientWritePlatformService;
+    private final McpErrorSanitizer mcpErrorSanitizer;
 
     @Override
     public String getCategory() {
@@ -90,8 +92,7 @@ public class ClientCreateTool implements FineractMcpTool {
             );
 
         } catch (Exception e) {
-            log.error("Error creating client '{}' '{}'", firstName, lastName, e);
-            throw new RuntimeException("Failed to create client: " + e.getMessage(), e);
+            throw new RuntimeException(mcpErrorSanitizer.sanitize(e, "fineract_client_create"));
         }
     }
 

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/client/ClientDetailsTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/client/ClientDetailsTool.java
@@ -2,6 +2,7 @@ package org.apache.fineract.infrastructure.mcp.tools.client;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.infrastructure.mcp.service.McpErrorSanitizer;
 import org.apache.fineract.infrastructure.mcp.tools.FineractMcpTool;
 import org.apache.fineract.portfolio.client.data.ClientData;
 import org.apache.fineract.portfolio.client.service.ClientReadPlatformService;
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Service;
 public class ClientDetailsTool implements FineractMcpTool {
 
     private final ClientReadPlatformService clientReadPlatformService;
+    private final McpErrorSanitizer mcpErrorSanitizer;
 
     @Override
     public String getCategory() {
@@ -52,8 +54,7 @@ public class ClientDetailsTool implements FineractMcpTool {
             );
 
         } catch (Exception e) {
-            log.error("Error retrieving client details for ID: {}", clientId, e);
-            throw new RuntimeException("Failed to retrieve client details: " + e.getMessage(), e);
+            throw new RuntimeException(mcpErrorSanitizer.sanitize(e, "fineract_client_get"));
         }
     }
 

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/client/ClientSearchTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/client/ClientSearchTool.java
@@ -3,6 +3,7 @@ package org.apache.fineract.infrastructure.mcp.tools.client;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.infrastructure.mcp.service.McpErrorSanitizer;
 import org.apache.fineract.infrastructure.mcp.tools.FineractMcpTool;
 import org.apache.fineract.portfolio.client.data.ClientData;
 import org.apache.fineract.portfolio.client.service.ClientReadPlatformService;
@@ -22,6 +23,7 @@ import org.springframework.stereotype.Service;
 public class ClientSearchTool implements FineractMcpTool {
 
     private final ClientReadPlatformService clientReadPlatformService;
+    private final McpErrorSanitizer mcpErrorSanitizer;
 
     @Override
     public String getCategory() {
@@ -62,8 +64,7 @@ public class ClientSearchTool implements FineractMcpTool {
                     .toList();
 
         } catch (Exception e) {
-            log.error("Error searching clients with query: '{}'", query, e);
-            throw new RuntimeException("Failed to search clients: " + e.getMessage(), e);
+            throw new RuntimeException(mcpErrorSanitizer.sanitize(e, "fineract_client_search"));
         }
     }
 

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/loan/LoanApprovalTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/loan/LoanApprovalTool.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.mcp.service.McpErrorSanitizer;
 import org.apache.fineract.infrastructure.mcp.tools.FineractMcpTool;
 import org.apache.fineract.portfolio.loanaccount.service.LoanApplicationWritePlatformService;
 import org.springframework.ai.tool.annotation.Tool;
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Service;
 public class LoanApprovalTool implements FineractMcpTool {
 
     private final LoanApplicationWritePlatformService loanApplicationWritePlatformService;
+    private final McpErrorSanitizer mcpErrorSanitizer;
 
     @Override
     public String getCategory() {
@@ -75,8 +77,7 @@ public class LoanApprovalTool implements FineractMcpTool {
             );
 
         } catch (Exception e) {
-            log.error("Error approving loan ID: {}", loanId, e);
-            throw new RuntimeException("Failed to approve loan: " + e.getMessage(), e);
+            throw new RuntimeException(mcpErrorSanitizer.sanitize(e, "fineract_loan_approve"));
         }
     }
 

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/loan/LoanDetailsTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/loan/LoanDetailsTool.java
@@ -2,6 +2,7 @@ package org.apache.fineract.infrastructure.mcp.tools.loan;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.infrastructure.mcp.service.McpErrorSanitizer;
 import org.apache.fineract.infrastructure.mcp.tools.FineractMcpTool;
 import org.apache.fineract.portfolio.loanaccount.data.LoanAccountData;
 import org.apache.fineract.portfolio.loanaccount.service.LoanReadPlatformService;
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Service;
 public class LoanDetailsTool implements FineractMcpTool {
 
     private final LoanReadPlatformService loanReadPlatformService;
+    private final McpErrorSanitizer mcpErrorSanitizer;
 
     @Override
     public String getCategory() {
@@ -57,8 +59,7 @@ public class LoanDetailsTool implements FineractMcpTool {
             );
 
         } catch (Exception e) {
-            log.error("Error retrieving loan details for ID: {}", loanId, e);
-            throw new RuntimeException("Failed to retrieve loan details: " + e.getMessage(), e);
+            throw new RuntimeException(mcpErrorSanitizer.sanitize(e, "fineract_loan_get"));
         }
     }
 

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/loan/LoanTransactionTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/loan/LoanTransactionTool.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.mcp.service.McpErrorSanitizer;
 import org.apache.fineract.infrastructure.mcp.tools.FineractMcpTool;
 import org.apache.fineract.portfolio.loanaccount.service.LoanWritePlatformService;
 import org.springframework.ai.tool.annotation.Tool;
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Service;
 public class LoanTransactionTool implements FineractMcpTool {
 
     private final LoanWritePlatformService loanWritePlatformService;
+    private final McpErrorSanitizer mcpErrorSanitizer;
 
     @Override
     public String getCategory() {
@@ -81,8 +83,7 @@ public class LoanTransactionTool implements FineractMcpTool {
             );
 
         } catch (Exception e) {
-            log.error("Error processing repayment for loan ID: {}", loanId, e);
-            throw new RuntimeException("Failed to process repayment: " + e.getMessage(), e);
+            throw new RuntimeException(mcpErrorSanitizer.sanitize(e, "fineract_loan_repayment"));
         }
     }
 

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/report/ReportExecutionTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/report/ReportExecutionTool.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.infrastructure.mcp.service.McpErrorSanitizer;
 import org.apache.fineract.infrastructure.mcp.tools.FineractMcpTool;
 import org.apache.fineract.infrastructure.report.service.ReportingProcessService;
 import org.apache.fineract.infrastructure.security.service.SqlValidator;
@@ -22,6 +23,7 @@ public class ReportExecutionTool implements FineractMcpTool {
 
     private final Map<String, ReportingProcessService> reportingProcessServices;
     private final SqlValidator sqlValidator;
+    private final McpErrorSanitizer mcpErrorSanitizer;
 
     @Override
     public String getCategory() {
@@ -93,8 +95,7 @@ public class ReportExecutionTool implements FineractMcpTool {
             );
 
         } catch (Exception e) {
-            log.error("Error executing report '{}'", reportName, e);
-            throw new RuntimeException("Failed to execute report: " + e.getMessage(), e);
+            throw new RuntimeException(mcpErrorSanitizer.sanitize(e, "fineract_report_run"));
         }
     }
 

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/savings/SavingsAccountTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/savings/SavingsAccountTool.java
@@ -2,6 +2,7 @@ package org.apache.fineract.infrastructure.mcp.tools.savings;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.infrastructure.mcp.service.McpErrorSanitizer;
 import org.apache.fineract.infrastructure.mcp.tools.FineractMcpTool;
 import org.apache.fineract.portfolio.savings.data.SavingsAccountData;
 import org.apache.fineract.portfolio.savings.service.SavingsAccountReadPlatformService;
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Service;
 public class SavingsAccountTool implements FineractMcpTool {
 
     private final SavingsAccountReadPlatformService savingsAccountReadPlatformService;
+    private final McpErrorSanitizer mcpErrorSanitizer;
 
     @Override
     public String getCategory() {
@@ -53,8 +55,7 @@ public class SavingsAccountTool implements FineractMcpTool {
             );
 
         } catch (Exception e) {
-            log.error("Error retrieving savings account details for ID: {}", savingsId, e);
-            throw new RuntimeException("Failed to retrieve savings details: " + e.getMessage(), e);
+            throw new RuntimeException(mcpErrorSanitizer.sanitize(e, "fineract_savings_get"));
         }
     }
 

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/savings/SavingsTransactionTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/savings/SavingsTransactionTool.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.mcp.service.McpErrorSanitizer;
 import org.apache.fineract.infrastructure.mcp.tools.FineractMcpTool;
 import org.apache.fineract.portfolio.savings.service.SavingsAccountWritePlatformService;
 import org.springframework.ai.tool.annotation.Tool;
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Service;
 public class SavingsTransactionTool implements FineractMcpTool {
 
     private final SavingsAccountWritePlatformService savingsAccountWritePlatformService;
+    private final McpErrorSanitizer mcpErrorSanitizer;
 
     @Override
     public String getCategory() {
@@ -74,8 +76,7 @@ public class SavingsTransactionTool implements FineractMcpTool {
             );
 
         } catch (Exception e) {
-            log.error("Error processing deposit for savings account ID: {}", savingsId, e);
-            throw new RuntimeException("Failed to process deposit: " + e.getMessage(), e);
+            throw new RuntimeException(mcpErrorSanitizer.sanitize(e, "fineract_savings_deposit"));
         }
     }
 
@@ -128,8 +129,7 @@ public class SavingsTransactionTool implements FineractMcpTool {
             );
 
         } catch (Exception e) {
-            log.error("Error processing withdrawal for savings account ID: {}", savingsId, e);
-            throw new RuntimeException("Failed to process withdrawal: " + e.getMessage(), e);
+            throw new RuntimeException(mcpErrorSanitizer.sanitize(e, "fineract_savings_withdrawal"));
         }
     }
 


### PR DESCRIPTION
# Overview

This PR improves error handling in the MCP plugin by preventing internal Fineract exceptions from being exposed to the LLM. Instead of returning raw exception details, all errors are now sanitized before being sent back to the client.

## Changes

* Added a centralized `McpErrorSanitizer` to handle and sanitize exceptions across all MCP tools.
* Allowed only safe, user-facing exceptions to return their original messages.
* Filtered sensitive information such as SQL queries, file paths, and stack traces from error responses.
* Returned a generic error message for unexpected or internal exceptions.
* Updated all MCP tool endpoints to use the centralized sanitizer for consistent error handling.

## Verification

* Ran `./mvnw clean compile` successfully.
* Verified that all MCP tool endpoints now return sanitized error responses instead of raw backend exceptions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in MCP-backed actions so failures now return safer, sanitized messages instead of raw backend details.
  * Applied consistent safe error responses across client, loan, savings, report, and search operations.
  * Added protections against leaking sensitive information such as SQL content, file paths, class paths, or stack traces in user-facing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->