### PR TITLE
MX-376 Add explicit null safety and input validation to MCP tools

### DIFF
--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/client/ClientCreateTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/client/ClientCreateTool.java
@@ -51,6 +51,15 @@ public class ClientCreateTool implements FineractMcpTool {
         log.info("MCP Tool: Creating client '{}' '{}' in office {}", firstName, lastName, officeId);
 
         try {
+            if (firstName == null || firstName.isBlank()) {
+                throw new IllegalArgumentException("firstName is required and must not be blank");
+            }
+            if (lastName == null || lastName.isBlank()) {
+                throw new IllegalArgumentException("lastName is required and must not be blank");
+            }
+            if (officeId == null) {
+                throw new IllegalArgumentException("officeId is required");
+            }
             // Build the command JSON for client creation
             var commandJson = new java.util.HashMap<String, Object>();
             commandJson.put(ClientApiConstants.firstnameParamName, firstName);

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/client/ClientDetailsTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/client/ClientDetailsTool.java
@@ -38,6 +38,9 @@ public class ClientDetailsTool implements FineractMcpTool {
         log.info("MCP Tool: Getting details for client ID: {}", clientId);
 
         try {
+            if (clientId == null) {
+                throw new IllegalArgumentException("clientId is required");
+            }
             ClientData clientData = clientReadPlatformService.retrieveOne(clientId);
 
             return new ClientDetailResult(

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/client/ClientSearchTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/client/ClientSearchTool.java
@@ -45,6 +45,9 @@ public class ClientSearchTool implements FineractMcpTool {
         int limit = (maxResults != null && maxResults > 0) ? maxResults : 20;
 
         try {
+            if (query == null || query.isBlank()) {
+                throw new IllegalArgumentException("query is required and must not be blank");
+            }
             // Use Fineract's search service to find matching clients
             var searchParameters = org.apache.fineract.infrastructure.core.service.SearchParameters.builder()
                     .name(query)

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/loan/LoanApprovalTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/loan/LoanApprovalTool.java
@@ -44,6 +44,9 @@ public class LoanApprovalTool implements FineractMcpTool {
         log.info("MCP Tool: Approving loan ID: {}", loanId);
 
         try {
+            if (loanId == null) {
+                throw new IllegalArgumentException("loanId is required");
+            }
             LocalDate approveDate = (approvalDate != null && !approvalDate.isBlank())
                     ? LocalDate.parse(approvalDate)
                     : LocalDate.now();

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/loan/LoanDetailsTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/loan/LoanDetailsTool.java
@@ -38,6 +38,9 @@ public class LoanDetailsTool implements FineractMcpTool {
         log.info("MCP Tool: Getting details for loan ID: {}", loanId);
 
         try {
+            if (loanId == null) {
+                throw new IllegalArgumentException("loanId is required");
+            }
             LoanAccountData loanData = loanReadPlatformService.retrieveOne(loanId);
 
             return new LoanDetailResult(

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/loan/LoanTransactionTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/loan/LoanTransactionTool.java
@@ -46,6 +46,12 @@ public class LoanTransactionTool implements FineractMcpTool {
         log.info("MCP Tool: Processing repayment of {} for loan ID: {}", amount, loanId);
 
         try {
+            if (loanId == null) {
+                throw new IllegalArgumentException("loanId is required");
+            }
+            if (amount == null || !Double.isFinite(amount) || amount <= 0) {
+                throw new IllegalArgumentException("amount is required, must be a finite number, and greater than zero");
+            }
             LocalDate txnDate = (transactionDate != null && !transactionDate.isBlank())
                     ? LocalDate.parse(transactionDate)
                     : LocalDate.now();

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/report/ReportExecutionTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/report/ReportExecutionTool.java
@@ -51,10 +51,12 @@ public class ReportExecutionTool implements FineractMcpTool {
 
         log.info("MCP Tool: Running report '{}' with output type '{}'", reportName, outputType);
 
-        // Validate report name to prevent SQL injection
-        sqlValidator.validate(reportName);
-
         try {
+            if (reportName == null || reportName.isBlank()) {
+                throw new IllegalArgumentException("reportName is required and must not be blank");
+            }
+            // Validate report name to prevent SQL injection
+            sqlValidator.validate(reportName);
             // Build query parameters
             Map<String, String> queryParams = new HashMap<>();
             queryParams.put("output-type", outputType != null ? outputType : "JSON");

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/savings/SavingsAccountTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/savings/SavingsAccountTool.java
@@ -37,6 +37,9 @@ public class SavingsAccountTool implements FineractMcpTool {
         log.info("MCP Tool: Getting details for savings account ID: {}", savingsId);
 
         try {
+            if (savingsId == null) {
+                throw new IllegalArgumentException("savingsId is required");
+            }
             SavingsAccountData savingsData = savingsAccountReadPlatformService.retrieveOne(savingsId);
 
             return new SavingsDetailResult(

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/savings/SavingsTransactionTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/savings/SavingsTransactionTool.java
@@ -44,6 +44,12 @@ public class SavingsTransactionTool implements FineractMcpTool {
         log.info("MCP Tool: Processing deposit of {} for savings account ID: {}", amount, savingsId);
 
         try {
+            if (savingsId == null) {
+                throw new IllegalArgumentException("savingsId is required");
+            }
+            if (amount == null || !Double.isFinite(amount) || amount <= 0) {
+                throw new IllegalArgumentException("amount is required, must be a finite number, and greater than zero");
+            }
             LocalDate txnDate = (transactionDate != null && !transactionDate.isBlank())
                     ? LocalDate.parse(transactionDate)
                     : LocalDate.now();
@@ -97,6 +103,12 @@ public class SavingsTransactionTool implements FineractMcpTool {
         log.info("MCP Tool: Processing withdrawal of {} for savings account ID: {}", amount, savingsId);
 
         try {
+            if (savingsId == null) {
+                throw new IllegalArgumentException("savingsId is required");
+            }
+            if (amount == null || !Double.isFinite(amount) || amount <= 0) {
+                throw new IllegalArgumentException("amount is required, must be a finite number, and greater than zero");
+            }
             LocalDate txnDate = (transactionDate != null && !transactionDate.isBlank())
                     ? LocalDate.parse(transactionDate)
                     : LocalDate.now();


### PR DESCRIPTION
# Overview

This PR improves input validation across the MCP tool endpoints by adding null, blank, and positive-value checks for required inputs. This prevents `NullPointerException`s and ensures invalid requests are rejected with clear error messages before reaching the core logic.

## Changes

* Added null and blank validation for required inputs across the Client, Loan, Savings, and Report tools.
* Added positive-value checks for transaction amounts.
* Standardized validation by throwing `IllegalArgumentException`, which is already handled by `McpErrorSanitizer` to return user-friendly error messages.

## Verification

* Ran `./mvnw clean compile` successfully.
* Verified that all MCP tool endpoints reject missing or invalid inputs before execution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added clearer validation for required client, loan, savings, report, and search inputs.
  - Prevented invalid or incomplete requests from being processed.
  - Added positive-amount checks for loan repayments, savings deposits, and withdrawals.
  - Invalid requests now receive immediate, actionable errors before operations begin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->