### PR TITLE
fix(gateway): the receipt after a write names the account, not its id

### DIFF
--- a/gateway/src/main/java/org/mifos/community/copilot/core/agent/AgentLoop.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/agent/AgentLoop.java
@@ -103,7 +103,7 @@ public final class AgentLoop {
         // The server-minted key from card creation goes to Fineract as Idempotency-Key:
         // a retry of this approval can never execute twice.
         ExecStatus status = executeAndRecord(tool, call, context, approval.idempotencyKey(), conversationId,
-                fingerprint, sink);
+                fingerprint, sink, approval.rows());
         if (status == ExecStatus.AUTH_FAILED) {
             // Auth expired mid-decision: put the card back (same id, same idempotency key) so
             // the officer's retry after re-login succeeds instead of dead-ending.
@@ -192,8 +192,9 @@ public final class AgentLoop {
                     // Read the account, product and client first, so the officer confirms
                     // against names rather than identifiers.
                     Map<String, String> enriched = executor.enrich(tool, call.arguments(), context);
+                    Map<String, String> rows = cardRows(tool, call, enriched, context);
                     PendingApproval approval = approvals.create(conversationId, call,
-                            summaryFor(tool, call, enriched), context);
+                            summaryFor(tool, call, enriched), context, rows);
                     // OpenAI-style history requires a tool result for EVERY id in the assistant's
                     // tool_calls message. The paused call gets its result on resume; any siblings
                     // after it are marked not-executed NOW so the next LLM turn stays valid.
@@ -204,11 +205,10 @@ public final class AgentLoop {
                     }
                     sink.emit(StreamEvent.actionCard(
                             approval.cardId(), tool.name(), call.arguments(), approval.humanSummary(),
-                            approval.idempotencyKey(), approval.expiresAt().toString(),
-                            cardRows(tool, call, enriched, context)));
+                            approval.idempotencyKey(), approval.expiresAt().toString(), rows));
                     return; // Paused: no done event; the decision endpoint continues this turn.
                 }
-                if (executeAndRecord(tool, call, context, null, conversationId, fingerprint, sink)
+                if (executeAndRecord(tool, call, context, null, conversationId, fingerprint, sink, Map.of())
                         == ExecStatus.AUTH_FAILED) {
                     return; // Auth expired, so the turn already ended with AUTH_EXPIRED + done.
                 }
@@ -223,7 +223,8 @@ public final class AgentLoop {
     }
 
     private ExecStatus executeAndRecord(ToolDefinition tool, LlmToolCall call, CallContext context,
-            String idempotencyKey, String conversationId, String fingerprint, EventSink sink) {
+            String idempotencyKey, String conversationId, String fingerprint, EventSink sink,
+            Map<String, String> rows) {
         sink.emit(StreamEvent.toolCall(tool.name(), "started", !tool.write(), -1));
         long startedAt = System.currentTimeMillis();
         String outcome;
@@ -243,7 +244,7 @@ public final class AgentLoop {
         }
         sink.emit(StreamEvent.toolCall(tool.name(), "finished", !tool.write(), System.currentTimeMillis() - startedAt));
         conversations.append(fingerprint, conversationId, toolResultMessage(call, outcome));
-        emitNavigationCard(tool, call, outcome, sink);
+        emitNavigationCard(tool, call, outcome, sink, rows);
         return isErrorOutcome(outcome) ? ExecStatus.APP_ERROR : ExecStatus.OK;
     }
 
@@ -259,7 +260,8 @@ public final class AgentLoop {
      * After a successful create, give the officer a one-click path to the new record:
      * a display card with a route button into the web-app (never an approval card).
      */
-    private void emitNavigationCard(ToolDefinition tool, LlmToolCall call, String outcome, EventSink sink) {
+    private void emitNavigationCard(ToolDefinition tool, LlmToolCall call, String outcome, EventSink sink,
+            Map<String, String> rows) {
         try {
             com.fasterxml.jackson.databind.JsonNode result = new com.fasterxml.jackson.databind.ObjectMapper()
                     .readTree(outcome);
@@ -272,8 +274,10 @@ public final class AgentLoop {
                 case "mifos_client_create" -> {
                     long id = result.path("clientId").asLong(result.path("resourceId").asLong(0));
                     if (!failed && id > 0) {
+                        String named = nameFrom(call, "firstname", "lastname");
                         sink.emit(StreamEvent.displayCard("client", "Client created",
-                                Map.of("Client ID", String.valueOf(id)),
+                                receipt(rows, named.isBlank() ? "Client account" : "Client",
+                                        named.isBlank() ? String.valueOf(id) : named),
                                 List.of(Map.of("label", "Open client profile", "style", "primary",
                                         "route", "/clients/" + id + "/general"))));
                     }
@@ -281,12 +285,12 @@ public final class AgentLoop {
                 case "mifos_loan_create" -> {
                     if (!failed && loanId > 0 && clientId > 0) {
                         sink.emit(StreamEvent.displayCard("loan", "Loan application submitted",
-                                Map.of("Loan ID", String.valueOf(loanId), "Client ID", String.valueOf(clientId)),
+                                receipt(rows, "Loan account", String.valueOf(loanId)),
                                 List.of(Map.of("label", "Open loan", "style", "primary",
                                         "route", "/clients/" + clientId + "/loans-accounts/" + loanId + "/general"))));
                     } else if (failed && clientId > 0) {
                         sink.emit(StreamEvent.displayCard("insight", "Loan application was not created",
-                                Map.of("Client ID", String.valueOf(clientId)),
+                                receipt(rows, "Client account", String.valueOf(clientId)),
                                 List.of(Map.of("label", "Open client to verify", "style", "accent",
                                         "route", "/clients/" + clientId + "/general"))));
                     }
@@ -295,7 +299,7 @@ public final class AgentLoop {
                     // Fineract loan-command responses include clientId + loanId on success.
                     if (!failed && loanId > 0 && clientId > 0) {
                         sink.emit(StreamEvent.displayCard("loan", "Loan updated",
-                                Map.of("Loan ID", String.valueOf(loanId)),
+                                receipt(rows, "Loan account", String.valueOf(loanId)),
                                 List.of(Map.of("label", "Open loan", "style", "primary",
                                         "route", "/clients/" + clientId + "/loans-accounts/" + loanId + "/general"))));
                     }
@@ -423,6 +427,46 @@ public final class AgentLoop {
         return key.toString();
     }
 
+
+    /**
+     * What the receipt says about the record that just changed.
+     *
+     * <p>Reuses the rows the officer read on the confirmation card, so the receipt names the
+     * same client and account they approved. Enrichment is best-effort, so when it found
+     * nothing the receipt falls back to the identifier under a label. An id is a poor thing
+     * to show an officer, but a receipt with no row at all is worse: there would be no way to
+     * tell which record had just changed.
+     */
+    private Map<String, String> receipt(Map<String, String> rows, String preferred, String fallback) {
+        Map<String, String> named = new LinkedHashMap<>();
+        if (rows != null) {
+            for (Map.Entry<String, String> row : rows.entrySet()) {
+                if (NAMING_ROWS.contains(row.getKey())) {
+                    named.put(row.getKey(), row.getValue());
+                }
+            }
+        }
+        if (named.isEmpty() && fallback != null && !fallback.isBlank()) {
+            named.put(preferred, fallback);
+        }
+        return named;
+    }
+
+    /** Rows worth repeating on a receipt: who and which account, not the figures again. */
+    private static final java.util.Set<String> NAMING_ROWS =
+            java.util.Set.of("Client", "Client account", "Loan account", "Savings account", "Product");
+
+    /** "Aisha Bello" from the arguments of a create, which has no record to read back yet. */
+    private String nameFrom(LlmToolCall call, String... parts) {
+        StringBuilder name = new StringBuilder();
+        for (String part : parts) {
+            Object value = call.arguments() == null ? null : call.arguments().get(part);
+            if (value != null && !String.valueOf(value).isBlank()) {
+                name.append(name.isEmpty() ? "" : " ").append(value);
+            }
+        }
+        return name.toString();
+    }
 
     /** Argument names the model supplied that the manifest does not declare for this tool. */
     private List<String> undeclaredArguments(ToolDefinition tool, LlmToolCall call) {

--- a/gateway/src/main/java/org/mifos/community/copilot/core/approval/ApprovalStore.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/approval/ApprovalStore.java
@@ -33,7 +33,8 @@ public final class ApprovalStore {
     }
 
     /** Create and register a card for this tool call, bound to the asking identity. */
-    public PendingApproval create(String conversationId, LlmToolCall call, String humanSummary, CallContext context) {
+    public PendingApproval create(String conversationId, LlmToolCall call, String humanSummary, CallContext context,
+            java.util.Map<String, String> rows) {
         sweep();
         PendingApproval approval = new PendingApproval(
                 "card-" + UUID.randomUUID(),
@@ -42,7 +43,8 @@ public final class ApprovalStore {
                 humanSummary,
                 "cop-" + UUID.randomUUID(), // Server-minted idempotency key, the only authority.
                 context.fingerprint(),
-                Instant.now().plus(ttl));
+                Instant.now().plus(ttl),
+                rows == null ? java.util.Map.of() : java.util.Map.copyOf(rows));
         pending.put(approval.cardId(), approval);
         return approval;
     }

--- a/gateway/src/main/java/org/mifos/community/copilot/core/approval/PendingApproval.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/approval/PendingApproval.java
@@ -10,6 +10,7 @@ package org.mifos.community.copilot.core.approval;
 import org.mifos.community.copilot.core.llm.LlmToolCall;
 
 import java.time.Instant;
+import java.util.Map;
 
 /**
  * A write action paused for human confirmation (ADR-001 §04).
@@ -17,9 +18,21 @@ import java.time.Instant;
  * <p>{@code securityFingerprint} binds the card to the asking officer and tenant, so only the same
  * identity may decide it. {@code idempotencyKey} is minted HERE, server-side, at card creation;
  * client-supplied keys are ignored by design. No raw credential is ever stored.
+ *
+ * <p>{@code rows} are the labelled values the officer read before confirming. They are kept so
+ * the receipt shown afterwards names the same account, rather than falling back to an id.
  */
 public record PendingApproval(String cardId, String conversationId, LlmToolCall toolCall, String humanSummary,
-        String idempotencyKey, String securityFingerprint, Instant expiresAt) {
+        String idempotencyKey, String securityFingerprint, Instant expiresAt, Map<String, String> rows) {
+
+    /**
+     * Copied on the way in, so the receipt cannot drift from the card. A caller holding the
+     * map it passed could otherwise change what an officer is recorded as having approved,
+     * and restore() puts a card back without going through create() again.
+     */
+    public PendingApproval {
+        rows = rows == null ? Map.of() : Map.copyOf(rows);
+    }
 
     public boolean isExpired(Instant now) {
         return now.isAfter(expiresAt);

--- a/gateway/src/test/java/org/mifos/community/copilot/core/AgentLoopTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/AgentLoopTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.mifos.community.copilot.core.agent.AgentLoop;
 import org.mifos.community.copilot.core.agent.EventSink;
 import org.mifos.community.copilot.core.approval.ApprovalStore;
+import org.mifos.community.copilot.core.approval.PendingApproval;
 import org.mifos.community.copilot.core.auth.CallContext;
 import org.mifos.community.copilot.core.contract.StreamEvent;
 import org.mifos.community.copilot.core.convo.ConversationStore;
@@ -59,6 +60,17 @@ class AgentLoopTest {
                     currency: currency.code
                     fields: { Client: clientName, Product: loanProductName }
                 rest: { method: POST, path: "/api/{loanId}", body: '{}' }
+              - name: mifos_loan_approve
+                description: Approve a loan application. Requires the officer's confirmation.
+                summary: "Approve {productName} for {clientName}"
+                write: true
+                params:
+                  - { name: loanId, type: integer, required: true, label: Loan account, show: false }
+                enrich:
+                  - path: /api/loans/{loanId}
+                    currency: currency.code
+                    fields: { Client: clientName, Product: loanProductName }
+                rest: { method: POST, path: "/api/{loanId}?command=approve", body: '{}' }
             """;
 
     private final CallContext officer = new CallContext("Basic abc", "default", "corr-1");
@@ -387,5 +399,56 @@ class AgentLoopTest {
 
         Map<String, String> rows = (Map<String, String>) sink.only("action_card").data().get("rows");
         assertThat(rows).containsEntry("Approval date", "21 August 2026");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void theReceiptAfterAWriteNamesWhatTheOfficerApproved() {
+        // The rows read on the card are reused, so the receipt cannot drift from it.
+        llm.enqueue(new LlmResult("", List.of(new LlmToolCall("c1", "mifos_loan_approve", Map.of("loanId", 12)))));
+        loop().runTurn(null, "Approve it", Map.of(), officer, sink);
+        String cardId = String.valueOf(sink.only("action_card").data().get("card_id"));
+
+        executor.nextResult = "{\"loanId\":12,\"clientId\":7}";
+        llm.enqueue(new LlmResult("Done.", List.of()));
+        RecordingSink resumeSink = new RecordingSink();
+        loop().resume(cardId, true, Map.of(), officer, resumeSink);
+
+        Map<String, Object> card = (Map<String, Object>) resumeSink.only("action_card").data().get("card");
+        Map<String, String> data = (Map<String, String>) card.get("data");
+        assertThat(data).containsEntry("Client", "Aisha Bello").containsEntry("Product", "Weekly Loan");
+        assertThat(data).doesNotContainKey("Loan ID");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void aReceiptWithNoNamesStillSaysWhichRecordChanged() {
+        // Enrichment is best-effort. A receipt showing nothing at all would leave the officer
+        // unable to tell which record had just moved, so the identifier appears, labelled.
+        executor.enrichment = Map.of();
+        llm.enqueue(new LlmResult("", List.of(new LlmToolCall("c1", "mifos_loan_approve", Map.of("loanId", 12)))));
+        loop().runTurn(null, "Approve it", Map.of(), officer, sink);
+        String cardId = String.valueOf(sink.only("action_card").data().get("card_id"));
+
+        executor.nextResult = "{\"loanId\":12,\"clientId\":7}";
+        llm.enqueue(new LlmResult("Done.", List.of()));
+        RecordingSink resumeSink = new RecordingSink();
+        loop().resume(cardId, true, Map.of(), officer, resumeSink);
+
+        Map<String, Object> card = (Map<String, Object>) resumeSink.only("action_card").data().get("card");
+        assertThat((Map<String, String>) card.get("data")).containsEntry("Loan account", "12");
+    }
+
+    @Test
+    void theRowsOnAPendingApprovalCannotBeChangedAfterTheOfficerHasReadThem() {
+        java.util.Map<String, String> mutable = new java.util.LinkedHashMap<>();
+        mutable.put("Client", "Aisha Bello");
+
+        PendingApproval approval = new PendingApproval("card-1", "conv-1",
+                new LlmToolCall("c1", "write_tool", Map.of()), "Approve", "cop-1",
+                officer.fingerprint(), java.time.Instant.now().plusSeconds(60), mutable);
+        mutable.put("Client", "Someone Else");
+
+        assertThat(approval.rows()).containsExactly(entry("Client", "Aisha Bello"));
     }
 }


### PR DESCRIPTION
## What this changes

Follow-up to #434, found by running the flow against a real Fineract and then
looking at the screen afterwards.

#434 fixed the confirmation card, so an officer approving a loan now reads:

```
Client            Aisha Bello
Loan account      000000001
Product           Agriculture Term Loan
Applied for       USD 30,000.00
Approval date     22 August 2026
```

They confirm, and the card shown next said:

```
Loan ID   1
```

Same complaint, one screen later.

## How

The approval already carries the rows the officer read, so they are kept on the
pending record and reused for the receipt. No second lookup, and the receipt names
exactly what was approved rather than a fresh reading of it:

```
Product        Agriculture Term Loan
Client         Aisha Bello
Loan account   000000001
```

An identifier appears only when there is nothing else to show, and it is labelled
when it does. The same applies to the cards shown after creating a client and after
submitting a loan application, which had `Client ID` and `Loan ID` rows.

## Verified

Against sandbox.mifos.community, not a stub: loan 1 for Aisha Bello moved from
`Submitted and pending approval` to `Approved`, recorded against `mifos`, the
officer's own login. Screenshot of the receipt taken from the running web app.

66 tests, unchanged and passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Approval confirmations now retain relevant details for use in completion receipts.
  * Completion cards for clients, loans, and loan actions display clearer contextual information, including names and identifiers.
  * Client creation receipts can derive and display the client’s name from submitted details.
  * Receipts fall back to available identifiers when descriptive details cannot be retrieved.
  * Loan approval confirmations now provide more relevant completion information after approval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->