### PR TITLE
fix(gateway): read values from the product and the credential, not from literals

### DIFF
--- a/gateway/src/main/java/org/mifos/community/copilot/core/agent/AgentLoop.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/agent/AgentLoop.java
@@ -114,6 +114,17 @@ public final class AgentLoop {
             approvals.restore(approval);
             return;
         }
+        if (status == ExecStatus.UNKNOWN) {
+            // Sent, no answer. Saying "not completed" would be a guess, and the wrong guess
+            // costs a second disbursement. The card goes back with its original idempotency
+            // key, so a retry that turns out to be a duplicate is refused by Fineract itself.
+            approvals.restore(approval);
+            sink.emit(StreamEvent.token("? Not confirmed: " + approval.humanSummary()
+                    + ". The banking system did not answer in time, so this may or may not have gone"
+                    + " through. Open the account and check before trying again.\n\n"));
+            sink.emit(StreamEvent.done(conversationId));
+            return;
+        }
         // Status line BEFORE the summary turn: if the LLM is unavailable or rate-limited for
         // the summary, the officer must still see what happened. It must never say "Executed"
         // for an action the core banking system rejected, which misleads on a money path.
@@ -136,7 +147,9 @@ public final class AgentLoop {
         /** Fineract rejected it (validation/business error), recorded for the model to explain. */
         APP_ERROR,
         /** The officer's session expired, so the turn already ended with AUTH_EXPIRED. */
-        AUTH_FAILED
+        AUTH_FAILED,
+        /** The request was sent and no answer came back, so nobody knows whether it ran. */
+        UNKNOWN
     }
 
     /** The shared LLM<->tools cycle; ends with done, an action_card pause, or an error. */
@@ -217,9 +230,17 @@ public final class AgentLoop {
                             approval.idempotencyKey(), approval.expiresAt().toString(), rows));
                     return; // Paused: no done event; the decision endpoint continues this turn.
                 }
-                if (executeAndRecord(tool, call, context, null, conversationId, fingerprint, sink, Map.of())
-                        == ExecStatus.AUTH_FAILED) {
+                ExecStatus readStatus = executeAndRecord(tool, call, context, null, conversationId,
+                        fingerprint, sink, Map.of());
+                if (readStatus == ExecStatus.AUTH_FAILED) {
                     return; // Auth expired, so the turn already ended with AUTH_EXPIRED + done.
+                }
+                if (readStatus == ExecStatus.UNKNOWN) {
+                    // Only writes are marked indeterminate, so this is a read that timed out.
+                    sink.emit(StreamEvent.error(ErrorCode.TOOL_FAILED,
+                            "The banking system did not answer in time. Please try again.", true));
+                    sink.emit(StreamEvent.done(conversationId));
+                    return;
                 }
                 if (sink.isCancelled()) {
                     return;
@@ -245,6 +266,10 @@ public final class AgentLoop {
                         "Your session expired. Please sign in again and retry.", true));
                 sink.emit(StreamEvent.done(conversationId));
                 return ExecStatus.AUTH_FAILED;
+            } else if (e.isIndeterminate()) {
+                sink.emit(StreamEvent.toolCall(tool.name(), "finished", !tool.write(),
+                        System.currentTimeMillis() - startedAt));
+                return ExecStatus.UNKNOWN;
             } else if (e.isPermissionFailure()) {
                 outcome = "{\"error\":\"Your Mifos X role does not permit this operation.\"}";
             } else {

--- a/gateway/src/main/java/org/mifos/community/copilot/core/agent/AgentLoop.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/agent/AgentLoop.java
@@ -102,7 +102,11 @@ public final class AgentLoop {
         }
         // The server-minted key from card creation goes to Fineract as Idempotency-Key:
         // a retry of this approval can never execute twice.
-        ExecStatus status = executeAndRecord(tool, call, context, approval.idempotencyKey(), conversationId,
+        // Execute under the session captured on the card, so a value the officer's screen
+        // owned when they read it is the value that runs when they confirm.
+        CallContext executionContext = new CallContext(context.authorizationHeader(), context.tenantId(),
+                context.correlationId(), approval.session());
+        ExecStatus status = executeAndRecord(tool, call, executionContext, approval.idempotencyKey(), conversationId,
                 fingerprint, sink, approval.rows());
         if (status == ExecStatus.AUTH_FAILED) {
             // Auth expired mid-decision: put the card back (same id, same idempotency key) so
@@ -191,10 +195,15 @@ public final class AgentLoop {
                     }
                     // Read the account, product and client first, so the officer confirms
                     // against names rather than identifiers.
-                    Map<String, String> enriched = executor.enrich(tool, call.arguments(), context);
-                    Map<String, String> rows = cardRows(tool, call, enriched, context);
-                    PendingApproval approval = approvals.create(conversationId, call,
-                            summaryFor(tool, call, enriched), context, rows);
+                    // Normalise before anything is shown. A date the executor would rewrite
+                    // has to be rewritten here, or the officer approves one value and another
+                    // one executes.
+                    LlmToolCall normalized = new LlmToolCall(call.id(), call.name(),
+                            executor.normalizeArguments(tool, call.arguments(), context));
+                    Map<String, String> enriched = executor.enrich(tool, normalized.arguments(), context);
+                    Map<String, String> rows = cardRows(tool, normalized, enriched, context);
+                    PendingApproval approval = approvals.create(conversationId, normalized,
+                            summaryFor(tool, normalized, enriched), context, rows);
                     // OpenAI-style history requires a tool result for EVERY id in the assistant's
                     // tool_calls message. The paused call gets its result on resume; any siblings
                     // after it are marked not-executed NOW so the next LLM turn stays valid.
@@ -204,7 +213,7 @@ public final class AgentLoop {
                                         + " turn required officer confirmation. Ask again if still needed.\"}"));
                     }
                     sink.emit(StreamEvent.actionCard(
-                            approval.cardId(), tool.name(), call.arguments(), approval.humanSummary(),
+                            approval.cardId(), tool.name(), normalized.arguments(), approval.humanSummary(),
                             approval.idempotencyKey(), approval.expiresAt().toString(), rows));
                     return; // Paused: no done event; the decision endpoint continues this turn.
                 }

--- a/gateway/src/main/java/org/mifos/community/copilot/core/agent/AgentLoop.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/agent/AgentLoop.java
@@ -67,8 +67,75 @@ public final class AgentLoop {
             CallContext context, EventSink sink) {
         String fingerprint = context.fingerprint();
         String conversationId = conversations.resolve(fingerprint, requestedConversationId);
+        settleAbandonedCalls(conversationId, context, fingerprint);
         conversations.append(fingerprint, conversationId, Map.of("role", "user", "content", userMessage));
         drive(conversationId, screenContext, context, sink);
+    }
+
+    /**
+     * Close off a confirmation the officer never answered.
+     *
+     * <p>Pausing for a card leaves an assistant {@code tool_calls} message in the history with
+     * no result against it, because the result is what the decision produces. Approve and
+     * reject both supply one. Walking away supplies nothing, and every OpenAI-shaped provider
+     * rejects a conversation where a tool call was asked and never answered. Without this the
+     * officer's next message returns HTTP 400 and that conversation never works again, which
+     * is a strange way to punish somebody for changing their mind.
+     *
+     * <p>So the abandoned call gets an honest result saying it was never carried out, and the
+     * card is dropped so it cannot be approved after the conversation has moved on.
+     */
+    private void settleAbandonedCalls(String conversationId, CallContext context, String fingerprint) {
+        approvals.discardFor(conversationId, context);
+        for (String callId : unansweredToolCalls(fingerprint, conversationId)) {
+            Map<String, Object> message = new LinkedHashMap<>();
+            message.put("role", "tool");
+            message.put("tool_call_id", callId);
+            message.put("content", "{\"status\":\"not_executed\",\"detail\":\"The officer did not confirm"
+                    + " this action, so nothing was carried out. Ask again if it is still wanted.\"}");
+            conversations.append(fingerprint, conversationId, message);
+        }
+    }
+
+    /**
+     * Ids from the trailing assistant {@code tool_calls} message that nothing has answered.
+     *
+     * <p>Only the trailing one matters: any earlier batch was settled when the turn that
+     * raised it finished, and a turn cannot pause twice.
+     */
+    private List<String> unansweredToolCalls(String fingerprint, String conversationId) {
+        List<Map<String, Object>> messages = conversations.messages(fingerprint, conversationId);
+        int last = -1;
+        for (int i = messages.size() - 1; i >= 0; i--) {
+            if (messages.get(i).get("tool_calls") != null) {
+                last = i;
+                break;
+            }
+        }
+        if (last < 0) {
+            return List.of();
+        }
+        java.util.Set<String> answered = new java.util.LinkedHashSet<>();
+        for (int i = last + 1; i < messages.size(); i++) {
+            Object id = messages.get(i).get("tool_call_id");
+            if (id != null) {
+                answered.add(String.valueOf(id));
+            }
+        }
+        List<String> unanswered = new java.util.ArrayList<>();
+        Object raw = messages.get(last).get("tool_calls");
+        if (raw instanceof List<?> calls) {
+            for (Object entry : calls) {
+                if (entry instanceof Map<?, ?> call) {
+                    Object id = call.get("id");
+                    String text = id == null ? "call-0" : String.valueOf(id);
+                    if (!answered.contains(text)) {
+                        unanswered.add(text);
+                    }
+                }
+            }
+        }
+        return unanswered;
     }
 
     /** Resume a paused turn after the officer's decision. */
@@ -169,9 +236,16 @@ public final class AgentLoop {
                         (delta) -> sink.emit(StreamEvent.token(delta)),
                         sink::isCancelled);
             } catch (LlmException e) {
-                sink.emit(StreamEvent.error(
-                        e.isRateLimited() ? ErrorCode.RATE_LIMITED : ErrorCode.LLM_UNAVAILABLE,
-                        "The AI model is unavailable right now. Please try again shortly.", true));
+                // A refusal is not an outage. Telling an officer to try again shortly, when the
+                // key is wrong or the request was malformed, sends them round a loop that cannot
+                // come out anywhere. Say it is not going to work and let somebody look at it.
+                sink.emit(e.isClientError()
+                        ? StreamEvent.error(ErrorCode.LLM_UNAVAILABLE,
+                                "The AI model rejected this request. Retrying will not help, so please"
+                                        + " tell your administrator.", false)
+                        : StreamEvent.error(
+                                e.isRateLimited() ? ErrorCode.RATE_LIMITED : ErrorCode.LLM_UNAVAILABLE,
+                                "The AI model is unavailable right now. Please try again shortly.", true));
                 sink.emit(StreamEvent.done(conversationId));
                 return;
             }

--- a/gateway/src/main/java/org/mifos/community/copilot/core/agent/AgentLoop.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/agent/AgentLoop.java
@@ -114,6 +114,11 @@ public final class AgentLoop {
             approvals.restore(approval);
             return;
         }
+        if (status == ExecStatus.APP_ERROR && nothingWasSent(conversationId, fingerprint)) {
+            // Rejected before the request left, so the officer can fix the problem and decide
+            // again on the same card rather than starting over.
+            approvals.restore(approval);
+        }
         if (status == ExecStatus.UNKNOWN) {
             // Sent, no answer. Saying "not completed" would be a guess, and the wrong guess
             // costs a second disbursement. The card goes back with its original idempotency
@@ -275,6 +280,12 @@ public final class AgentLoop {
             } else {
                 outcome = "{\"error\":" + jsonQuote(e.getMessage()) + "}";
             }
+        } catch (RuntimeException e) {
+            // Something went wrong building the request, so nothing was sent. Report it as a
+            // rejection, which is what it is, rather than letting it escape and end the turn
+            // with no explanation and the card already spent.
+            outcome = "{\"error\":" + jsonQuote(e.getMessage() == null ? "The request could not be prepared."
+                    : e.getMessage()) + "}";
         }
         sink.emit(StreamEvent.toolCall(tool.name(), "finished", !tool.write(), System.currentTimeMillis() - startedAt));
         conversations.append(fingerprint, conversationId, toolResultMessage(call, outcome));
@@ -500,6 +511,23 @@ public final class AgentLoop {
             }
         }
         return name.toString();
+    }
+
+    /**
+     * Whether the last recorded outcome was a refusal raised before anything reached Fineract.
+     *
+     * <p>Those are worth putting the card back for: nothing ran, and the officer may be able
+     * to correct what caused it. A refusal from Fineract itself is a decision, and the card
+     * stays spent.
+     */
+    private boolean nothingWasSent(String conversationId, String fingerprint) {
+        List<Map<String, Object>> messages = conversations.messages(fingerprint, conversationId);
+        if (messages.isEmpty()) {
+            return false;
+        }
+        Object content = messages.get(messages.size() - 1).get("content");
+        String text = content == null ? "" : String.valueOf(content);
+        return text.contains("could not be prepared") || text.contains("not one you can work in");
     }
 
     /** Argument names the model supplied that the manifest does not declare for this tool. */

--- a/gateway/src/main/java/org/mifos/community/copilot/core/approval/ApprovalStore.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/approval/ApprovalStore.java
@@ -62,6 +62,20 @@ public final class ApprovalStore {
     }
 
     /**
+     * Drop every card still waiting in this conversation, and say which calls they answered for.
+     *
+     * <p>Called when the officer moves on without deciding. Two things have to happen together:
+     * the abandoned card must stop being decidable, because approving it later would execute an
+     * action out of order against a conversation that has moved past it, and the tool call it
+     * was holding open has to be closed off. Doing only the second would leave a live card
+     * pointing at a call the history has already settled.
+     */
+    public void discardFor(String conversationId, CallContext context) {
+        pending.values().removeIf((approval) -> approval.conversationId().equals(conversationId)
+                && approval.securityFingerprint().equals(context.fingerprint()));
+    }
+
+    /**
      * Atomically consume the card. Returns empty when unknown, already decided, expired, or
      * presented by a different user/tenant than the one who asked. A fingerprint mismatch is
      * SIDE-EFFECT-FREE: a stranger probing a card id must not be able to destroy the rightful

--- a/gateway/src/main/java/org/mifos/community/copilot/core/approval/ApprovalStore.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/approval/ApprovalStore.java
@@ -44,7 +44,8 @@ public final class ApprovalStore {
                 "cop-" + UUID.randomUUID(), // Server-minted idempotency key, the only authority.
                 context.fingerprint(),
                 Instant.now().plus(ttl),
-                rows == null ? java.util.Map.of() : java.util.Map.copyOf(rows));
+                rows == null ? java.util.Map.of() : java.util.Map.copyOf(rows),
+                context.session());
         pending.put(approval.cardId(), approval);
         return approval;
     }

--- a/gateway/src/main/java/org/mifos/community/copilot/core/approval/PendingApproval.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/approval/PendingApproval.java
@@ -23,7 +23,8 @@ import java.util.Map;
  * the receipt shown afterwards names the same account, rather than falling back to an id.
  */
 public record PendingApproval(String cardId, String conversationId, LlmToolCall toolCall, String humanSummary,
-        String idempotencyKey, String securityFingerprint, Instant expiresAt, Map<String, String> rows) {
+        String idempotencyKey, String securityFingerprint, Instant expiresAt, Map<String, String> rows,
+        Map<String, Object> session) {
 
     /**
      * Copied on the way in, so the receipt cannot drift from the card. A caller holding the
@@ -32,6 +33,9 @@ public record PendingApproval(String cardId, String conversationId, LlmToolCall 
      */
     public PendingApproval {
         rows = rows == null ? Map.of() : Map.copyOf(rows);
+        // Captured when the card was raised. A write lands in the office the officer was
+        // working in at that moment, not whichever one is claimed when Confirm is pressed.
+        session = session == null ? Map.of() : Map.copyOf(session);
     }
 
     public boolean isExpired(Instant now) {

--- a/gateway/src/main/java/org/mifos/community/copilot/core/auth/CallContext.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/auth/CallContext.java
@@ -19,7 +19,21 @@ import java.util.HexFormat;
  * context's {@code authorizationHeader} + {@code tenantId}, so Fineract RBAC evaluates and the
  * audit trail records the real user. The credential is never logged and never sent to the LLM.
  */
-public record CallContext(String authorizationHeader, String tenantId, String correlationId) {
+public record CallContext(String authorizationHeader, String tenantId, String correlationId,
+        java.util.Map<String, Object> session) {
+
+    /**
+     * Facts the officer's session knows and the model must not choose: which office they
+     * belong to, which staff record is theirs. A body template reads these as
+     * {@code ${session.officeId}}, so a branch can never be picked by a sentence.
+     */
+    public CallContext {
+        session = session == null ? java.util.Map.of() : java.util.Map.copyOf(session);
+    }
+
+    public CallContext(String authorizationHeader, String tenantId, String correlationId) {
+        this(authorizationHeader, tenantId, correlationId, java.util.Map.of());
+    }
 
     public boolean hasCredential() {
         return authorizationHeader != null && !authorizationHeader.isBlank();

--- a/gateway/src/main/java/org/mifos/community/copilot/core/llm/LlmException.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/llm/LlmException.java
@@ -11,17 +11,34 @@ package org.mifos.community.copilot.core.llm;
 public class LlmException extends Exception {
 
     private final boolean rateLimited;
+    private final boolean clientError;
 
     public LlmException(String message, Throwable cause) {
-        this(message, cause, false);
+        this(message, cause, false, false);
     }
 
     public LlmException(String message, Throwable cause, boolean rateLimited) {
+        this(message, cause, rateLimited, false);
+    }
+
+    public LlmException(String message, Throwable cause, boolean rateLimited, boolean clientError) {
         super(message, cause);
         this.rateLimited = rateLimited;
+        this.clientError = clientError;
     }
 
     public boolean isRateLimited() {
         return rateLimited;
+    }
+
+    /**
+     * True when the provider refused the request rather than failing to serve it.
+     *
+     * <p>A rejected key, a malformed body or a model that does not exist are all settled
+     * facts. They do not come right on their own, and presenting them as a passing outage
+     * invites an officer to keep trying something that cannot succeed.
+     */
+    public boolean isClientError() {
+        return clientError;
     }
 }

--- a/gateway/src/main/java/org/mifos/community/copilot/core/llm/OpenAiCompatibleLlmClient.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/llm/OpenAiCompatibleLlmClient.java
@@ -91,7 +91,9 @@ public final class OpenAiCompatibleLlmClient implements LlmClient {
             if (response.statusCode() == 429) {
                 throw new LlmException("LLM provider rate limit hit", null, true);
             }
-            throw new LlmException("LLM provider returned HTTP " + response.statusCode(), null);
+            boolean refused = response.statusCode() == 400 || response.statusCode() == 401
+                    || response.statusCode() == 403 || response.statusCode() == 404;
+            throw new LlmException("LLM provider returned HTTP " + response.statusCode(), null, false, refused);
         }
 
         return consumeStream(response.body(), onToken, cancelled);

--- a/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
@@ -78,7 +78,8 @@ public final class FineractRestToolExecutor implements ToolExecutor {
         // The product owns its interest rate, its schedule and its strategy. Anything the
         // officer did not name is read from it rather than invented here.
         // Normalised first, so what executes is exactly what the card showed.
-        Map<String, Object> effective = withDefaults(tool, normalizeArguments(tool, args, context), context);
+        Map<String, Object> effective = withComputed(tool,
+                withDefaults(tool, normalizeArguments(tool, args, context), context));
         String path = substitutePath(rest.path(), effective, today);
         HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create(fineractBaseUrl + path))
                 .timeout(Duration.ofSeconds(30))
@@ -103,6 +104,10 @@ public final class FineractRestToolExecutor implements ToolExecutor {
         HttpResponse<String> response;
         try {
             response = http.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+        } catch (java.net.http.HttpTimeoutException e) {
+            // The request was sent and the answer never came. For a write, that is not the
+            // same as a refusal, and it must not be reported as one.
+            throw new ToolExecutionException("Timed out waiting for " + tool.name(), 0, e, tool.write());
         } catch (IOException | InterruptedException e) {
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
@@ -184,6 +189,52 @@ public final class FineractRestToolExecutor implements ToolExecutor {
         return effective;
     }
 
+    /**
+     * Values derived from two others, once the product's own numbers are known.
+     *
+     * <p>Only a product of two parameters is supported, which is all that is needed and all
+     * that belongs in a manifest. A loan's term is its repayment count times how often it
+     * repays; writing the term as the repayment count is correct only when a loan repays
+     * every period, and silently halves the term of a fortnightly product.
+     *
+     * <p>Anything the officer stated is left as they stated it.
+     */
+    private Map<String, Object> withComputed(ToolDefinition tool, Map<String, Object> args) {
+        if (tool.computed().isEmpty()) {
+            return args;
+        }
+        java.util.Map<String, Object> out = new java.util.LinkedHashMap<>(args);
+        for (Map.Entry<String, String> rule : tool.computed().entrySet()) {
+            Object already = out.get(rule.getKey());
+            if (already != null && !String.valueOf(already).isBlank()) {
+                continue;
+            }
+            String[] operands = rule.getValue().split("\\*");
+            if (operands.length != 2) {
+                continue;
+            }
+            Double left = asNumber(out.get(operands[0].trim()));
+            Double right = asNumber(out.get(operands[1].trim()));
+            if (left == null || right == null) {
+                continue; // Not enough to compute with; Fineract will name what is missing.
+            }
+            double product = left * right;
+            out.put(rule.getKey(), product == Math.rint(product) ? (Object) (long) product : (Object) product);
+        }
+        return out;
+    }
+
+    private Double asNumber(Object value) {
+        if (value instanceof Number number) {
+            return number.doubleValue();
+        }
+        try {
+            return value == null ? null : Double.valueOf(String.valueOf(value).trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
     /** Replace {param} tokens in the path, URL-encoding values; unresolved required tokens fail fast. */
     private String substitutePath(String template, Map<String, Object> args, String today) throws ToolExecutionException {
         String out = template;
@@ -217,50 +268,87 @@ public final class FineractRestToolExecutor implements ToolExecutor {
      * is the point of the prefix: an office is decided by who is signed in, never by a
      * sentence somebody typed.
      */
+    /**
+     * Fill the request body.
+     *
+     * <p>The template is itself valid JSON, with every slot written as a quoted
+     * {@code "${name}"}, so it is parsed and walked rather than edited as text. Replacing
+     * tokens by repeated string substitution meant a value could be read back as a token on
+     * a later pass: a client whose surname was literally {@code ${mobileNo}} was persisted
+     * with their phone number as their surname.
+     *
+     * <p>A slot named {@code session.x} is filled from the officer's logged-in session and
+     * never from an argument, so a value the session owns cannot be shadowed by something the
+     * model produced. A slot with nothing to fill it is dropped, because Fineract must not
+     * receive an empty string standing in for a field the officer did not set.
+     */
     String buildBody(String template, Map<String, Object> args, String today, Map<String, Object> session) {
         if (template == null) {
             return "{}";
         }
-        String out = template;
-        if (session != null) {
-            for (Map.Entry<String, Object> entry : session.entrySet()) {
-                Object value = entry.getValue();
-                if (value == null || String.valueOf(value).isBlank()) {
-                    continue;
+        try {
+            JsonNode parsed = mapper.readTree(template);
+            if (!parsed.isObject()) {
+                return template;
+            }
+            ObjectNode filled = mapper.createObjectNode();
+            fill((ObjectNode) parsed, filled, args == null ? Map.of() : args,
+                    session == null ? Map.of() : session);
+            return mapper.writeValueAsString(filled);
+        } catch (IOException e) {
+            // A template that is not JSON is a manifest bug, not a runtime condition.
+            throw new IllegalStateException("Tool body template is not valid JSON", e);
+        }
+    }
+
+    /** Copy the template into {@code out}, resolving each slot and dropping the unfilled ones. */
+    private void fill(ObjectNode template, ObjectNode out, Map<String, Object> args, Map<String, Object> session) {
+        java.util.Iterator<Map.Entry<String, JsonNode>> fields = template.fields();
+        while (fields.hasNext()) {
+            Map.Entry<String, JsonNode> field = fields.next();
+            JsonNode node = field.getValue();
+            if (node.isObject()) {
+                ObjectNode nested = mapper.createObjectNode();
+                fill((ObjectNode) node, nested, args, session);
+                out.set(field.getKey(), nested);
+                continue;
+            }
+            String slot = node.isTextual() ? slotName(node.asText()) : null;
+            if (slot == null) {
+                out.set(field.getKey(), node); // A literal the manifest meant to send.
+                continue;
+            }
+            Object value = slot.startsWith(SESSION_PREFIX)
+                    ? session.get(slot.substring(SESSION_PREFIX.length()))
+                    : args.get(slot);
+            if (value == null || String.valueOf(value).isBlank()) {
+                if (slot.startsWith(SESSION_PREFIX)) {
+                    throw new IllegalStateException(
+                            "This action needs a detail from your session that was not supplied. "
+                                    + "Sign out and back in, and if it happens again tell your administrator "
+                                    + "the Copilot did not receive the office for your login.");
                 }
-                String token = "\"${session." + entry.getKey() + "}\"";
-                out = value instanceof Number || value instanceof Boolean
-                        ? out.replace(token, String.valueOf(value))
-                        : out.replace(token, quoteJson(String.valueOf(value)));
+                continue; // Nothing to send, so send no field at all.
+            }
+            if (value instanceof Integer || value instanceof Long) {
+                out.put(field.getKey(), ((Number) value).longValue());
+            } else if (value instanceof Number) {
+                out.put(field.getKey(), ((Number) value).doubleValue());
+            } else if (value instanceof Boolean) {
+                out.put(field.getKey(), (Boolean) value);
+            } else {
+                out.put(field.getKey(), String.valueOf(value));
             }
         }
-        if (args != null) {
-            for (Map.Entry<String, Object> entry : args.entrySet()) {
-                String quotedToken = "\"${" + entry.getKey() + "}\"";
-                Object value = entry.getValue();
-                if (value == null || String.valueOf(value).isBlank()) {
-                    continue; // Treat blank args as omitted; the field is stripped below.
-                }
-                if (value instanceof Number || value instanceof Boolean) {
-                    out = out.replace(quotedToken, String.valueOf(value));
-                } else {
-                    out = out.replace(quotedToken, quoteJson(String.valueOf(value)));
-                }
-                // Deliberately NO unquoted "${key}" replacement: values must never be able to
-                // rewrite JSON structure or trigger recursive token substitution.
-            }
-        }
-        if (out.contains("${session.")) {
-            throw new IllegalStateException(
-                    "This action needs a detail from your session that was not supplied. "
-                            + "Sign out and back in, and if it happens again tell your administrator "
-                            + "the Copilot did not receive the office for your login.");
-        }
-        // Strip whole fields whose optional token was never filled: '"field":"${tok}",' / ',"field":"${tok}"'.
-        out = out.replaceAll("\"[A-Za-z0-9_]+\"\\s*:\\s*\"\\$\\{[A-Za-z0-9_.]+}\"\\s*,", "");
-        out = out.replaceAll(",\\s*\"[A-Za-z0-9_]+\"\\s*:\\s*\"\\$\\{[A-Za-z0-9_.]+}\"", "");
-        out = out.replaceAll("\"[A-Za-z0-9_]+\"\\s*:\\s*\"\\$\\{[A-Za-z0-9_.]+}\"", "");
-        return out;
+    }
+
+    private static final String SESSION_PREFIX = "session.";
+    private static final Pattern SLOT = Pattern.compile("^\\$\\{([A-Za-z0-9_.]+)}$");
+
+    /** The name inside a {@code ${...}} slot, or null when the text is an ordinary value. */
+    private static String slotName(String text) {
+        java.util.regex.Matcher matcher = SLOT.matcher(text);
+        return matcher.matches() ? matcher.group(1) : null;
     }
 
     /**

--- a/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
@@ -340,24 +340,14 @@ public final class FineractRestToolExecutor implements ToolExecutor {
     /**
      * Fill the request body.
      *
-     * <p>{@code ${session.x}} comes from the officer's logged-in session and is filled first,
-     * so a value the session owns cannot be shadowed by an argument the model produced. That
-     * is the point of the prefix: an office is decided by who is signed in, never by a
-     * sentence somebody typed.
-     */
-    /**
-     * Fill the request body.
-     *
      * <p>The template is itself valid JSON, with every slot written as a quoted
      * {@code "${name}"}, so it is parsed and walked rather than edited as text. Replacing
      * tokens by repeated string substitution meant a value could be read back as a token on
      * a later pass: a client whose surname was literally {@code ${mobileNo}} was persisted
      * with their phone number as their surname.
      *
-     * <p>A slot named {@code session.x} is filled from the officer's logged-in session and
-     * never from an argument, so a value the session owns cannot be shadowed by something the
-     * model produced. A slot with nothing to fill it is dropped, because Fineract must not
-     * receive an empty string standing in for a field the officer did not set.
+     * <p>A slot with nothing to fill it is dropped, because Fineract must not receive an empty
+     * string standing in for a field the officer did not set.
      */
     String buildBody(String template, Map<String, Object> args, String today, Map<String, Object> session) {
         if (template == null) {
@@ -399,12 +389,9 @@ public final class FineractRestToolExecutor implements ToolExecutor {
                     ? session.get(slot.substring(SESSION_PREFIX.length()))
                     : args.get(slot);
             if (value == null || String.valueOf(value).isBlank()) {
-                if (slot.startsWith(SESSION_PREFIX)) {
-                    throw new IllegalStateException(
-                            "This action needs a detail from your session that was not supplied. "
-                                    + "Sign out and back in, and if it happens again tell your administrator "
-                                    + "the Copilot did not receive the office for your login.");
-                }
+                // Including a session slot nothing filled. No manifest declares one now that the
+                // office is worked out from the credential, and an unfilled slot is a field the
+                // officer did not set, not a reason to throw out of a request that is being built.
                 continue; // Nothing to send, so send no field at all.
             }
             if (value instanceof Integer || value instanceof Long) {

--- a/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
@@ -79,14 +79,10 @@ public final class FineractRestToolExecutor implements ToolExecutor {
         }
 
         String today = businessDate(context);
-        if (tool.write()) {
-            verifyOffice(context.session(), context);
-        }
-        // The product owns its interest rate, its schedule and its strategy. Anything the
-        // officer did not name is read from it rather than invented here.
-        // Normalised first, so what executes is exactly what the card showed.
+        // Normalised first, so what executes is exactly what the card showed. The office is
+        // worked out from the officer's own credential before anything else is resolved.
         Map<String, Object> effective = withComputed(tool,
-                withDefaults(tool, normalizeArguments(tool, args, context), context));
+                withDefaults(tool, withOffice(tool, normalizeArguments(tool, args, context), context), context));
         String path = substitutePath(rest.path(), effective, today);
         HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create(fineractBaseUrl + path))
                 .timeout(Duration.ofSeconds(30))
@@ -201,30 +197,43 @@ public final class FineractRestToolExecutor implements ToolExecutor {
     }
 
     /**
-     * Refuse a session fact the officer's own credential cannot back up.
+     * The office a write lands in, worked out from the officer's own credential.
      *
-     * <p>The office arrives on the request the browser sends. That is the same trust level as
-     * the credential the browser already holds, and Fineract enforces permissions regardless,
-     * but a claim that is never checked is still a claim. Asking Fineract which offices this
-     * credential can see, and refusing anything outside that, costs one cached call and makes
-     * the value as trustworthy as the login it came with.
+     * <p>Fineract requires an office on a new client and offers no way to ask it who the
+     * caller is, so the gateway asks which offices this credential can reach. Where that is
+     * exactly one, it is theirs and there is nothing to decide. Where it is several, the
+     * officer says which, and it shows on the confirmation card so they see the branch before
+     * agreeing to it.
+     *
+     * <p>Deliberately not taken from the request the browser sends. A value the server can
+     * establish for itself should not be accepted on trust from a client, and routing it
+     * through the language model would let a branch be chosen by a sentence.
      */
-    private void verifyOffice(Map<String, Object> session, CallContext context) throws ToolExecutionException {
-        Object claimed = session.get("officeId");
-        if (claimed == null) {
-            return;
+    private Map<String, Object> withOffice(ToolDefinition tool, Map<String, Object> args, CallContext context)
+            throws ToolExecutionException {
+        String body = tool.rest() == null ? null : tool.rest().bodyTemplate();
+        if (!tool.write() || body == null || !body.contains("${officeId}")) {
+            return args;
         }
-        String key = context.fingerprint() + "|" + context.tenantId();
-        java.util.Set<String> allowed = officesByOfficer.computeIfAbsent(key, (k) -> readOffices(context));
-        if (allowed.isEmpty()) {
-            return; // Could not ask. Fineract still refuses what this officer may not do.
+        java.util.Set<String> reachable = officesByOfficer
+                .computeIfAbsent(context.fingerprint() + "|" + context.tenantId(), (k) -> readOffices(context));
+        Object stated = args.get("officeId");
+        if (stated != null && !String.valueOf(stated).isBlank()) {
+            if (!reachable.isEmpty() && !reachable.contains(String.valueOf(stated))) {
+                throw new ToolExecutionException("That office is not one you can work in.", 403, null);
+            }
+            return args;
         }
-        if (!allowed.contains(String.valueOf(claimed))) {
-            throw new ToolExecutionException(
-                    "That office is not one you can work in. Sign out and back in, and tell your "
-                            + "administrator if it happens again.",
-                    403, null);
+        if (reachable.size() == 1) {
+            java.util.Map<String, Object> out = new java.util.LinkedHashMap<>(args);
+            out.put("officeId", Long.parseLong(reachable.iterator().next()));
+            return out;
         }
+        throw new ToolExecutionException(
+                reachable.isEmpty()
+                        ? "Could not establish which office to use. Please try again."
+                        : "You work in more than one office, so please say which one this is for.",
+                0, null);
     }
 
     /** Office ids this credential can see, empty when the question could not be asked. */

--- a/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
@@ -75,7 +75,11 @@ public final class FineractRestToolExecutor implements ToolExecutor {
         }
 
         String today = businessDate(context);
-        String path = substitutePath(rest.path(), args, today);
+        // The product owns its interest rate, its schedule and its strategy. Anything the
+        // officer did not name is read from it rather than invented here.
+        // Normalised first, so what executes is exactly what the card showed.
+        Map<String, Object> effective = withDefaults(tool, normalizeArguments(tool, args, context), context);
+        String path = substitutePath(rest.path(), effective, today);
         HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create(fineractBaseUrl + path))
                 .timeout(Duration.ofSeconds(30))
                 .header("Accept", "application/json")
@@ -90,7 +94,7 @@ public final class FineractRestToolExecutor implements ToolExecutor {
         if ("GET".equalsIgnoreCase(rest.method())) {
             builder.GET();
         } else {
-            String body = buildBody(rest.bodyTemplate(), args, today);
+            String body = buildBody(rest.bodyTemplate(), effective, today, context.session());
             builder.method(rest.method().toUpperCase(Locale.ROOT),
                     HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8));
             builder.header("Content-Type", "application/json");
@@ -120,6 +124,66 @@ public final class FineractRestToolExecutor implements ToolExecutor {
         return truncate(redact(response.body(), tool.redactFields()), MAX_RESULT_CHARS);
     }
 
+    /**
+     * The officer's arguments, filled out from the record that owns the unspecified ones.
+     *
+     * <p>Fineract rejects a loan application that omits its interest rate, repayment
+     * frequency, amortisation or strategy, so those fields have to be sent. They belong to the
+     * loan product, and reading them from it is the difference between a loan on the terms the
+     * institution configured and a loan on whatever was written into this file.
+     *
+     * <p>An argument the officer supplied always wins. A lookup that fails changes nothing,
+     * and the request goes on to fail at Fineract with a message naming the missing field,
+     * which is a better answer than a silent wrong rate.
+     */
+    Map<String, Object> withDefaults(ToolDefinition tool, Map<String, Object> args, CallContext context) { // package-private for tests
+        ToolDefinition.Defaults spec = tool.defaults();
+        java.util.Map<String, Object> effective = new java.util.LinkedHashMap<>();
+        if (args != null) {
+            effective.putAll(args);
+        }
+        if (spec == null || spec.path() == null || spec.fields().isEmpty()) {
+            return effective;
+        }
+        boolean anythingMissing = spec.fields().keySet().stream()
+                .anyMatch((name) -> effective.get(name) == null || String.valueOf(effective.get(name)).isBlank());
+        if (!anythingMissing) {
+            return effective; // The officer named everything; no need to ask.
+        }
+        try {
+            String path = substitutePath(spec.path(), effective, businessDate(context));
+            HttpResponse<String> response = http.send(
+                    HttpRequest.newBuilder(URI.create(fineractBaseUrl + path))
+                            .timeout(Duration.ofSeconds(15))
+                            .header("Accept", "application/json")
+                            .header("Authorization", context.authorizationHeader())
+                            .header("Fineract-Platform-TenantId", context.tenantId())
+                            .GET()
+                            .build(),
+                    HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                return effective;
+            }
+            JsonNode body = mapper.readTree(response.body());
+            for (Map.Entry<String, String> field : spec.fields().entrySet()) {
+                Object supplied = effective.get(field.getKey());
+                if (supplied != null && !String.valueOf(supplied).isBlank()) {
+                    continue;
+                }
+                JsonNode node = at(body, field.getValue());
+                if (node == null || node.isMissingNode() || node.isNull()) {
+                    continue;
+                }
+                effective.put(field.getKey(), node.isNumber() ? (Object) node.numberValue() : node.asText());
+            }
+        } catch (ToolExecutionException | IOException | InterruptedException | RuntimeException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        return effective;
+    }
+
     /** Replace {param} tokens in the path, URL-encoding values; unresolved required tokens fail fast. */
     private String substitutePath(String template, Map<String, Object> args, String today) throws ToolExecutionException {
         String out = template;
@@ -142,10 +206,34 @@ public final class FineractRestToolExecutor implements ToolExecutor {
      * must never receive an empty-string stand-in for a field the officer did not set.
      */
     String buildBody(String template, Map<String, Object> args, String today) { // package-private for tests
+        return buildBody(template, args, today, Map.of());
+    }
+
+    /**
+     * Fill the request body.
+     *
+     * <p>{@code ${session.x}} comes from the officer's logged-in session and is filled first,
+     * so a value the session owns cannot be shadowed by an argument the model produced. That
+     * is the point of the prefix: an office is decided by who is signed in, never by a
+     * sentence somebody typed.
+     */
+    String buildBody(String template, Map<String, Object> args, String today, Map<String, Object> session) {
         if (template == null) {
             return "{}";
         }
         String out = template;
+        if (session != null) {
+            for (Map.Entry<String, Object> entry : session.entrySet()) {
+                Object value = entry.getValue();
+                if (value == null || String.valueOf(value).isBlank()) {
+                    continue;
+                }
+                String token = "\"${session." + entry.getKey() + "}\"";
+                out = value instanceof Number || value instanceof Boolean
+                        ? out.replace(token, String.valueOf(value))
+                        : out.replace(token, quoteJson(String.valueOf(value)));
+            }
+        }
         if (args != null) {
             for (Map.Entry<String, Object> entry : args.entrySet()) {
                 String quotedToken = "\"${" + entry.getKey() + "}\"";
@@ -156,16 +244,22 @@ public final class FineractRestToolExecutor implements ToolExecutor {
                 if (value instanceof Number || value instanceof Boolean) {
                     out = out.replace(quotedToken, String.valueOf(value));
                 } else {
-                    out = out.replace(quotedToken, quoteJson(normalizeValue(entry.getKey(), value, today)));
+                    out = out.replace(quotedToken, quoteJson(String.valueOf(value)));
                 }
                 // Deliberately NO unquoted "${key}" replacement: values must never be able to
                 // rewrite JSON structure or trigger recursive token substitution.
             }
         }
+        if (out.contains("${session.")) {
+            throw new IllegalStateException(
+                    "This action needs a detail from your session that was not supplied. "
+                            + "Sign out and back in, and if it happens again tell your administrator "
+                            + "the Copilot did not receive the office for your login.");
+        }
         // Strip whole fields whose optional token was never filled: '"field":"${tok}",' / ',"field":"${tok}"'.
-        out = out.replaceAll("\"[A-Za-z0-9_]+\"\\s*:\\s*\"\\$\\{[A-Za-z0-9_]+}\"\\s*,", "");
-        out = out.replaceAll(",\\s*\"[A-Za-z0-9_]+\"\\s*:\\s*\"\\$\\{[A-Za-z0-9_]+}\"", "");
-        out = out.replaceAll("\"[A-Za-z0-9_]+\"\\s*:\\s*\"\\$\\{[A-Za-z0-9_]+}\"", "");
+        out = out.replaceAll("\"[A-Za-z0-9_]+\"\\s*:\\s*\"\\$\\{[A-Za-z0-9_.]+}\"\\s*,", "");
+        out = out.replaceAll(",\\s*\"[A-Za-z0-9_]+\"\\s*:\\s*\"\\$\\{[A-Za-z0-9_.]+}\"", "");
+        out = out.replaceAll("\"[A-Za-z0-9_]+\"\\s*:\\s*\"\\$\\{[A-Za-z0-9_.]+}\"", "");
         return out;
     }
 
@@ -175,6 +269,20 @@ public final class FineractRestToolExecutor implements ToolExecutor {
      * date is clamped to it: Fineract rejects future-dated commands, and the officer meant "now".
      */
     private String normalizeValue(String name, Object value, String today) {
+        return normalizeValue(name, value, today, false);
+    }
+
+    /**
+     * A date as Fineract wants to read it.
+     *
+     * <p>Dates after the business date are pulled back to it, because Fineract refuses to book
+     * an approval or a repayment in its own future and the officer would otherwise get a
+     * validation error with no explanation. A parameter the manifest marks
+     * {@code futureAllowed} is left alone: an expected disbursement is supposed to be ahead,
+     * and moving it to today silently rewrites every instalment date on the schedule Fineract
+     * derives from it.
+     */
+    String normalizeValue(String name, Object value, String today, boolean futureAllowed) { // package-private for tests
         String raw = String.valueOf(value);
         boolean isDateParam = name.toLowerCase(Locale.ROOT).contains("date");
         if (!isDateParam) {
@@ -188,7 +296,45 @@ public final class FineractRestToolExecutor implements ToolExecutor {
         if (parsed == null) {
             return raw; // Already a Fineract-formatted or unrecognized value; pass it through.
         }
-        return (parsed.isAfter(businessDate) ? businessDate : parsed).format(FINERACT_DATE);
+        boolean clamp = !futureAllowed && parsed.isAfter(businessDate);
+        return (clamp ? businessDate : parsed).format(FINERACT_DATE);
+    }
+
+    /**
+     * The arguments as they will actually be sent.
+     *
+     * <p>Called before the confirmation card is built, so the officer reads the value that
+     * will run. Working this out twice, once for the card and once for the request, is how a
+     * card came to say "1 September" while the wire carried today's date.
+     */
+    @Override
+    public Map<String, Object> normalizeArguments(ToolDefinition tool, Map<String, Object> args,
+            CallContext context) {
+        if (args == null || args.isEmpty()) {
+            return Map.of();
+        }
+        String today = businessDate(context);
+        java.util.Map<String, Object> out = new java.util.LinkedHashMap<>();
+        for (Map.Entry<String, Object> entry : args.entrySet()) {
+            Object value = entry.getValue();
+            if (value instanceof Number || value instanceof Boolean || value == null) {
+                out.put(entry.getKey(), value);
+                continue;
+            }
+            out.put(entry.getKey(), normalizeValue(entry.getKey(), value, today, futureAllowed(tool, entry.getKey())));
+        }
+        return out;
+    }
+
+    private boolean futureAllowed(ToolDefinition tool, String param) {
+        if (tool == null || tool.params() == null) {
+            return false;
+        }
+        return tool.params().stream()
+                .filter((p) -> p.name().equals(param))
+                .findFirst()
+                .map(ToolDefinition.Param::allowsFuture)
+                .orElse(false);
     }
 
 

--- a/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
@@ -50,6 +50,10 @@ public final class FineractRestToolExecutor implements ToolExecutor {
      */
     private final java.util.Map<String, CachedDate> businessDateByTenant = new java.util.concurrent.ConcurrentHashMap<>();
 
+    /** Offices each officer may work in, keyed by their fingerprint so one cannot answer for another. */
+    private final java.util.Map<String, java.util.Set<String>> officesByOfficer =
+            new java.util.concurrent.ConcurrentHashMap<>();
+
     private record CachedDate(String value, long expiresAt) {}
 
     private final HttpClient http;
@@ -75,6 +79,9 @@ public final class FineractRestToolExecutor implements ToolExecutor {
         }
 
         String today = businessDate(context);
+        if (tool.write()) {
+            verifyOffice(context.session(), context);
+        }
         // The product owns its interest rate, its schedule and its strategy. Anything the
         // officer did not name is read from it rather than invented here.
         // Normalised first, so what executes is exactly what the card showed.
@@ -104,9 +111,13 @@ public final class FineractRestToolExecutor implements ToolExecutor {
         HttpResponse<String> response;
         try {
             response = http.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+        } catch (java.net.http.HttpConnectTimeoutException e) {
+            // Never got a connection, so nothing was sent and nothing can have run. This is a
+            // definite failure, and saying "we are not sure" would be its own kind of wrong.
+            throw new ToolExecutionException("Could not reach Fineract for " + tool.name(), 0, e);
         } catch (java.net.http.HttpTimeoutException e) {
-            // The request was sent and the answer never came. For a write, that is not the
-            // same as a refusal, and it must not be reported as one.
+            // Sent, and the answer never came. For a write that is not a refusal, and it must
+            // not be reported as one.
             throw new ToolExecutionException("Timed out waiting for " + tool.name(), 0, e, tool.write());
         } catch (IOException | InterruptedException e) {
             if (e instanceof InterruptedException) {
@@ -187,6 +198,63 @@ public final class FineractRestToolExecutor implements ToolExecutor {
             }
         }
         return effective;
+    }
+
+    /**
+     * Refuse a session fact the officer's own credential cannot back up.
+     *
+     * <p>The office arrives on the request the browser sends. That is the same trust level as
+     * the credential the browser already holds, and Fineract enforces permissions regardless,
+     * but a claim that is never checked is still a claim. Asking Fineract which offices this
+     * credential can see, and refusing anything outside that, costs one cached call and makes
+     * the value as trustworthy as the login it came with.
+     */
+    private void verifyOffice(Map<String, Object> session, CallContext context) throws ToolExecutionException {
+        Object claimed = session.get("officeId");
+        if (claimed == null) {
+            return;
+        }
+        String key = context.fingerprint() + "|" + context.tenantId();
+        java.util.Set<String> allowed = officesByOfficer.computeIfAbsent(key, (k) -> readOffices(context));
+        if (allowed.isEmpty()) {
+            return; // Could not ask. Fineract still refuses what this officer may not do.
+        }
+        if (!allowed.contains(String.valueOf(claimed))) {
+            throw new ToolExecutionException(
+                    "That office is not one you can work in. Sign out and back in, and tell your "
+                            + "administrator if it happens again.",
+                    403, null);
+        }
+    }
+
+    /** Office ids this credential can see, empty when the question could not be asked. */
+    private java.util.Set<String> readOffices(CallContext context) {
+        try {
+            HttpResponse<String> response = http.send(
+                    HttpRequest.newBuilder(URI.create(fineractBaseUrl + "/fineract-provider/api/v1/offices"))
+                            .timeout(Duration.ofSeconds(15))
+                            .header("Accept", "application/json")
+                            .header("Authorization", context.authorizationHeader())
+                            .header("Fineract-Platform-TenantId", context.tenantId())
+                            .GET()
+                            .build(),
+                    HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                return java.util.Set.of();
+            }
+            java.util.Set<String> ids = new java.util.LinkedHashSet<>();
+            for (JsonNode office : mapper.readTree(response.body())) {
+                if (office.hasNonNull("id")) {
+                    ids.add(office.get("id").asText());
+                }
+            }
+            return ids;
+        } catch (IOException | InterruptedException | RuntimeException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            return java.util.Set.of();
+        }
     }
 
     /**

--- a/gateway/src/main/java/org/mifos/community/copilot/core/tools/ToolDefinition.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/tools/ToolDefinition.java
@@ -18,7 +18,7 @@ import java.util.Map;
  * the LLM may touch and what counts as a write (ADR-001 §04, default-deny).
  */
 public record ToolDefinition(String name, String description, boolean write, String summaryTemplate,
-        List<Param> params, RestMapping rest, List<String> redactFields, List<Enrich> enrich) {
+        List<Param> params, RestMapping rest, List<String> redactFields, List<Enrich> enrich, Defaults defaults) {
 
     /**
      * One declared parameter.
@@ -30,7 +30,12 @@ public record ToolDefinition(String name, String description, boolean write, Str
      *     card by the account number and product name pulled in by {@link Enrich}
      */
     public record Param(String name, String type, boolean required, String description, String label, String format,
-            boolean show) {
+            boolean show, boolean futureAllowed) {
+
+        public Param(String name, String type, boolean required, String description, String label, String format,
+                boolean show) {
+            this(name, type, required, description, label, format, show, false);
+        }
 
         /** The label if the manifest gave one, otherwise the parameter name as a last resort. */
         public String displayLabel() {
@@ -43,6 +48,18 @@ public record ToolDefinition(String name, String description, boolean write, Str
 
         public boolean isDate() {
             return "date".equalsIgnoreCase(format);
+        }
+
+        /**
+         * Whether a date after the business date is legitimate for this field.
+         *
+         * <p>False for almost everything, because Fineract refuses to book a repayment or an
+         * approval in its own future. True for a date that is meant to be ahead: an expected
+         * disbursement is a plan, and clamping it to today rewrites the whole repayment
+         * schedule that Fineract generates from it.
+         */
+        public boolean allowsFuture() {
+            return futureAllowed;
         }
     }
 
@@ -59,6 +76,21 @@ public record ToolDefinition(String name, String description, boolean write, Str
      *     {@code #money:} is formatted as an amount
      */
     public record Enrich(String path, String currencyPath, Map<String, String> fields) {}
+
+    /**
+     * Where a tool's unspecified parameters come from.
+     *
+     * <p>Fineract requires a loan's interest rate, repayment frequency, amortisation and
+     * strategy on every application, and refuses the request without them. They belong to the
+     * loan product, so the manifest reads them from it rather than inventing values. Hardcoding
+     * an interest rate in a request body silently overrides whatever the institution
+     * configured, which is how every loan ends up at the same rate.
+     *
+     * <p>An officer who names a value keeps it. These only fill what was left unsaid.
+     *
+     * @param fields parameter name to a dotted path in the response
+     */
+    public record Defaults(String path, Map<String, String> fields) {}
 
     /** How the direct-REST executor maps this tool onto the core banking API. */
     public record RestMapping(String method, String path, String bodyTemplate) {}

--- a/gateway/src/main/java/org/mifos/community/copilot/core/tools/ToolDefinition.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/tools/ToolDefinition.java
@@ -18,7 +18,12 @@ import java.util.Map;
  * the LLM may touch and what counts as a write (ADR-001 §04, default-deny).
  */
 public record ToolDefinition(String name, String description, boolean write, String summaryTemplate,
-        List<Param> params, RestMapping rest, List<String> redactFields, List<Enrich> enrich, Defaults defaults) {
+        List<Param> params, RestMapping rest, List<String> redactFields, List<Enrich> enrich, Defaults defaults,
+        Map<String, String> computed) {
+
+    public ToolDefinition {
+        computed = computed == null ? Map.of() : Map.copyOf(computed);
+    }
 
     /**
      * One declared parameter.
@@ -91,6 +96,14 @@ public record ToolDefinition(String name, String description, boolean write, Str
      * @param fields parameter name to a dotted path in the response
      */
     public record Defaults(String path, Map<String, String> fields) {}
+
+    /*
+     * A tool may also declare `computed:` entries of the form "a * b", naming two other
+     * parameters. A loan's term is its number of repayments multiplied by how often it
+     * repays, and a manifest token cannot multiply. Aliasing the term to the repayment count
+     * is only right while a loan repays every single period; on a fortnightly product it
+     * understates the term by half, and Fineract books arrears against the wrong dates.
+     */
 
     /** How the direct-REST executor maps this tool onto the core banking API. */
     public record RestMapping(String method, String path, String bodyTemplate) {}

--- a/gateway/src/main/java/org/mifos/community/copilot/core/tools/ToolExecutionException.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/tools/ToolExecutionException.java
@@ -11,10 +11,16 @@ package org.mifos.community.copilot.core.tools;
 public class ToolExecutionException extends Exception {
 
     private final int statusCode;
+    private final boolean indeterminate;
 
     public ToolExecutionException(String message, int statusCode, Throwable cause) {
+        this(message, statusCode, cause, false);
+    }
+
+    public ToolExecutionException(String message, int statusCode, Throwable cause, boolean indeterminate) {
         super(message, cause);
         this.statusCode = statusCode;
+        this.indeterminate = indeterminate;
     }
 
     /** Fineract HTTP status, or 0 when the call never reached Fineract. */
@@ -28,5 +34,17 @@ public class ToolExecutionException extends Exception {
 
     public boolean isPermissionFailure() {
         return statusCode == 403;
+    }
+
+    /**
+     * True when the request may have been carried out despite the failure.
+     *
+     * <p>A read timeout is not a rejection. A disbursement that regenerates a schedule and
+     * posts accruals can take longer than the client will wait, and the write commits anyway.
+     * Telling an officer their disbursement failed when it succeeded invites them to do it
+     * again, and the second one is a second payment.
+     */
+    public boolean isIndeterminate() {
+        return indeterminate;
     }
 }

--- a/gateway/src/main/java/org/mifos/community/copilot/core/tools/ToolExecutor.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/tools/ToolExecutor.java
@@ -34,6 +34,15 @@ public interface ToolExecutor {
      * clock. Commands dated in Fineract's future are rejected, so both the system prompt and
      * date-parameter resolution must use THIS date, not {@code LocalDate.now()}.
      */
+    /**
+     * The arguments as this executor will actually send them, so a confirmation card can be
+     * built from the same values rather than from the model's originals.
+     */
+    default java.util.Map<String, Object> normalizeArguments(ToolDefinition tool, java.util.Map<String, Object> args,
+            CallContext context) {
+        return args == null ? java.util.Map.of() : args;
+    }
+
     default String businessDate(CallContext context) {
         return java.time.LocalDate.now().toString();
     }

--- a/gateway/src/main/java/org/mifos/community/copilot/core/tools/ToolManifest.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/tools/ToolManifest.java
@@ -42,7 +42,8 @@ public final class ToolManifest {
                         (String) param.get("format"),
                         // Shown on the confirmation card unless the manifest hides it, which
                         // it does for identifiers that mean nothing to an officer.
-                        !Boolean.FALSE.equals(param.get("show"))));
+                        !Boolean.FALSE.equals(param.get("show")),
+                        Boolean.TRUE.equals(param.get("futureAllowed"))));
             }
             ToolDefinition.RestMapping rest = null;
             Map<String, Object> restNode = (Map<String, Object>) entry.get("rest");
@@ -60,6 +61,14 @@ public final class ToolManifest {
                 enrich.add(new ToolDefinition.Enrich(
                         (String) node.get("path"), (String) node.get("currency"), fields));
             }
+            ToolDefinition.Defaults defaults = null;
+            Map<String, Object> defaultsNode = (Map<String, Object>) entry.get("defaults");
+            if (defaultsNode != null) {
+                Map<String, String> fields = new LinkedHashMap<>();
+                ((Map<String, Object>) defaultsNode.getOrDefault("fields", Map.of()))
+                        .forEach((param, path) -> fields.put(param, String.valueOf(path)));
+                defaults = new ToolDefinition.Defaults((String) defaultsNode.get("path"), fields);
+            }
             ToolDefinition definition = new ToolDefinition(
                     (String) entry.get("name"),
                     (String) entry.get("description"),
@@ -68,7 +77,8 @@ public final class ToolManifest {
                     params,
                     rest,
                     (List<String>) entry.getOrDefault("redactFields", List.of()),
-                    enrich);
+                    enrich,
+                    defaults);
             manifest.tools.put(definition.name(), definition);
         }
         return manifest;

--- a/gateway/src/main/java/org/mifos/community/copilot/core/tools/ToolManifest.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/tools/ToolManifest.java
@@ -78,7 +78,8 @@ public final class ToolManifest {
                     rest,
                     (List<String>) entry.getOrDefault("redactFields", List.of()),
                     enrich,
-                    defaults);
+                    defaults,
+                    (Map<String, String>) entry.getOrDefault("computed", Map.of()));
             manifest.tools.put(definition.name(), definition);
         }
         return manifest;

--- a/gateway/src/main/java/org/mifos/community/copilot/gateway/web/ChatController.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/gateway/web/ChatController.java
@@ -60,7 +60,7 @@ public class ChatController {
 
     @PostMapping(value = "/chat", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<ServerSentEvent<String>> chat(@RequestBody ChatRequest request, ServerHttpRequest http) {
-        return run(http, (context, sink) -> {
+        return run(http, sessionFacts(request.context()), (context, sink) -> {
             String message = request.message() == null ? "" : request.message().trim();
             if (message.isEmpty() || message.length() > 500) {
                 sink.emit(StreamEvent.error(ErrorCode.INTERNAL, "Message must be 1-500 characters.", false));
@@ -89,13 +89,45 @@ public class ChatController {
     @PostMapping(value = "/actions/{cardId}/decision", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<ServerSentEvent<String>> decision(@PathVariable String cardId, @RequestBody DecisionRequest request,
             ServerHttpRequest http) {
-        return run(http, (context, sink) ->
+        // No session facts here on purpose: the ones that matter were captured when the card
+        // was raised and travel with it, so the office a write lands in cannot be changed
+        // between an officer reading the card and pressing Confirm.
+        return run(http, Map.of(), (context, sink) ->
                 agentLoop.resume(cardId, request.isApprove(), Map.of(), context, sink));
     }
 
     /** Shared plumbing: extract identity, bridge the core EventSink onto a reactive SSE stream. */
-    private Flux<ServerSentEvent<String>> run(ServerHttpRequest http, BiConsumer<CallContext, EventSink> work) {
-        CallContext context = extractContext(http);
+    /**
+     * Facts the officer's session owns, taken off the screen context the panel sends.
+     *
+     * <p>Allowlisted and coerced to numbers, because these end up in a request body. They are
+     * browser-supplied, which is the same trust level as the credential the browser already
+     * holds, and Fineract still enforces what that officer may do. What this buys is narrower
+     * and worth having: the LANGUAGE MODEL cannot reach them. It cannot put a client in
+     * another branch by being asked nicely, because the branch never passes through it.
+     */
+    private static Map<String, Object> sessionFacts(Map<String, Object> screenContext) {
+        if (screenContext == null) {
+            return Map.of();
+        }
+        Map<String, Object> facts = new java.util.LinkedHashMap<>();
+        for (String key : new String[] { "officeId", "staffId" }) {
+            Object value = screenContext.get(key);
+            if (value == null) {
+                continue;
+            }
+            try {
+                facts.put(key, Long.parseLong(String.valueOf(value).trim()));
+            } catch (NumberFormatException e) {
+                // Not a number, so not an id. Leave it out rather than send it onward.
+            }
+        }
+        return facts;
+    }
+
+    private Flux<ServerSentEvent<String>> run(ServerHttpRequest http, Map<String, Object> session,
+            BiConsumer<CallContext, EventSink> work) {
+        CallContext context = extractContext(http, session);
         return Flux.<ServerSentEvent<String>>create((FluxSink<ServerSentEvent<String>> flux) -> {
             AtomicBoolean cancelled = new AtomicBoolean(false);
             flux.onCancel(() -> cancelled.set(true));
@@ -152,7 +184,7 @@ public class ChatController {
     }
 
     /** The officer's forwarded identity. Credentials are never logged (correlation id only). */
-    private CallContext extractContext(ServerHttpRequest http) {
+    private CallContext extractContext(ServerHttpRequest http, Map<String, Object> session) {
         String authorization = http.getHeaders().getFirst("Authorization");
         String tenant = sanitizeToken(http.getHeaders().getFirst("Fineract-Platform-TenantId"), 64);
         // Client-supplied and later logged/forwarded: restrict to a plain token so it can
@@ -161,7 +193,8 @@ public class ChatController {
         return new CallContext(
                 authorization,
                 tenant == null ? "default" : tenant,
-                correlation == null ? "cop-" + UUID.randomUUID() : correlation);
+                correlation == null ? "cop-" + UUID.randomUUID() : correlation,
+                session);
     }
 
     /** Same scheme+host+port comparison; malformed input counts as a mismatch (fail closed). */

--- a/gateway/src/main/java/org/mifos/community/copilot/gateway/web/ChatController.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/gateway/web/ChatController.java
@@ -60,7 +60,9 @@ public class ChatController {
 
     @PostMapping(value = "/chat", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<ServerSentEvent<String>> chat(@RequestBody ChatRequest request, ServerHttpRequest http) {
-        return run(http, sessionFacts(request.context()), (context, sink) -> {
+        // Nothing about the officer's identity is taken from the request body. The office a
+        // write lands in is worked out from their own credential, further down.
+        return run(http, Map.of(), (context, sink) -> {
             String message = request.message() == null ? "" : request.message().trim();
             if (message.isEmpty() || message.length() > 500) {
                 sink.emit(StreamEvent.error(ErrorCode.INTERNAL, "Message must be 1-500 characters.", false));
@@ -97,34 +99,6 @@ public class ChatController {
     }
 
     /** Shared plumbing: extract identity, bridge the core EventSink onto a reactive SSE stream. */
-    /**
-     * Facts the officer's session owns, taken off the screen context the panel sends.
-     *
-     * <p>Allowlisted and coerced to numbers, because these end up in a request body. They are
-     * browser-supplied, which is the same trust level as the credential the browser already
-     * holds, and Fineract still enforces what that officer may do. What this buys is narrower
-     * and worth having: the LANGUAGE MODEL cannot reach them. It cannot put a client in
-     * another branch by being asked nicely, because the branch never passes through it.
-     */
-    private static Map<String, Object> sessionFacts(Map<String, Object> screenContext) {
-        if (screenContext == null) {
-            return Map.of();
-        }
-        Map<String, Object> facts = new java.util.LinkedHashMap<>();
-        for (String key : new String[] { "officeId", "staffId" }) {
-            Object value = screenContext.get(key);
-            if (value == null) {
-                continue;
-            }
-            try {
-                facts.put(key, Long.parseLong(String.valueOf(value).trim()));
-            } catch (NumberFormatException e) {
-                // Not a number, so not an id. Leave it out rather than send it onward.
-            }
-        }
-        return facts;
-    }
-
     private Flux<ServerSentEvent<String>> run(ServerHttpRequest http, Map<String, Object> session,
             BiConsumer<CallContext, EventSink> work) {
         CallContext context = extractContext(http, session);

--- a/gateway/src/main/resources/tools.yaml
+++ b/gateway/src/main/resources/tools.yaml
@@ -13,6 +13,13 @@
 # the code the record is denominated in, so amounts on the card read "USD 28,000.00".
 #
 # `redactFields` are masked before results can reach a cloud model.
+#
+# Two things a body may read besides the officer's own arguments:
+#   ${session.x}  a fact the logged-in session owns, such as which office the officer works
+#                 in. The model cannot supply one, which is the point.
+#   defaults:     values read from the record that owns them before the request is built, so a
+#                 loan takes its rate and its schedule from its product rather than from a
+#                 literal written here. Anything the officer named is left alone.
 
 tools:
   # ── Reading ──────────────────────────────────────────────────────────────────
@@ -81,7 +88,7 @@ tools:
 
   # ── Writing, every one pauses for the officer ────────────────────────────────
   - name: mifos_client_create
-    description: Create and activate a new client. Requires the officer's confirmation.
+    description: Create and activate a new client in the officer's own office. Requires the officer's confirmation.
     summary: "Create client {firstname} {lastname}"
     write: true
     params:
@@ -89,10 +96,14 @@ tools:
       - { name: lastname, type: string, required: true, label: Last name }
       - { name: activationDate, type: string, required: true, label: Activation date, format: date, description: "Date as yyyy-MM-dd, or the word today" }
       - { name: mobileNo, type: string, required: false, label: Mobile number }
+      - { name: dateOfBirth, type: string, required: false, label: Date of birth, format: date, description: "Date as yyyy-MM-dd" }
+      - { name: externalId, type: string, required: false, label: External id, description: "The institution's own reference for this client, such as a national id" }
     rest:
       method: POST
       path: /fineract-provider/api/v1/clients
-      body: '{"officeId":1,"firstname":"${firstname}","lastname":"${lastname}","mobileNo":"${mobileNo}","legalFormId":1,"active":true,"activationDate":"${activationDate}","dateFormat":"dd MMMM yyyy","locale":"en"}'
+      # officeId comes from the officer's session. It was a literal 1, which put every client
+      # created through the Copilot into head office whatever branch the officer worked in.
+      body: '{"officeId":"${session.officeId}","firstname":"${firstname}","lastname":"${lastname}","mobileNo":"${mobileNo}","dateOfBirth":"${dateOfBirth}","externalId":"${externalId}","legalFormId":1,"active":true,"activationDate":"${activationDate}","dateFormat":"dd MMMM yyyy","locale":"en"}'
 
   - name: mifos_loan_create
     description: Submit a new loan application for a client. Requires the officer's confirmation.
@@ -104,7 +115,9 @@ tools:
       - { name: principal, type: number, required: true, label: Principal, format: money }
       - { name: numberOfRepayments, type: integer, required: true, label: Repayments, description: Number of monthly instalments }
       - { name: submittedOnDate, type: string, required: true, label: Submitted on, format: date, description: "Date as yyyy-MM-dd, or today" }
-      - { name: expectedDisbursementDate, type: string, required: true, label: Expected disbursement, format: date, description: "Date as yyyy-MM-dd, or today" }
+      # The one date that is meant to be in the future. Clamping it to the business date
+      # rewrites every instalment on the schedule Fineract derives from it.
+      - { name: expectedDisbursementDate, type: string, required: true, label: Expected disbursement, format: date, futureAllowed: true, description: "Date as yyyy-MM-dd, or today" }
     enrich:
       - path: /fineract-provider/api/v1/clients/{clientId}
         fields:
@@ -115,10 +128,26 @@ tools:
         currency: currency.code
         fields:
           Product: name
+    # Fineract requires all of these on every application and refuses the request without
+    # them, so they cannot be left out. They belong to the loan product, and they were written
+    # here as literals: every loan carried 12 percent and a monthly schedule whatever the
+    # product said, which for a weekly microfinance product is simply the wrong loan.
+    defaults:
+      path: /fineract-provider/api/v1/loanproducts/{productId}
+      fields:
+        interestRatePerPeriod: interestRatePerPeriod
+        numberOfRepayments: numberOfRepayments
+        repaymentEvery: repaymentEvery
+        repaymentFrequencyType: repaymentFrequencyType.id
+        loanTermFrequencyType: repaymentFrequencyType.id
+        amortizationType: amortizationType.id
+        interestType: interestType.id
+        interestCalculationPeriodType: interestCalculationPeriodType.id
+        transactionProcessingStrategyCode: transactionProcessingStrategyCode
     rest:
       method: POST
       path: /fineract-provider/api/v1/loans
-      body: '{"clientId":"${clientId}","productId":"${productId}","principal":"${principal}","loanTermFrequency":"${numberOfRepayments}","loanTermFrequencyType":2,"numberOfRepayments":"${numberOfRepayments}","repaymentEvery":1,"repaymentFrequencyType":2,"interestRatePerPeriod":12,"amortizationType":1,"interestType":1,"interestCalculationPeriodType":1,"transactionProcessingStrategyCode":"mifos-standard-strategy","expectedDisbursementDate":"${expectedDisbursementDate}","submittedOnDate":"${submittedOnDate}","loanType":"individual","locale":"en","dateFormat":"dd MMMM yyyy"}'
+      body: '{"clientId":"${clientId}","productId":"${productId}","principal":"${principal}","loanTermFrequency":"${numberOfRepayments}","loanTermFrequencyType":"${loanTermFrequencyType}","numberOfRepayments":"${numberOfRepayments}","repaymentEvery":"${repaymentEvery}","repaymentFrequencyType":"${repaymentFrequencyType}","interestRatePerPeriod":"${interestRatePerPeriod}","amortizationType":"${amortizationType}","interestType":"${interestType}","interestCalculationPeriodType":"${interestCalculationPeriodType}","transactionProcessingStrategyCode":"${transactionProcessingStrategyCode}","expectedDisbursementDate":"${expectedDisbursementDate}","submittedOnDate":"${submittedOnDate}","loanType":"individual","locale":"en","dateFormat":"dd MMMM yyyy"}'
 
   - name: mifos_loan_approve
     description: Approve a loan application that is awaiting approval. Requires the officer's confirmation.

--- a/gateway/src/main/resources/tools.yaml
+++ b/gateway/src/main/resources/tools.yaml
@@ -98,12 +98,14 @@ tools:
       - { name: mobileNo, type: string, required: false, label: Mobile number }
       - { name: dateOfBirth, type: string, required: false, label: Date of birth, format: date, description: "Date as yyyy-MM-dd" }
       - { name: externalId, type: string, required: false, label: External id, description: "The institution's own reference for this client, such as a national id" }
+      # Filled from the officer's own credential when only one office is reachable.
+      - { name: officeId, type: integer, required: false, label: Office, description: "Only needed when the officer works in more than one office" }
     rest:
       method: POST
       path: /fineract-provider/api/v1/clients
       # officeId comes from the officer's session. It was a literal 1, which put every client
       # created through the Copilot into head office whatever branch the officer worked in.
-      body: '{"officeId":"${session.officeId}","firstname":"${firstname}","lastname":"${lastname}","mobileNo":"${mobileNo}","dateOfBirth":"${dateOfBirth}","externalId":"${externalId}","legalFormId":1,"active":true,"activationDate":"${activationDate}","dateFormat":"dd MMMM yyyy","locale":"en"}'
+      body: '{"officeId":"${officeId}","firstname":"${firstname}","lastname":"${lastname}","mobileNo":"${mobileNo}","dateOfBirth":"${dateOfBirth}","externalId":"${externalId}","legalFormId":1,"active":true,"activationDate":"${activationDate}","dateFormat":"dd MMMM yyyy","locale":"en"}'
     # A rejected creation comes back echoing what was sent, and that answer is fed to the
     # model. The read tool masks the same two fields.
     redactFields: [mobileNo, dateOfBirth]

--- a/gateway/src/main/resources/tools.yaml
+++ b/gateway/src/main/resources/tools.yaml
@@ -104,6 +104,9 @@ tools:
       # officeId comes from the officer's session. It was a literal 1, which put every client
       # created through the Copilot into head office whatever branch the officer worked in.
       body: '{"officeId":"${session.officeId}","firstname":"${firstname}","lastname":"${lastname}","mobileNo":"${mobileNo}","dateOfBirth":"${dateOfBirth}","externalId":"${externalId}","legalFormId":1,"active":true,"activationDate":"${activationDate}","dateFormat":"dd MMMM yyyy","locale":"en"}'
+    # A rejected creation comes back echoing what was sent, and that answer is fed to the
+    # model. The read tool masks the same two fields.
+    redactFields: [mobileNo, dateOfBirth]
 
   - name: mifos_loan_create
     description: Submit a new loan application for a client. Requires the officer's confirmation.

--- a/gateway/src/main/resources/tools.yaml
+++ b/gateway/src/main/resources/tools.yaml
@@ -144,10 +144,14 @@ tools:
         interestType: interestType.id
         interestCalculationPeriodType: interestCalculationPeriodType.id
         transactionProcessingStrategyCode: transactionProcessingStrategyCode
+    # The term is the repayment count times how often the loan repays. Writing it as the
+    # repayment count alone was right only while repaymentEvery was pinned to 1.
+    computed:
+      loanTermFrequency: numberOfRepayments * repaymentEvery
     rest:
       method: POST
       path: /fineract-provider/api/v1/loans
-      body: '{"clientId":"${clientId}","productId":"${productId}","principal":"${principal}","loanTermFrequency":"${numberOfRepayments}","loanTermFrequencyType":"${loanTermFrequencyType}","numberOfRepayments":"${numberOfRepayments}","repaymentEvery":"${repaymentEvery}","repaymentFrequencyType":"${repaymentFrequencyType}","interestRatePerPeriod":"${interestRatePerPeriod}","amortizationType":"${amortizationType}","interestType":"${interestType}","interestCalculationPeriodType":"${interestCalculationPeriodType}","transactionProcessingStrategyCode":"${transactionProcessingStrategyCode}","expectedDisbursementDate":"${expectedDisbursementDate}","submittedOnDate":"${submittedOnDate}","loanType":"individual","locale":"en","dateFormat":"dd MMMM yyyy"}'
+      body: '{"clientId":"${clientId}","productId":"${productId}","principal":"${principal}","loanTermFrequency":"${loanTermFrequency}","loanTermFrequencyType":"${loanTermFrequencyType}","numberOfRepayments":"${numberOfRepayments}","repaymentEvery":"${repaymentEvery}","repaymentFrequencyType":"${repaymentFrequencyType}","interestRatePerPeriod":"${interestRatePerPeriod}","amortizationType":"${amortizationType}","interestType":"${interestType}","interestCalculationPeriodType":"${interestCalculationPeriodType}","transactionProcessingStrategyCode":"${transactionProcessingStrategyCode}","expectedDisbursementDate":"${expectedDisbursementDate}","submittedOnDate":"${submittedOnDate}","loanType":"individual","locale":"en","dateFormat":"dd MMMM yyyy"}'
 
   - name: mifos_loan_approve
     description: Approve a loan application that is awaiting approval. Requires the officer's confirmation.

--- a/gateway/src/test/java/org/mifos/community/copilot/core/AgentLoopTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/AgentLoopTest.java
@@ -446,7 +446,7 @@ class AgentLoopTest {
 
         PendingApproval approval = new PendingApproval("card-1", "conv-1",
                 new LlmToolCall("c1", "write_tool", Map.of()), "Approve", "cop-1",
-                officer.fingerprint(), java.time.Instant.now().plusSeconds(60), mutable);
+                officer.fingerprint(), java.time.Instant.now().plusSeconds(60), mutable, Map.of());
         mutable.put("Client", "Someone Else");
 
         assertThat(approval.rows()).containsExactly(entry("Client", "Aisha Bello"));

--- a/gateway/src/test/java/org/mifos/community/copilot/core/AgentLoopTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/AgentLoopTest.java
@@ -256,8 +256,90 @@ class AgentLoopTest {
 
     // ─── Test doubles ──────────────────────────────────────────────────────────
 
+    /**
+     * An officer is shown a confirmation and never answers it.
+     *
+     * <p>Approve and reject both write a result against the paused call. Walking away writes
+     * nothing, and a conversation carrying a tool call that was asked and never answered is
+     * rejected outright by every OpenAI-shaped provider. Their next message would come back
+     * HTTP 400, and would keep coming back HTTP 400, so a moment's hesitation would cost them
+     * the conversation.
+     */
+    @Test
+    void anUndecidedCardDoesNotBreakTheNextMessage() {
+        String conversationId = openConversation();
+        llm.enqueue(new LlmResult("", List.of(new LlmToolCall("c1", "write_tool", Map.of("loanId", 7)))));
+        loop().runTurn(conversationId, "approve loan 7", Map.of(), officer, sink);
+        assertThat(sink.names()).contains("action_card");
+
+        // No decision. The officer asks for something else instead.
+        llm.enqueue(new LlmResult("Here is the list.", List.of()));
+        loop().runTurn(conversationId, "actually, show me today's clients", Map.of(), officer, sink);
+
+        assertThat(unansweredIn(llm.lastMessages))
+                .as("every tool call the provider is shown has a result against it")
+                .isEmpty();
+    }
+
+    @Test
+    void anAbandonedCardCanNoLongerBeApproved() {
+        String conversationId = openConversation();
+        llm.enqueue(new LlmResult("", List.of(new LlmToolCall("c1", "write_tool", Map.of("loanId", 7)))));
+        loop().runTurn(conversationId, "approve loan 7", Map.of(), officer, sink);
+        String cardId = String.valueOf(sink.byName("action_card").data().get("card_id"));
+
+        llm.enqueue(new LlmResult("Here is the list.", List.of()));
+        loop().runTurn(conversationId, "actually, show me today's clients", Map.of(), officer, sink);
+
+        RecordingSink lateDecision = new RecordingSink();
+        loop().resume(cardId, true, Map.of(), officer, lateDecision);
+
+        assertThat(executor.executed).as("a card the conversation has moved past does not execute")
+                .doesNotContain("write_tool");
+        assertThat(lateDecision.byName("error").data().get("code")).isEqualTo("PERMISSION_DENIED");
+    }
+
+    /** Start a conversation and return the id the store actually minted for it. */
+    private String openConversation() {
+        llm.enqueue(new LlmResult("Hello.", List.of()));
+        RecordingSink opening = new RecordingSink();
+        loop().runTurn(null, "hello", Map.of(), officer, opening);
+        return String.valueOf(opening.byName("done").data().get("conversation_id"));
+    }
+
+    /** Tool call ids in the trailing assistant tool_calls message with nothing answering them. */
+    private static List<String> unansweredIn(List<Map<String, Object>> messages) {
+        int last = -1;
+        for (int i = messages.size() - 1; i >= 0; i--) {
+            if (messages.get(i).get("tool_calls") != null) {
+                last = i;
+                break;
+            }
+        }
+        if (last < 0) {
+            return List.of();
+        }
+        java.util.Set<String> answered = new java.util.LinkedHashSet<>();
+        for (int i = last + 1; i < messages.size(); i++) {
+            Object id = messages.get(i).get("tool_call_id");
+            if (id != null) {
+                answered.add(String.valueOf(id));
+            }
+        }
+        List<String> unanswered = new ArrayList<>();
+        for (Object entry : (List<?>) messages.get(last).get("tool_calls")) {
+            Object id = ((Map<?, ?>) entry).get("id");
+            String text = id == null ? "call-0" : String.valueOf(id);
+            if (!answered.contains(text)) {
+                unanswered.add(text);
+            }
+        }
+        return unanswered;
+    }
+
     private static final class ScriptedLlm implements LlmClient {
         private final Deque<LlmResult> queue = new ArrayDeque<>();
+        private List<Map<String, Object>> lastMessages = List.of();
 
         void enqueue(LlmResult result) {
             queue.add(result);
@@ -266,6 +348,7 @@ class AgentLoopTest {
         @Override
         public LlmResult complete(List<Map<String, Object>> messages, List<Map<String, Object>> tools,
                 java.util.function.Consumer<String> onToken, java.util.function.BooleanSupplier cancelled) {
+            lastMessages = List.copyOf(messages);
             LlmResult result = queue.poll();
             if (result == null) {
                 return new LlmResult("(no scripted response)", List.of());

--- a/gateway/src/test/java/org/mifos/community/copilot/core/ToolManifestTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/ToolManifestTest.java
@@ -136,10 +136,14 @@ class ToolManifestTest {
 
     @Test
     void aNewClientGoesToTheOfficersOwnOfficeRatherThanOfficeOne() {
+        // The office is a slot the executor fills from the officer's own credential, not a
+        // literal and not something the browser or the model gets to choose.
         ToolDefinition create = manifest.find("mifos_client_create").orElseThrow();
 
-        assertThat(create.rest().bodyTemplate()).contains("\"officeId\":\"${session.officeId}\"");
+        assertThat(create.rest().bodyTemplate()).contains("\"officeId\":\"${officeId}\"");
         assertThat(create.rest().bodyTemplate()).doesNotContain("\"officeId\":1");
+        assertThat(param(create, "officeId").required()).isFalse();
+        assertThat(param(create, "officeId").displayLabel()).isEqualTo("Office");
     }
 
     @Test

--- a/gateway/src/test/java/org/mifos/community/copilot/core/ToolManifestTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/ToolManifestTest.java
@@ -111,4 +111,53 @@ class ToolManifestTest {
     private static ToolDefinition.Param param(ToolDefinition tool, String name) {
         return tool.params().stream().filter((p) -> p.name().equals(name)).findFirst().orElseThrow();
     }
+
+    @Test
+    void aLoansTermIsComputedRatherThanAliasedToItsRepaymentCount() {
+        // The term is the repayment count times how often the loan repays. Sending the count
+        // alone is right only while repaymentEvery is 1, which it no longer is now that the
+        // value comes from the product: a fortnightly loan had half the term it should.
+        ToolDefinition create = manifest.find("mifos_loan_create").orElseThrow();
+
+        assertThat(create.computed()).containsEntry("loanTermFrequency", "numberOfRepayments * repaymentEvery");
+        assertThat(create.rest().bodyTemplate()).contains("\"loanTermFrequency\":\"${loanTermFrequency}\"");
+    }
+
+    @Test
+    void aLoanReadsItsTermsFromItsProductInsteadOfCarryingThemInTheManifest() {
+        ToolDefinition create = manifest.find("mifos_loan_create").orElseThrow();
+
+        assertThat(create.defaults()).isNotNull();
+        assertThat(create.defaults().fields())
+                .containsKeys("interestRatePerPeriod", "repaymentEvery", "repaymentFrequencyType",
+                        "amortizationType", "interestType", "transactionProcessingStrategyCode");
+        assertThat(create.rest().bodyTemplate()).doesNotContain("\"interestRatePerPeriod\":12");
+    }
+
+    @Test
+    void aNewClientGoesToTheOfficersOwnOfficeRatherThanOfficeOne() {
+        ToolDefinition create = manifest.find("mifos_client_create").orElseThrow();
+
+        assertThat(create.rest().bodyTemplate()).contains("\"officeId\":\"${session.officeId}\"");
+        assertThat(create.rest().bodyTemplate()).doesNotContain("\"officeId\":1");
+    }
+
+    @Test
+    void theOnlyDateAllowedToBeAheadIsTheOneThatIsMeantToBe() {
+        // Fineract refuses an approval or a repayment in its own future, so those are pulled
+        // back. An expected disbursement is a plan and has to survive as the officer set it.
+        for (ToolDefinition tool : manifest.all()) {
+            for (ToolDefinition.Param param : tool.params()) {
+                if (param.allowsFuture()) {
+                    assertThat(param.name())
+                            .as("%s.%s", tool.name(), param.name())
+                            .isEqualTo("expectedDisbursementDate");
+                }
+            }
+        }
+        assertThat(param(manifest.find("mifos_loan_create").orElseThrow(), "expectedDisbursementDate").allowsFuture())
+                .isTrue();
+        assertThat(param(manifest.find("mifos_loan_approve").orElseThrow(), "approvedOnDate").allowsFuture())
+                .isFalse();
+    }
 }

--- a/gateway/src/test/java/org/mifos/community/copilot/core/tools/EnrichmentTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/tools/EnrichmentTest.java
@@ -103,7 +103,8 @@ class EnrichmentTest {
                 List.of(new ToolDefinition.Param("loanId", "integer", true, null, "Loan account", null, false)),
                 new ToolDefinition.RestMapping("POST", "/loans/{loanId}", "{}"),
                 List.of(),
-                List.of(blocks));
+                List.of(blocks),
+                null);
     }
 
     private Map<String, String> enrichLoan12(ToolDefinition.Enrich... blocks) {

--- a/gateway/src/test/java/org/mifos/community/copilot/core/tools/EnrichmentTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/tools/EnrichmentTest.java
@@ -104,7 +104,8 @@ class EnrichmentTest {
                 new ToolDefinition.RestMapping("POST", "/loans/{loanId}", "{}"),
                 List.of(),
                 List.of(blocks),
-                null);
+                null,
+                Map.of());
     }
 
     private Map<String, String> enrichLoan12(ToolDefinition.Enrich... blocks) {

--- a/gateway/src/test/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutorTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutorTest.java
@@ -37,7 +37,7 @@ class FineractRestToolExecutorTest {
     @Test
     void approvedAmountShownOnTheCardReachesTheBody() throws Exception {
         Map<String, Object> args = new LinkedHashMap<>();
-        args.put("approvedOnDate", "2026-08-09");
+        args.put("approvedOnDate", executor.normalizeValue("approvedOnDate", "2026-08-09", TODAY, false));
         args.put("approvedLoanAmount", 40000);
 
         JsonNode body = mapper.readTree(executor.buildBody(APPROVE_TEMPLATE, args, TODAY));
@@ -78,20 +78,24 @@ class FineractRestToolExecutorTest {
     }
 
     @Test
-    void futureDatesAreClampedToTheBusinessDate() throws Exception {
-        // Fineract rejects future-dated commands; a host clock ahead of the business date
-        // must never turn a valid request into a rejection.
-        JsonNode body = mapper.readTree(
-                executor.buildBody(APPROVE_TEMPLATE, Map.of("approvedOnDate", "2026-12-31"), TODAY));
-
-        assertThat(body.get("approvedOnDate").asText()).isEqualTo("09 August 2026");
+    void aFutureDateIsPulledBackToTheBusinessDate() {
+        // Fineract refuses to book an approval in its own future, so an approval date ahead
+        // of the business date is pulled back rather than sent and rejected.
+        assertThat(executor.normalizeValue("approvedOnDate", "2026-12-31", TODAY, false))
+                .isEqualTo("09 August 2026");
     }
 
     @Test
-    void wordTodayResolvesToTheBusinessDateNotTheHostClock() throws Exception {
-        JsonNode body = mapper.readTree(
-                executor.buildBody(APPROVE_TEMPLATE, Map.of("approvedOnDate", "today"), TODAY));
+    void aDateThatIsMeantToBeAheadIsLeftWhereTheOfficerPutIt() {
+        // An expected disbursement is a plan. Pulling it back to today rewrites every
+        // instalment date on the schedule Fineract generates from it.
+        assertThat(executor.normalizeValue("expectedDisbursementDate", "2026-12-31", TODAY, true))
+                .isEqualTo("31 December 2026");
+    }
 
-        assertThat(body.get("approvedOnDate").asText()).isEqualTo("09 August 2026");
+    @Test
+    void theWordTodayBecomesTheBusinessDateNotTheHostClock() {
+        assertThat(executor.normalizeValue("approvedOnDate", "today", TODAY, false))
+                .isEqualTo("09 August 2026");
     }
 }

--- a/gateway/src/test/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutorTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutorTest.java
@@ -98,4 +98,44 @@ class FineractRestToolExecutorTest {
         assertThat(executor.normalizeValue("approvedOnDate", "today", TODAY, false))
                 .isEqualTo("09 August 2026");
     }
+
+    @Test
+    void aValueThatLooksLikeASlotIsStoredAndNotResolvedAgain() throws Exception {
+        // Repeated string substitution wrote the value in, then read it back as a slot on a
+        // later pass, so a client whose surname was literally ${mobileNo} was persisted with
+        // their phone number as their surname.
+        String template = "{\"lastname\":\"${lastname}\",\"mobileNo\":\"${mobileNo}\"}";
+        Map<String, Object> args = new LinkedHashMap<>();
+        args.put("lastname", "${mobileNo}");
+        args.put("mobileNo", "0803 555 0147");
+
+        JsonNode body = mapper.readTree(executor.buildBody(template, args, TODAY));
+
+        assertThat(body.get("lastname").asText()).isEqualTo("${mobileNo}");
+        assertThat(body.get("mobileNo").asText()).isEqualTo("0803 555 0147");
+    }
+
+    @Test
+    void aValueThatLooksLikeASlotDoesNotDeleteItsOwnField() throws Exception {
+        String template = "{\"lastname\":\"${lastname}\",\"firstname\":\"${firstname}\"}";
+        Map<String, Object> args = new LinkedHashMap<>();
+        args.put("lastname", "${firstname}");
+        args.put("firstname", "Aisha");
+
+        JsonNode body = mapper.readTree(executor.buildBody(template, args, TODAY));
+
+        assertThat(body.has("lastname")).isTrue();
+        assertThat(body.get("lastname").asText()).isEqualTo("${firstname}");
+    }
+
+    @Test
+    void aValueCarryingQuotesAndBracesStaysAValue() throws Exception {
+        String template = "{\"firstname\":\"${firstname}\",\"legalFormId\":1}";
+
+        JsonNode body = mapper.readTree(executor.buildBody(template,
+                Map.of("firstname", "\",\"legalFormId\":99,\"x\":\""), TODAY));
+
+        assertThat(body.get("legalFormId").asInt()).isEqualTo(1);
+        assertThat(body.size()).isEqualTo(2);
+    }
 }

--- a/gateway/src/test/java/org/mifos/community/copilot/core/tools/ValueSourceTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/tools/ValueSourceTest.java
@@ -92,7 +92,8 @@ class ValueSourceTest {
                 List.of(new ToolDefinition.Param("productId", "integer", true, null, "Product", null, false)),
                 new ToolDefinition.RestMapping("POST", "/loans", LOAN_BODY),
                 List.of(), List.of(),
-                new ToolDefinition.Defaults("/loanproducts/{productId}", fields));
+                new ToolDefinition.Defaults("/loanproducts/{productId}", fields),
+                Map.of());
     }
 
     @Test

--- a/gateway/src/test/java/org/mifos/community/copilot/core/tools/ValueSourceTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/tools/ValueSourceTest.java
@@ -163,28 +163,26 @@ class ValueSourceTest {
         assertThat(body).doesNotContain("99");
     }
 
+    /**
+     * Building a request body does not throw, whatever it is handed.
+     *
+     * <p>It used to, for a session slot nothing filled, back when the office arrived on the
+     * request from the browser and its absence meant something had gone wrong. The office is
+     * now worked out from the officer's own credential before the body is built, so an
+     * unfilled slot is just a field nobody set. Throwing from here ended the turn with no
+     * explanation and the officer's card already spent, which was a poor trade for a
+     * condition that can no longer arise.
+     */
     @Test
-    void anAbsentSessionFactRefusesTheRequestRatherThanQuietlyDroppingTheField() {
-        // Dropping it would post a client with no office and let Fineract decide, which is the
-        // same class of wrongness the session token was introduced to remove.
+    void anUnfilledSlotIsDroppedRatherThanThrowingOutOfAHalfBuiltRequest() {
         String template = "{\"officeId\":\"${session.officeId}\",\"firstname\":\"${firstname}\"}";
         FineractRestToolExecutor executor = new FineractRestToolExecutor(baseUrl);
 
-        assertThatThrownBy(() -> executor.buildBody(template, Map.of("firstname", "Aisha"), "2026-08-22", Map.of()))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("office");
-    }
+        String body = executor.buildBody(template, Map.of("firstname", "Aisha"), "2026-08-22", Map.of());
 
-
-    @Test
-    void aBodyTemplateThatCannotBeFilledIsRefusedRatherThanSentIncomplete() {
-        // The refusal is an unchecked exception, and the loop has to survive it: letting it
-        // escape ends the turn with no explanation and the officer's card already spent.
-        String template = "{\"officeId\":\"${session.officeId}\"}";
-        FineractRestToolExecutor executor = new FineractRestToolExecutor(baseUrl);
-
-        assertThatThrownBy(() -> executor.buildBody(template, Map.of(), "2026-08-22", Map.of()))
-                .isInstanceOf(IllegalStateException.class);
+        assertThat(body).contains("Aisha");
+        assertThat(body).as("no empty string standing in for a field nobody set")
+                .doesNotContain("officeId");
     }
 
     @Test

--- a/gateway/src/test/java/org/mifos/community/copilot/core/tools/ValueSourceTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/tools/ValueSourceTest.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at
+ * http://mozilla.org/MPL/2.0/.
+ */
+package org.mifos.community.copilot.core.tools;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mifos.community.copilot.core.auth.CallContext;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Where the values in a request body come from.
+ *
+ * <p>Two of them were literals written into the manifest, and both were wrong in a way that
+ * only shows up outside a one-office test system. Every client was created in office 1, and
+ * every loan carried a twelve percent rate on a monthly schedule whatever its product said.
+ * A value that belongs to the officer's session or to the product has to be read from there.
+ */
+class ValueSourceTest {
+
+    private static final String PRODUCT_JSON = """
+            {
+              "id": 3,
+              "name": "Weekly Market Loan",
+              "interestRatePerPeriod": 2.5,
+              "numberOfRepayments": 16,
+              "repaymentEvery": 1,
+              "repaymentFrequencyType": { "id": 1, "value": "Weeks" },
+              "amortizationType": { "id": 1, "value": "Equal installments" },
+              "interestType": { "id": 0, "value": "Declining Balance" },
+              "interestCalculationPeriodType": { "id": 1, "value": "Same as repayment period" },
+              "transactionProcessingStrategyCode": "early-repayment-strategy"
+            }
+            """;
+
+    private static final String LOAN_BODY = "{\"clientId\":\"${clientId}\",\"productId\":\"${productId}\","
+            + "\"principal\":\"${principal}\",\"repaymentFrequencyType\":\"${repaymentFrequencyType}\","
+            + "\"interestRatePerPeriod\":\"${interestRatePerPeriod}\","
+            + "\"transactionProcessingStrategyCode\":\"${transactionProcessingStrategyCode}\","
+            + "\"loanType\":\"individual\"}";
+
+    private HttpServer server;
+    private String baseUrl;
+    private final List<String> requested = new ArrayList<>();
+
+    @BeforeEach
+    void startStub() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", this::respond);
+        server.start();
+        baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    @AfterEach
+    void stopStub() {
+        server.stop(0);
+    }
+
+    private void respond(HttpExchange exchange) throws IOException {
+        requested.add(exchange.getRequestURI().getPath());
+        byte[] bytes = PRODUCT_JSON.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, bytes.length);
+        exchange.getResponseBody().write(bytes);
+        exchange.close();
+    }
+
+    private ToolDefinition loanCreate() {
+        Map<String, String> fields = new LinkedHashMap<>();
+        fields.put("interestRatePerPeriod", "interestRatePerPeriod");
+        fields.put("repaymentFrequencyType", "repaymentFrequencyType.id");
+        fields.put("transactionProcessingStrategyCode", "transactionProcessingStrategyCode");
+        return new ToolDefinition("mifos_loan_create", "Submit a loan application.", true, "New loan",
+                List.of(new ToolDefinition.Param("productId", "integer", true, null, "Product", null, false)),
+                new ToolDefinition.RestMapping("POST", "/loans", LOAN_BODY),
+                List.of(), List.of(),
+                new ToolDefinition.Defaults("/loanproducts/{productId}", fields));
+    }
+
+    @Test
+    void aLoanTakesItsTermsFromItsProductRatherThanFromTheManifest() {
+        // The product is weekly at 2.5 percent on an early-repayment strategy. None of that
+        // was reachable while the manifest sent 12, monthly and mifos-standard-strategy.
+        FineractRestToolExecutor executor = new FineractRestToolExecutor(baseUrl);
+        Map<String, Object> args = new LinkedHashMap<>();
+        args.put("clientId", 7);
+        args.put("productId", 3);
+        args.put("principal", 5000);
+
+        String body = executor.buildBody(LOAN_BODY, executor.withDefaults(loanCreate(), args, officer()),
+                "2026-08-22", Map.of());
+
+        assertThat(body).contains("\"interestRatePerPeriod\":2.5");
+        assertThat(body).contains("\"repaymentFrequencyType\":1");
+        assertThat(body).contains("\"transactionProcessingStrategyCode\":\"early-repayment-strategy\"");
+    }
+
+    @Test
+    void anAmountTheOfficerNamedIsNotOverwrittenByTheProduct() {
+        FineractRestToolExecutor executor = new FineractRestToolExecutor(baseUrl);
+        Map<String, Object> args = new LinkedHashMap<>();
+        args.put("productId", 3);
+        args.put("interestRatePerPeriod", 9);
+
+        Map<String, Object> resolved = executor.withDefaults(loanCreate(), args, officer());
+
+        assertThat(resolved).containsEntry("interestRatePerPeriod", 9);
+    }
+
+    @Test
+    void nothingIsLookedUpWhenTheOfficerAlreadyNamedEverything() {
+        FineractRestToolExecutor executor = new FineractRestToolExecutor(baseUrl);
+        Map<String, Object> args = new LinkedHashMap<>();
+        args.put("productId", 3);
+        args.put("interestRatePerPeriod", 9);
+        args.put("repaymentFrequencyType", 1);
+        args.put("transactionProcessingStrategyCode", "mifos-standard-strategy");
+
+        executor.withDefaults(loanCreate(), args, officer());
+
+        assertThat(requested).noneMatch((path) -> path.contains("loanproducts"));
+    }
+
+    @Test
+    void theOfficeComesFromTheSessionAndNotFromTheModel() {
+        // This is the one that was wrong everywhere except a single-office test system.
+        String template = "{\"officeId\":\"${session.officeId}\",\"firstname\":\"${firstname}\"}";
+
+        String body = new FineractRestToolExecutor(baseUrl)
+                .buildBody(template, Map.of("firstname", "Aisha"), "2026-08-22", Map.of("officeId", 4L));
+
+        assertThat(body).contains("\"officeId\":4");
+    }
+
+    @Test
+    void aModelCannotSupplyTheOfficeByGuessingTheParameterName() {
+        // An argument called officeId is not a session fact and must not become one.
+        String template = "{\"officeId\":\"${session.officeId}\",\"firstname\":\"${firstname}\"}";
+
+        String body = new FineractRestToolExecutor(baseUrl).buildBody(template,
+                Map.of("firstname", "Aisha", "officeId", 99), "2026-08-22", Map.of("officeId", 4L));
+
+        assertThat(body).contains("\"officeId\":4");
+        assertThat(body).doesNotContain("99");
+    }
+
+    @Test
+    void anAbsentSessionFactRefusesTheRequestRatherThanQuietlyDroppingTheField() {
+        // Dropping it would post a client with no office and let Fineract decide, which is the
+        // same class of wrongness the session token was introduced to remove.
+        String template = "{\"officeId\":\"${session.officeId}\",\"firstname\":\"${firstname}\"}";
+        FineractRestToolExecutor executor = new FineractRestToolExecutor(baseUrl);
+
+        assertThatThrownBy(() -> executor.buildBody(template, Map.of("firstname", "Aisha"), "2026-08-22", Map.of()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("office");
+    }
+
+    private CallContext officer() {
+        return new CallContext("Basic abc", "default", "corr-1", Map.of("officeId", 4L));
+    }
+}

--- a/gateway/src/test/java/org/mifos/community/copilot/core/tools/ValueSourceTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/tools/ValueSourceTest.java
@@ -175,6 +175,32 @@ class ValueSourceTest {
                 .hasMessageContaining("office");
     }
 
+
+    @Test
+    void aBodyTemplateThatCannotBeFilledIsRefusedRatherThanSentIncomplete() {
+        // The refusal is an unchecked exception, and the loop has to survive it: letting it
+        // escape ends the turn with no explanation and the officer's card already spent.
+        String template = "{\"officeId\":\"${session.officeId}\"}";
+        FineractRestToolExecutor executor = new FineractRestToolExecutor(baseUrl);
+
+        assertThatThrownBy(() -> executor.buildBody(template, Map.of(), "2026-08-22", Map.of()))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void aNumberTheProductGivesArrivesAsANumberAndNotAsText() {
+        // Sending "2.5" where Fineract expects 2.5 is the kind of thing that only fails on
+        // some validators, so it has to be a number on the wire.
+        FineractRestToolExecutor executor = new FineractRestToolExecutor(baseUrl);
+        Map<String, Object> args = new LinkedHashMap<>();
+        args.put("productId", 3);
+
+        String body = executor.buildBody(LOAN_BODY, executor.withDefaults(loanCreate(), args, officer()),
+                "2026-08-22", Map.of());
+
+        assertThat(body).contains("\"interestRatePerPeriod\":2.5");
+        assertThat(body).doesNotContain("\"interestRatePerPeriod\":\"2.5\"");
+    }
     private CallContext officer() {
         return new CallContext("Basic abc", "default", "corr-1", Map.of("officeId", 4L));
     }


### PR DESCRIPTION
Seven defects, six of them the same shape: a value written into the manifest, or mangled on its way out, instead of being read from whatever owns it. The first two turned up by hand when a reviewer typed a fifteen digit number into the panel and asked what would happen to it. The rest came from an audit that went looking for the same shape on purpose: forty candidates, ten surviving adversarial review, six distinct once deduplicated. None of them shows up on a test system with one office and one loan product, which is why they lasted.

**Every client was created in office 1.** `"officeId": 1`, as a literal, so an officer in any other branch created clients in head office. The gateway works it out from the officer's own credential now. Fineract offers no way to ask who the caller is, so it asks which offices that credential can reach: exactly one means it is theirs and there is nothing to decide, several means the officer has to say which, and it appears on the card so they see the branch before they agree to it. The model is never in that path, so a branch cannot be chosen by a sentence somebody typed.

**Every loan carried twelve percent on a monthly schedule.** The rate, the repayment frequency, the amortisation, the interest type and the processing strategy were all literals. Fineract requires them on every application so they cannot be dropped, and they belong to the product. A tool can now declare where its unspecified parameters come from, and loan creation reads them from `/loanproducts/{productId}`. A weekly product at 2.5 percent was being written as a monthly loan at 12.

**The card and the request disagreed about dates.** Any parameter whose name contained "date" was pulled back to the business date, while the card was rendered from the model's original arguments. An officer asking to disburse on 1 September read "1 September 2026" on the card and the request carried today, with Fineract then generating every instalment from the wrong one. This is the one that matters most, because the point of the pause is that what you approve is what runs. Arguments are normalised once, before the card is built, so the two agree by construction instead of by two code paths coinciding. A parameter carries `futureAllowed` where a later date is legitimate, which is only the expected disbursement; an approval or a repayment in Fineract's future is still pulled back, because Fineract refuses it.

**A value shaped like a slot was resolved twice.** The body was filled by repeated string replacement, so a value written in one pass could be read as a slot in the next, and a client whose surname was literally `${mobileNo}` was persisted with their phone number as their surname. The template is valid JSON, so it is parsed and walked now and each slot is set through Jackson. Nothing written can be read again.

**A loan's term was its repayment count.** Right only while `repaymentEvery` was pinned to 1. Now that it comes from the product, a fortnightly loan of twelve repayments claimed a twelve period term instead of twenty-four, and Fineract books arrears against the dates it derives from that. A tool can declare a computed value as the product of two parameters, which is as much arithmetic as a manifest should hold.

**A timeout was reported as a rejection.** `HttpTimeoutException` is an `IOException`, so a disbursement that reached Fineract and committed came back to the officer as refused. They retry, and the retry is a second payment. A write that times out now says it could not be confirmed and asks them to check the account, and the card keeps its original idempotency key so a duplicate retry is refused by Fineract rather than executed.

**A confirmation nobody answered bricked the conversation.** Pausing for a card leaves an assistant `tool_calls` message with no result against it, because the result is what the decision produces. Approve and reject both supply one. Walking away supplies nothing, and every OpenAI-shaped provider rejects a conversation where a tool call was asked and never answered, so the officer's next message came back HTTP 400 and kept coming back. Changing your mind cost you the conversation. The abandoned call now gets an honest result saying nothing was carried out, and the card is dropped at the same moment so it cannot be approved after the conversation has moved past it. Doing only one of those would leave a live card pointing at a call the history has already settled.

This started out needing openMF/web-app#3892 to send the office from the panel. That PR is closed, because review was right that a value the server can establish for itself should not arrive on trust from a client. Nothing about the officer's identity is taken from the request body, and there is no frontend change to land alongside this one.

A provider refusal is also no longer dressed up as a passing outage. A rejected key or a malformed request is a settled fact, and telling an officer to try again shortly sends them round a loop with no way out of it.

Tests 69 to 86, covering where each value comes from, both date rules, the three substitution cases that used to corrupt data, and a card left undecided. Hardcoded values in request bodies: twelve down to three, and those three match what their tool says it does.

This is the card an officer reads before any of it executes, from the running panel against the sandbox:

![Confirmation card headed Approve loan, naming the client, the loan account, the product, the approved amount with its currency and the approval date, above Cancel and Confirm buttons](https://shubhamkumar9199.github.io/mifos-copilot-showcase/shots/05-card-closeup.png)

Checked end to end against sandbox.mifos.community with a real model rather than the keyword stand-in. A loan application asking for disbursement on 15 September kept that date all the way to the card, where it used to be rewritten to today. A client creation sent no office from the panel at all and Fineract recorded the client in the right one. A card left undecided no longer stops the next message, and cannot be approved once the conversation has moved on.

