### PR TITLE
MX-387 Enforce rigorous authorization checks across all MCP tools

### DIFF
--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/client/ClientCreateTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/client/ClientCreateTool.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.infrastructure.mcp.service.McpErrorSanitizer;
+import org.apache.fineract.infrastructure.mcp.service.McpAuthenticationService;
 import org.apache.fineract.infrastructure.mcp.tools.FineractMcpTool;
 import org.apache.fineract.portfolio.client.api.ClientApiConstants;
 import org.apache.fineract.portfolio.client.service.ClientWritePlatformService;
@@ -22,6 +23,7 @@ public class ClientCreateTool implements FineractMcpTool {
 
     private final ClientWritePlatformService clientWritePlatformService;
     private final McpErrorSanitizer mcpErrorSanitizer;
+    private final McpAuthenticationService mcpAuthenticationService;
 
     @Override
     public String getCategory() {
@@ -49,6 +51,10 @@ public class ClientCreateTool implements FineractMcpTool {
             String emailAddress) {
 
         log.info("MCP Tool: Creating client '{}' '{}' in office {}", firstName, lastName, officeId);
+
+        if (!mcpAuthenticationService.isAuthorized()) {
+            throw new SecurityException("User is not authorized to execute MCP tools. Required permissions: ALL_FUNCTIONS or USE_MCP_TOOLS");
+        }
 
         try {
             if (firstName == null || firstName.isBlank()) {

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/client/ClientDetailsTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/client/ClientDetailsTool.java
@@ -3,6 +3,7 @@ package org.apache.fineract.infrastructure.mcp.tools.client;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.mcp.service.McpErrorSanitizer;
+import org.apache.fineract.infrastructure.mcp.service.McpAuthenticationService;
 import org.apache.fineract.infrastructure.mcp.tools.FineractMcpTool;
 import org.apache.fineract.portfolio.client.data.ClientData;
 import org.apache.fineract.portfolio.client.service.ClientReadPlatformService;
@@ -20,6 +21,7 @@ public class ClientDetailsTool implements FineractMcpTool {
 
     private final ClientReadPlatformService clientReadPlatformService;
     private final McpErrorSanitizer mcpErrorSanitizer;
+    private final McpAuthenticationService mcpAuthenticationService;
 
     @Override
     public String getCategory() {
@@ -36,6 +38,10 @@ public class ClientDetailsTool implements FineractMcpTool {
             Long clientId) {
 
         log.info("MCP Tool: Getting details for client ID: {}", clientId);
+
+        if (!mcpAuthenticationService.isAuthorized()) {
+            throw new SecurityException("User is not authorized to execute MCP tools. Required permissions: ALL_FUNCTIONS or USE_MCP_TOOLS");
+        }
 
         try {
             if (clientId == null) {

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/client/ClientSearchTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/client/ClientSearchTool.java
@@ -4,6 +4,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.mcp.service.McpErrorSanitizer;
+import org.apache.fineract.infrastructure.mcp.service.McpAuthenticationService;
 import org.apache.fineract.infrastructure.mcp.tools.FineractMcpTool;
 import org.apache.fineract.portfolio.client.data.ClientData;
 import org.apache.fineract.portfolio.client.service.ClientReadPlatformService;
@@ -24,6 +25,7 @@ public class ClientSearchTool implements FineractMcpTool {
 
     private final ClientReadPlatformService clientReadPlatformService;
     private final McpErrorSanitizer mcpErrorSanitizer;
+    private final McpAuthenticationService mcpAuthenticationService;
 
     @Override
     public String getCategory() {
@@ -43,6 +45,10 @@ public class ClientSearchTool implements FineractMcpTool {
         log.info("MCP Tool: Searching clients with query: '{}'", query);
 
         int limit = (maxResults != null && maxResults > 0) ? maxResults : 20;
+
+        if (!mcpAuthenticationService.isAuthorized()) {
+            throw new SecurityException("User is not authorized to execute MCP tools. Required permissions: ALL_FUNCTIONS or USE_MCP_TOOLS");
+        }
 
         try {
             if (query == null || query.isBlank()) {

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/loan/LoanApprovalTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/loan/LoanApprovalTool.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.infrastructure.mcp.service.McpErrorSanitizer;
+import org.apache.fineract.infrastructure.mcp.service.McpAuthenticationService;
 import org.apache.fineract.infrastructure.mcp.tools.FineractMcpTool;
 import org.apache.fineract.portfolio.loanaccount.service.LoanApplicationWritePlatformService;
 import org.springframework.ai.tool.annotation.Tool;
@@ -21,6 +22,7 @@ public class LoanApprovalTool implements FineractMcpTool {
 
     private final LoanApplicationWritePlatformService loanApplicationWritePlatformService;
     private final McpErrorSanitizer mcpErrorSanitizer;
+    private final McpAuthenticationService mcpAuthenticationService;
 
     @Override
     public String getCategory() {
@@ -42,6 +44,10 @@ public class LoanApprovalTool implements FineractMcpTool {
             String note) {
 
         log.info("MCP Tool: Approving loan ID: {}", loanId);
+
+        if (!mcpAuthenticationService.isAuthorized()) {
+            throw new SecurityException("User is not authorized to execute MCP tools. Required permissions: ALL_FUNCTIONS or USE_MCP_TOOLS");
+        }
 
         try {
             if (loanId == null) {

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/loan/LoanDetailsTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/loan/LoanDetailsTool.java
@@ -3,6 +3,7 @@ package org.apache.fineract.infrastructure.mcp.tools.loan;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.mcp.service.McpErrorSanitizer;
+import org.apache.fineract.infrastructure.mcp.service.McpAuthenticationService;
 import org.apache.fineract.infrastructure.mcp.tools.FineractMcpTool;
 import org.apache.fineract.portfolio.loanaccount.data.LoanAccountData;
 import org.apache.fineract.portfolio.loanaccount.service.LoanReadPlatformService;
@@ -20,6 +21,7 @@ public class LoanDetailsTool implements FineractMcpTool {
 
     private final LoanReadPlatformService loanReadPlatformService;
     private final McpErrorSanitizer mcpErrorSanitizer;
+    private final McpAuthenticationService mcpAuthenticationService;
 
     @Override
     public String getCategory() {
@@ -36,6 +38,10 @@ public class LoanDetailsTool implements FineractMcpTool {
             Long loanId) {
 
         log.info("MCP Tool: Getting details for loan ID: {}", loanId);
+
+        if (!mcpAuthenticationService.isAuthorized()) {
+            throw new SecurityException("User is not authorized to execute MCP tools. Required permissions: ALL_FUNCTIONS or USE_MCP_TOOLS");
+        }
 
         try {
             if (loanId == null) {

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/loan/LoanTransactionTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/loan/LoanTransactionTool.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.infrastructure.mcp.service.McpErrorSanitizer;
+import org.apache.fineract.infrastructure.mcp.service.McpAuthenticationService;
 import org.apache.fineract.infrastructure.mcp.tools.FineractMcpTool;
 import org.apache.fineract.portfolio.loanaccount.service.LoanWritePlatformService;
 import org.springframework.ai.tool.annotation.Tool;
@@ -21,6 +22,7 @@ public class LoanTransactionTool implements FineractMcpTool {
 
     private final LoanWritePlatformService loanWritePlatformService;
     private final McpErrorSanitizer mcpErrorSanitizer;
+    private final McpAuthenticationService mcpAuthenticationService;
 
     @Override
     public String getCategory() {
@@ -44,6 +46,10 @@ public class LoanTransactionTool implements FineractMcpTool {
             String note) {
 
         log.info("MCP Tool: Processing repayment of {} for loan ID: {}", amount, loanId);
+
+        if (!mcpAuthenticationService.isAuthorized()) {
+            throw new SecurityException("User is not authorized to execute MCP tools. Required permissions: ALL_FUNCTIONS or USE_MCP_TOOLS");
+        }
 
         try {
             if (loanId == null) {

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/report/ReportExecutionTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/report/ReportExecutionTool.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.mcp.service.McpErrorSanitizer;
+import org.apache.fineract.infrastructure.mcp.service.McpAuthenticationService;
 import org.apache.fineract.infrastructure.mcp.tools.FineractMcpTool;
 import org.apache.fineract.infrastructure.report.service.ReportingProcessService;
 import org.apache.fineract.infrastructure.security.service.SqlValidator;
@@ -24,6 +25,7 @@ public class ReportExecutionTool implements FineractMcpTool {
     private final Map<String, ReportingProcessService> reportingProcessServices;
     private final SqlValidator sqlValidator;
     private final McpErrorSanitizer mcpErrorSanitizer;
+    private final McpAuthenticationService mcpAuthenticationService;
 
     @Override
     public String getCategory() {
@@ -50,6 +52,10 @@ public class ReportExecutionTool implements FineractMcpTool {
             Long loanOfficerId) {
 
         log.info("MCP Tool: Running report '{}' with output type '{}'", reportName, outputType);
+
+        if (!mcpAuthenticationService.isAuthorized()) {
+            throw new SecurityException("User is not authorized to execute MCP tools. Required permissions: ALL_FUNCTIONS or USE_MCP_TOOLS");
+        }
 
         try {
             if (reportName == null || reportName.isBlank()) {

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/savings/SavingsAccountTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/savings/SavingsAccountTool.java
@@ -3,6 +3,7 @@ package org.apache.fineract.infrastructure.mcp.tools.savings;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.mcp.service.McpErrorSanitizer;
+import org.apache.fineract.infrastructure.mcp.service.McpAuthenticationService;
 import org.apache.fineract.infrastructure.mcp.tools.FineractMcpTool;
 import org.apache.fineract.portfolio.savings.data.SavingsAccountData;
 import org.apache.fineract.portfolio.savings.service.SavingsAccountReadPlatformService;
@@ -20,6 +21,7 @@ public class SavingsAccountTool implements FineractMcpTool {
 
     private final SavingsAccountReadPlatformService savingsAccountReadPlatformService;
     private final McpErrorSanitizer mcpErrorSanitizer;
+    private final McpAuthenticationService mcpAuthenticationService;
 
     @Override
     public String getCategory() {
@@ -35,6 +37,10 @@ public class SavingsAccountTool implements FineractMcpTool {
             Long savingsId) {
 
         log.info("MCP Tool: Getting details for savings account ID: {}", savingsId);
+
+        if (!mcpAuthenticationService.isAuthorized()) {
+            throw new SecurityException("User is not authorized to execute MCP tools. Required permissions: ALL_FUNCTIONS or USE_MCP_TOOLS");
+        }
 
         try {
             if (savingsId == null) {

--- a/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/savings/SavingsTransactionTool.java
+++ b/plugin/src/main/java/org/apache/fineract/infrastructure/mcp/tools/savings/SavingsTransactionTool.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.infrastructure.mcp.service.McpErrorSanitizer;
+import org.apache.fineract.infrastructure.mcp.service.McpAuthenticationService;
 import org.apache.fineract.infrastructure.mcp.tools.FineractMcpTool;
 import org.apache.fineract.portfolio.savings.service.SavingsAccountWritePlatformService;
 import org.springframework.ai.tool.annotation.Tool;
@@ -21,6 +22,7 @@ public class SavingsTransactionTool implements FineractMcpTool {
 
     private final SavingsAccountWritePlatformService savingsAccountWritePlatformService;
     private final McpErrorSanitizer mcpErrorSanitizer;
+    private final McpAuthenticationService mcpAuthenticationService;
 
     @Override
     public String getCategory() {
@@ -42,6 +44,10 @@ public class SavingsTransactionTool implements FineractMcpTool {
             String note) {
 
         log.info("MCP Tool: Processing deposit of {} for savings account ID: {}", amount, savingsId);
+
+        if (!mcpAuthenticationService.isAuthorized()) {
+            throw new SecurityException("User is not authorized to execute MCP tools. Required permissions: ALL_FUNCTIONS or USE_MCP_TOOLS");
+        }
 
         try {
             if (savingsId == null) {
@@ -101,6 +107,10 @@ public class SavingsTransactionTool implements FineractMcpTool {
             String note) {
 
         log.info("MCP Tool: Processing withdrawal of {} for savings account ID: {}", amount, savingsId);
+
+        if (!mcpAuthenticationService.isAuthorized()) {
+            throw new SecurityException("User is not authorized to execute MCP tools. Required permissions: ALL_FUNCTIONS or USE_MCP_TOOLS");
+        }
 
         try {
             if (savingsId == null) {

--- a/plugin/src/test/java/org/apache/fineract/infrastructure/mcp/tools/client/ClientCreateToolTest.java
+++ b/plugin/src/test/java/org/apache/fineract/infrastructure/mcp/tools/client/ClientCreateToolTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.infrastructure.mcp.service.McpErrorSanitizer;
+import org.apache.fineract.infrastructure.mcp.service.McpAuthenticationService;
 import org.apache.fineract.portfolio.client.service.ClientWritePlatformService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,11 +25,15 @@ public class ClientCreateToolTest {
     @Mock
     private McpErrorSanitizer sanitizer;
 
+    @Mock
+    private McpAuthenticationService mcpAuthenticationService;
+
     @InjectMocks
     private ClientCreateTool tool;
 
     @BeforeEach
     void setUp() {
+        org.mockito.Mockito.lenient().when(mcpAuthenticationService.isAuthorized()).thenReturn(true);
         org.mockito.Mockito.lenient().when(sanitizer.sanitize(any(), any())).thenAnswer(invocation -> {
             Exception e = invocation.getArgument(0);
             return e.getMessage();

--- a/plugin/src/test/java/org/apache/fineract/infrastructure/mcp/tools/loan/LoanTransactionToolTest.java
+++ b/plugin/src/test/java/org/apache/fineract/infrastructure/mcp/tools/loan/LoanTransactionToolTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.infrastructure.mcp.service.McpErrorSanitizer;
+import org.apache.fineract.infrastructure.mcp.service.McpAuthenticationService;
 import org.apache.fineract.portfolio.loanaccount.service.LoanWritePlatformService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,11 +26,15 @@ public class LoanTransactionToolTest {
     @Mock
     private McpErrorSanitizer sanitizer;
 
+    @Mock
+    private McpAuthenticationService mcpAuthenticationService;
+
     @InjectMocks
     private LoanTransactionTool tool;
 
     @BeforeEach
     void setUp() {
+        org.mockito.Mockito.lenient().when(mcpAuthenticationService.isAuthorized()).thenReturn(true);
         // Mock sanitizer to just throw RuntimeException with the original message for easier testing of guards
         org.mockito.Mockito.lenient().when(sanitizer.sanitize(any(), any())).thenAnswer(invocation -> {
             Exception e = invocation.getArgument(0);

--- a/plugin/src/test/java/org/apache/fineract/infrastructure/mcp/tools/report/ReportExecutionToolTest.java
+++ b/plugin/src/test/java/org/apache/fineract/infrastructure/mcp/tools/report/ReportExecutionToolTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 import jakarta.ws.rs.core.Response;
 import java.util.Map;
 import org.apache.fineract.infrastructure.mcp.service.McpErrorSanitizer;
+import org.apache.fineract.infrastructure.mcp.service.McpAuthenticationService;
 import org.apache.fineract.infrastructure.report.service.ReportingProcessService;
 import org.apache.fineract.infrastructure.security.service.SqlValidator;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,12 +31,16 @@ public class ReportExecutionToolTest {
     @Mock
     private McpErrorSanitizer sanitizer;
 
+    @Mock
+    private McpAuthenticationService mcpAuthenticationService;
+
     private ReportExecutionTool tool;
 
     @BeforeEach
     void setUp() {
+        org.mockito.Mockito.lenient().when(mcpAuthenticationService.isAuthorized()).thenReturn(true);
         Map<String, ReportingProcessService> reportingProcessServices = Map.of("default", reportingProcessService);
-        tool = new ReportExecutionTool(reportingProcessServices, sqlValidator, sanitizer);
+        tool = new ReportExecutionTool(reportingProcessServices, sqlValidator, sanitizer, mcpAuthenticationService);
 
         org.mockito.Mockito.lenient().when(sanitizer.sanitize(any(), any())).thenAnswer(invocation -> {
             Exception e = invocation.getArgument(0);

--- a/plugin/src/test/java/org/apache/fineract/infrastructure/mcp/tools/savings/SavingsTransactionToolTest.java
+++ b/plugin/src/test/java/org/apache/fineract/infrastructure/mcp/tools/savings/SavingsTransactionToolTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.infrastructure.mcp.service.McpErrorSanitizer;
+import org.apache.fineract.infrastructure.mcp.service.McpAuthenticationService;
 import org.apache.fineract.portfolio.savings.service.SavingsAccountWritePlatformService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,11 +26,15 @@ public class SavingsTransactionToolTest {
     @Mock
     private McpErrorSanitizer sanitizer;
 
+    @Mock
+    private McpAuthenticationService mcpAuthenticationService;
+
     @InjectMocks
     private SavingsTransactionTool tool;
 
     @BeforeEach
     void setUp() {
+        org.mockito.Mockito.lenient().when(mcpAuthenticationService.isAuthorized()).thenReturn(true);
         org.mockito.Mockito.lenient().when(sanitizer.sanitize(any(), any())).thenAnswer(invocation -> {
             Exception e = invocation.getArgument(0);
             return e.getMessage();
@@ -99,5 +104,17 @@ public class SavingsTransactionToolTest {
         assertThat(result.savingsId()).isEqualTo(1L);
         assertThat(result.amount()).isEqualTo(50.0);
         assertThat(result.transactionType()).isEqualTo("withdrawal");
+        assertThat(result.message()).isEqualTo("Withdrawal processed successfully");
+    }
+
+    @Test
+    void processDeposit_whenNotAuthorized_throwsException() {
+        // Arrange
+        org.mockito.Mockito.when(mcpAuthenticationService.isAuthorized()).thenReturn(false);
+
+        // Act & Assert
+        assertThatThrownBy(() -> tool.processDeposit(1L, 100.0, null, null))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("User is not authorized to execute MCP tools");
     }
 }


### PR DESCRIPTION
## Changes

* Added `McpAuthenticationService` as a dependency across all 9 Spring AI `@Tool` implementations.
* Added authorization checks to each tool so unauthorized requests are rejected with a `SecurityException` before any business logic is executed.
* Updated the unit tests to mock `McpAuthenticationService`, keeping the existing tests isolated while covering the new authentication flow.
* Added tests for unauthorized access to verify that protected endpoints are blocked as expected.
