### PR TITLE
fix(gateway): hold the Copilot to the same rules as the form

### DIFF
--- a/gateway/src/main/java/org/mifos/community/copilot/core/agent/AgentLoop.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/agent/AgentLoop.java
@@ -18,6 +18,7 @@ import org.mifos.community.copilot.core.llm.LlmException;
 import org.mifos.community.copilot.core.llm.LlmResult;
 import org.mifos.community.copilot.core.llm.LlmToolCall;
 import org.mifos.community.copilot.core.tools.Display;
+import org.mifos.community.copilot.core.tools.ArgumentCheck;
 import org.mifos.community.copilot.core.tools.ToolDefinition;
 import org.mifos.community.copilot.core.tools.ToolExecutionException;
 import org.mifos.community.copilot.core.tools.ToolExecutor;
@@ -248,6 +249,14 @@ public final class AgentLoop {
                                 "The AI model is unavailable right now. Please try again shortly.", true));
                 sink.emit(StreamEvent.done(conversationId));
                 return;
+            } catch (RuntimeException e) {
+                // The response body is read as a stream of lines, and a connection that dies
+                // mid-read surfaces as an unchecked wrapper rather than the declared failure.
+                // Letting it escape leaves the officer watching a stream that never ends.
+                sink.emit(StreamEvent.error(ErrorCode.LLM_UNAVAILABLE,
+                        "The AI model stopped responding. Please try again.", true));
+                sink.emit(StreamEvent.done(conversationId));
+                return;
             }
             if (sink.isCancelled()) {
                 return; // Stop is silent: nothing else may run after a cancel.
@@ -271,6 +280,17 @@ public final class AgentLoop {
                     // Default-deny: the model asked for something outside the manifest.
                     conversations.append(fingerprint, conversationId, toolResultMessage(call,
                             "{\"error\":\"Tool '" + call.name() + "' is not available.\"}"));
+                    continue;
+                }
+                // Values the web app would not accept are not values the Copilot may send.
+                // Checked before the card, because the card is where the officer agrees to
+                // this, and before enrichment, which costs a call that a bad value wastes.
+                List<String> invalid = ArgumentCheck.problems(tool, call.arguments());
+                if (!invalid.isEmpty()) {
+                    conversations.append(fingerprint, conversationId, toolResultMessage(call,
+                            "{\"error\":\"not_valid\",\"problems\":" + jsonArray(invalid)
+                                    + ",\"detail\":\"Nothing was sent. Tell the officer what is wrong,"
+                                    + " in your own words, and ask for a value that works.\"}"));
                     continue;
                 }
                 if (tool.write()) {
@@ -604,6 +624,15 @@ public final class AgentLoop {
         return text.contains("could not be prepared") || text.contains("not one you can work in");
     }
 
+    /** The problems as a JSON array, so the model reads them as a list rather than a sentence. */
+    private String jsonArray(List<String> values) {
+        StringBuilder out = new StringBuilder("[");
+        for (int i = 0; i < values.size(); i++) {
+            out.append(i == 0 ? "" : ",").append(jsonQuote(values.get(i)));
+        }
+        return out.append("]").toString();
+    }
+
     /** Argument names the model supplied that the manifest does not declare for this tool. */
     private List<String> undeclaredArguments(ToolDefinition tool, LlmToolCall call) {
         if (call.arguments() == null || call.arguments().isEmpty()) {
@@ -631,7 +660,8 @@ public final class AgentLoop {
         List<Map<String, Object>> encoded = calls.stream().map((call) -> Map.<String, Object>of(
                 "id", call.id() == null ? "call-0" : call.id(),
                 "type", "function",
-                "function", Map.of("name", call.name(), "arguments", encodeArguments(call.arguments())))).toList();
+                "function", Map.of("name", call.name(), "arguments",
+                        encodeArguments(manifest.find(call.name()).orElse(null), call.arguments())))).toList();
         Map<String, Object> message = new LinkedHashMap<>();
         message.put("role", "assistant");
         message.put("content", "");
@@ -645,6 +675,29 @@ public final class AgentLoop {
         message.put("tool_call_id", call.id() == null ? "call-0" : call.id());
         message.put("content", content);
         return message;
+    }
+
+    /**
+     * The arguments as the model will see them again, with the private ones masked.
+     *
+     * <p>What a tool declares private is masked in the answer Fineract gives, and was not
+     * masked in the record of what was asked. That record is replayed to the model on every
+     * later round of the same conversation, so a phone number went out once as an argument
+     * and then again on every turn that followed.
+     *
+     * <p>The officer still sees the real values, on the card, which is where they check them.
+     */
+    private String encodeArguments(ToolDefinition tool, Map<String, Object> arguments) {
+        if (tool == null || tool.redactFields().isEmpty() || arguments == null) {
+            return encodeArguments(arguments);
+        }
+        Map<String, Object> masked = new LinkedHashMap<>(arguments);
+        for (String field : tool.redactFields()) {
+            if (masked.get(field) != null) {
+                masked.put(field, "•••");
+            }
+        }
+        return encodeArguments(masked);
     }
 
     private String encodeArguments(Map<String, Object> arguments) {

--- a/gateway/src/main/java/org/mifos/community/copilot/core/convo/ConversationStore.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/convo/ConversationStore.java
@@ -49,10 +49,27 @@ public final class ConversationStore {
         }
     }
 
+    /**
+     * The conversation so far, as a snapshot.
+     *
+     * <p>A copy, not the list itself. {@link #append} adds a message and then trims the oldest
+     * back off, so the list momentarily holds one more than its limit and then shrinks. A
+     * reader walking it by index at that moment reads past the end, and the same officer with
+     * two tabs open is enough to arrange that. It surfaced as an exception escaping a decision
+     * after the write had already reached Fineract, which is the worst possible moment for
+     * one, and the caller cannot be expected to know it must hold a lock it cannot see.
+     */
     public List<Map<String, Object>> messages(String fingerprint, String conversationId) {
         Map<String, List<Map<String, Object>>> conversations = userStore(fingerprint);
+        List<Map<String, Object>> messages;
         synchronized (conversations) {
-            return conversations.getOrDefault(conversationId, new ArrayList<>());
+            messages = conversations.get(conversationId);
+        }
+        if (messages == null) {
+            return new ArrayList<>();
+        }
+        synchronized (messages) {
+            return new ArrayList<>(messages);
         }
     }
 

--- a/gateway/src/main/java/org/mifos/community/copilot/core/tools/ArgumentCheck.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/tools/ArgumentCheck.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at
+ * http://mozilla.org/MPL/2.0/.
+ */
+package org.mifos.community.copilot.core.tools;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * Whether the values in a tool call are ones the officer could have typed into the web app.
+ *
+ * <p>The Copilot is a companion to a form, not a second door into the same database. Every
+ * rule here is copied from a validator the Mifos X web app already applies to the same field,
+ * so anything it refuses is something the officer could not have done in the UI either, and
+ * anything the UI allows still works in a sentence. A client whose first name was
+ * {@code 999999999999999} could never have been created through the form; it was created
+ * through the Copilot, because the Copilot had no opinion about what a name looks like.
+ *
+ * <p>Problems come back as sentences meant for a person. They are handed to the model as a
+ * tool result rather than raised as an error, so the assistant can say what is wrong and ask
+ * for a better value, which is what a colleague would do.
+ */
+public final class ArgumentCheck {
+
+    private ArgumentCheck() {
+    }
+
+    /** Human-readable problems with these arguments, empty when there is nothing wrong. */
+    public static List<String> problems(ToolDefinition tool, Map<String, Object> args) {
+        List<String> problems = new ArrayList<>();
+        for (ToolDefinition.Param param : tool.params()) {
+            Object raw = args == null ? null : args.get(param.name());
+            String value = raw == null ? "" : String.valueOf(raw).trim();
+            if (value.isEmpty()) {
+                if (param.required()) {
+                    problems.add(param.displayLabel() + " is needed.");
+                }
+                continue; // Nothing to check against, and an absent optional is fine.
+            }
+            checkPattern(param, value, problems);
+            checkBounds(param, value, problems);
+            checkLength(param, value, problems);
+        }
+        return problems;
+    }
+
+    private static void checkPattern(ToolDefinition.Param param, String value, List<String> problems) {
+        if (param.pattern() == null || param.pattern().isBlank()) {
+            return;
+        }
+        // A number reaches us as whatever the model's JSON produced, so 1.2E7 and 12000000 are
+        // the same value written two ways. The rule is about the value, not the notation.
+        String subject = plain(value);
+        try {
+            if (!Pattern.compile(param.pattern()).matcher(subject).matches()) {
+                problems.add(param.displayLabel() + " must "
+                        + (param.mustBe() == null || param.mustBe().isBlank()
+                                ? "be in the format this field expects"
+                                : param.mustBe())
+                        + ".");
+            }
+        } catch (PatternSyntaxException e) {
+            // A broken pattern is a manifest bug. Refusing every value because of it would
+            // take the tool out of service, which is worse than not checking this one rule.
+        }
+    }
+
+    /**
+     * How long the column is, which is Fineract's rule rather than the form's.
+     *
+     * <p>The web app puts no length limit on a name; Fineract stores it in a varchar(50) and
+     * refuses anything longer. Left unchecked, a long name reaches the officer as a database
+     * complaint after they have already confirmed the card. Better to say it before.
+     */
+    private static void checkLength(ToolDefinition.Param param, String value, List<String> problems) {
+        BigDecimal limit = number(param.maxLength());
+        if (limit != null && value.length() > limit.intValue()) {
+            problems.add(param.displayLabel() + " must be " + limit.intValue() + " characters or fewer.");
+        }
+    }
+
+    private static void checkBounds(ToolDefinition.Param param, String value, List<String> problems) {
+        BigDecimal number = number(value);
+        if (number == null) {
+            return; // Not a number, so a numeric bound says nothing about it.
+        }
+        BigDecimal min = number(param.min());
+        BigDecimal max = number(param.max());
+        if (min != null && number.compareTo(min) < 0) {
+            problems.add(param.displayLabel() + " must be at least " + min.toPlainString() + ".");
+        }
+        if (max != null && number.compareTo(max) > 0) {
+            problems.add(param.displayLabel() + " must be no more than " + max.toPlainString() + ".");
+        }
+    }
+
+    /** The value written out in full, so scientific notation does not dodge a pattern. */
+    private static String plain(String value) {
+        BigDecimal number = number(value);
+        return number == null ? value : number.stripTrailingZeros().toPlainString();
+    }
+
+    private static BigDecimal number(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return new BigDecimal(value.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/gateway/src/main/java/org/mifos/community/copilot/core/tools/ArgumentCheck.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/tools/ArgumentCheck.java
@@ -89,11 +89,17 @@ public final class ArgumentCheck {
 
     private static void checkBounds(ToolDefinition.Param param, String value, List<String> problems) {
         BigDecimal number = number(value);
-        if (number == null) {
-            return; // Not a number, so a numeric bound says nothing about it.
-        }
         BigDecimal min = number(param.min());
         BigDecimal max = number(param.max());
+        if (number == null) {
+            // Declaring a bound is declaring the field numeric. Letting "none" through because
+            // it cannot be compared meant a card was raised for a loan of "none" repayments,
+            // and the officer learned it was nonsense only when Fineract said so.
+            if (min != null || max != null) {
+                problems.add(param.displayLabel() + " must be a number.");
+            }
+            return;
+        }
         if (min != null && number.compareTo(min) < 0) {
             problems.add(param.displayLabel() + " must be at least " + min.toPlainString() + ".");
         }

--- a/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
@@ -9,7 +9,9 @@ package org.mifos.community.copilot.core.tools;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 
 import org.mifos.community.copilot.core.auth.CallContext;
 
@@ -779,32 +781,62 @@ public final class FineractRestToolExecutor implements ToolExecutor {
         if (redactFields == null || redactFields.isEmpty()) {
             return json;
         }
-        String out = json;
-        if (args != null) {
-            for (String field : redactFields) {
-                Object value = args.get(field);
-                String text = value == null ? null : String.valueOf(value).trim();
-                if (text == null || text.isEmpty()) {
-                    continue;
-                }
-                if (text.length() >= MIN_REDACTABLE_LENGTH) {
-                    out = out.replace(text, MASK);
-                } else {
-                    // Short values are matched whole, so masking an external id of "A12" does
-                    // not also eat the "A12" inside a word. Skipping them outright left the
-                    // shortest ids, which are the oldest customers, as the ones that leaked.
-                    out = out.replaceAll("(?<![\\p{L}\\p{N}])" + java.util.regex.Pattern.quote(text)
-                            + "(?![\\p{L}\\p{N}])", MASK);
-                }
-            }
-        }
+        java.util.List<String> secrets = secrets(redactFields, args);
         try {
-            JsonNode root = mapper.readTree(out);
-            redactNode(root, redactFields);
+            // Decoded first. Masking the raw document compares against escaped text, so a
+            // value carrying a quote, a backslash or an accent the server wrote as \\uXXXX
+            // never matched itself and stayed in the prose while looking masked.
+            JsonNode root = mapper.readTree(json);
+            redactNode(root, redactFields, secrets);
             return mapper.writeValueAsString(root);
         } catch (IOException e) {
-            return out; // Not JSON, but the values were masked as text, which is the leak.
+            // Not JSON, so the text is all there is and masking it directly is the best available.
+            String out = json;
+            for (String secret : secrets) {
+                out = maskWithin(out, secret);
+            }
+            return out;
         }
+    }
+
+    /** The submitted values behind the fields a tool calls private, trimmed and non-empty. */
+    private static java.util.List<String> secrets(java.util.List<String> redactFields, Map<String, Object> args) {
+        java.util.List<String> secrets = new java.util.ArrayList<>();
+        if (args == null) {
+            return secrets;
+        }
+        for (String field : redactFields) {
+            Object value = args.get(field);
+            String text = value == null ? null : String.valueOf(value).trim();
+            if (text != null && !text.isEmpty()) {
+                secrets.add(text);
+            }
+        }
+        return secrets;
+    }
+
+    /**
+     * Replace one value wherever it appears in a piece of decoded text.
+     *
+     * <p>A short value is matched whole, so masking an external id of {@code A12} does not eat
+     * the same three characters inside a longer word. Skipping short ones outright, which is
+     * what this did first, left the shortest ids as the only ones that leaked.
+     */
+    private static String maskWithin(String text, String secret) {
+        if (secret.length() >= MIN_REDACTABLE_LENGTH) {
+            return text.replace(secret, MASK);
+        }
+        // Pattern.quote makes the value a literal, and the lookarounds are single characters,
+        // so there is nothing here for a crafted value to make backtrack.
+        return text.replaceAll("(?<![\\p{L}\\p{N}])" + Pattern.quote(secret) + "(?![\\p{L}\\p{N}])", MASK);
+    }
+
+    private static String maskAll(String text, java.util.List<String> secrets) {
+        String out = text;
+        for (String secret : secrets) {
+            out = maskWithin(out, secret);
+        }
+        return out;
     }
 
     /** Above this length a value is distinctive enough to mask wherever it appears. */
@@ -812,7 +844,7 @@ public final class FineractRestToolExecutor implements ToolExecutor {
 
     private static final String MASK = "•••";
 
-    private void redactNode(JsonNode node, java.util.List<String> fields) {
+    private void redactNode(JsonNode node, java.util.List<String> fields, java.util.List<String> secrets) {
         if (node instanceof ObjectNode object) {
             for (String field : fields) {
                 if (object.has(field)) {
@@ -825,7 +857,7 @@ public final class FineractRestToolExecutor implements ToolExecutor {
                 if (object.has("value")) {
                     object.put("value", MASK);
                 }
-                if (object.get("args") instanceof com.fasterxml.jackson.databind.node.ArrayNode arguments) {
+                if (object.get("args") instanceof ArrayNode arguments) {
                     arguments.forEach((argument) -> {
                         if (argument instanceof ObjectNode entry && entry.has("value")) {
                             entry.put("value", MASK);
@@ -833,9 +865,26 @@ public final class FineractRestToolExecutor implements ToolExecutor {
                     });
                 }
             }
-            object.forEach((child) -> redactNode(child, fields));
-        } else if (node.isArray()) {
-            node.forEach((child) -> redactNode(child, fields));
+            java.util.List<String> names = new java.util.ArrayList<>();
+            object.fieldNames().forEachRemaining(names::add);
+            for (String name : names) {
+                JsonNode child = object.get(name);
+                if (child != null && child.isTextual()) {
+                    // The message prose, where Fineract writes the value it is complaining about.
+                    object.put(name, maskAll(child.asText(), secrets));
+                } else {
+                    redactNode(child, fields, secrets);
+                }
+            }
+        } else if (node instanceof ArrayNode array) {
+            for (int i = 0; i < array.size(); i++) {
+                JsonNode child = array.get(i);
+                if (child.isTextual()) {
+                    array.set(i, TextNode.valueOf(maskAll(child.asText(), secrets)));
+                } else {
+                    redactNode(child, fields, secrets);
+                }
+            }
         }
     }
 

--- a/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
@@ -50,7 +50,13 @@ public final class FineractRestToolExecutor implements ToolExecutor {
      */
     private final java.util.Map<String, CachedDate> businessDateByTenant = new java.util.concurrent.ConcurrentHashMap<>();
 
-    /** Offices each officer may work in, keyed by their fingerprint so one cannot answer for another. */
+    /**
+     * Offices each officer may work in, keyed by their fingerprint so one cannot answer for another.
+     *
+     * <p>Only successful answers go in here. Caching a failure would mean one bad moment from
+     * {@code /offices} disabled the check for the rest of the process's life, which is a long
+     * time to be unable to tell whose branch is whose.
+     */
     private final java.util.Map<String, java.util.Set<String>> officesByOfficer =
             new java.util.concurrent.ConcurrentHashMap<>();
 
@@ -131,9 +137,10 @@ public final class FineractRestToolExecutor implements ToolExecutor {
         if (response.statusCode() < 200 || response.statusCode() >= 300) {
             // Application errors go back to the model as STRUCTURED JSON (never a quoted
             // string carrying escaped JSON) so both the LLM and the UI read them cleanly.
-            return applicationError(tool.name(), response.statusCode(), response.body(), tool.redactFields());
+            return applicationError(tool.name(), response.statusCode(), response.body(),
+                    tool.redactFields(), effective);
         }
-        return truncate(redact(response.body(), tool.redactFields()), MAX_RESULT_CHARS);
+        return truncate(redact(response.body(), tool.redactFields(), effective), MAX_RESULT_CHARS);
     }
 
     /**
@@ -215,11 +222,24 @@ public final class FineractRestToolExecutor implements ToolExecutor {
         if (!tool.write() || body == null || !body.contains("${officeId}")) {
             return args;
         }
-        java.util.Set<String> reachable = officesByOfficer
-                .computeIfAbsent(context.fingerprint() + "|" + context.tenantId(), (k) -> readOffices(context));
+        String key = context.fingerprint() + "|" + context.tenantId();
+        java.util.Set<String> reachable = officesByOfficer.get(key);
+        if (reachable == null) {
+            // Absent means the question could not be asked, which is not the same as an answer
+            // of none. Only a real answer is remembered, so a bad minute does not become
+            // permanent by being cached.
+            reachable = readOffices(context).orElseThrow(() -> new ToolExecutionException(
+                    "Could not establish which offices you work in, so this was not carried out."
+                            + " Please try again.",
+                    0, null));
+            officesByOfficer.put(key, reachable);
+        }
         Object stated = args.get("officeId");
         if (stated != null && !String.valueOf(stated).isBlank()) {
-            if (!reachable.isEmpty() && !reachable.contains(String.valueOf(stated))) {
+            // Checked against what the credential actually reaches, always. Accepting it
+            // whenever the list happened to be empty was a way in: one failed lookup and any
+            // office the model named went to the wire unexamined.
+            if (!reachable.contains(String.valueOf(stated))) {
                 throw new ToolExecutionException("That office is not one you can work in.", 403, null);
             }
             return args;
@@ -231,13 +251,20 @@ public final class FineractRestToolExecutor implements ToolExecutor {
         }
         throw new ToolExecutionException(
                 reachable.isEmpty()
-                        ? "Could not establish which office to use. Please try again."
+                        ? "Your login does not reach any office, so this was not carried out."
+                                + " Please tell your administrator."
                         : "You work in more than one office, so please say which one this is for.",
                 0, null);
     }
 
-    /** Office ids this credential can see, empty when the question could not be asked. */
-    private java.util.Set<String> readOffices(CallContext context) {
+    /**
+     * Office ids this credential can see.
+     *
+     * <p>An empty {@code Optional} means the question could not be asked, and an empty set
+     * means it was asked and the answer was none. Collapsing those two into one empty set is
+     * what let a failed lookup read as a permissive answer.
+     */
+    private java.util.Optional<java.util.Set<String>> readOffices(CallContext context) {
         try {
             HttpResponse<String> response = http.send(
                     HttpRequest.newBuilder(URI.create(fineractBaseUrl + "/fineract-provider/api/v1/offices"))
@@ -249,7 +276,7 @@ public final class FineractRestToolExecutor implements ToolExecutor {
                             .build(),
                     HttpResponse.BodyHandlers.ofString());
             if (response.statusCode() < 200 || response.statusCode() >= 300) {
-                return java.util.Set.of();
+                return java.util.Optional.empty();
             }
             java.util.Set<String> ids = new java.util.LinkedHashSet<>();
             for (JsonNode office : mapper.readTree(response.body())) {
@@ -257,12 +284,12 @@ public final class FineractRestToolExecutor implements ToolExecutor {
                     ids.add(office.get("id").asText());
                 }
             }
-            return ids;
+            return java.util.Optional.of(ids);
         } catch (IOException | InterruptedException | RuntimeException e) {
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
-            return java.util.Set.of();
+            return java.util.Optional.empty();
         }
     }
 
@@ -708,8 +735,9 @@ public final class FineractRestToolExecutor implements ToolExecutor {
      * Error bodies get the SAME redaction + truncation as success bodies, because Fineract error
      * payloads can echo request PII, and they flow to the LLM like any tool result.
      */
-    private String applicationError(String toolName, int status, String body, java.util.List<String> redactFields) {
-        String safeBody = truncate(redact(body == null ? "" : body, redactFields), 2_000);
+    private String applicationError(String toolName, int status, String body,
+            java.util.List<String> redactFields, Map<String, Object> args) {
+        String safeBody = truncate(redact(body == null ? "" : body, redactFields, args), 2_000);
         ObjectNode error = mapper.createObjectNode();
         error.put("tool", toolName);
         error.put("httpStatus", status);
@@ -732,24 +760,77 @@ public final class FineractRestToolExecutor implements ToolExecutor {
     }
 
     /** Mask configured PII fields before the payload can reach a cloud LLM (ADR-001 §2.2). */
-    private String redact(String json, java.util.List<String> redactFields) {
+    /**
+     * Mask the fields a tool says are private, by name and by value.
+     *
+     * <p>By name is not enough. Masking a key called {@code mobileNo} catches the read that
+     * returns a client, and misses the thing that actually leaks: Fineract rejects a duplicate
+     * with "Client with mobileNo `0712345678` already exists", where the number sits in prose
+     * under {@code defaultUserMessage} and again under {@code errors[].value}. No key is named
+     * after the parameter anywhere in that payload, so nothing was masked, and the whole
+     * rejection went into the conversation and on to the model.
+     *
+     * <p>So the submitted values are masked too, wherever they appear in the text. Short ones
+     * are left alone: replacing every "1" in a document to protect an id of 1 would destroy
+     * the message and protect nothing worth protecting.
+     */
+    // Package-private so the redaction tests can feed it a real Fineract error payload.
+    String redact(String json, java.util.List<String> redactFields, Map<String, Object> args) {
         if (redactFields == null || redactFields.isEmpty()) {
             return json;
         }
+        String out = json;
+        if (args != null) {
+            for (String field : redactFields) {
+                Object value = args.get(field);
+                String text = value == null ? null : String.valueOf(value).trim();
+                if (text == null || text.isEmpty()) {
+                    continue;
+                }
+                if (text.length() >= MIN_REDACTABLE_LENGTH) {
+                    out = out.replace(text, MASK);
+                } else {
+                    // Short values are matched whole, so masking an external id of "A12" does
+                    // not also eat the "A12" inside a word. Skipping them outright left the
+                    // shortest ids, which are the oldest customers, as the ones that leaked.
+                    out = out.replaceAll("(?<![\\p{L}\\p{N}])" + java.util.regex.Pattern.quote(text)
+                            + "(?![\\p{L}\\p{N}])", MASK);
+                }
+            }
+        }
         try {
-            JsonNode root = mapper.readTree(json);
+            JsonNode root = mapper.readTree(out);
             redactNode(root, redactFields);
             return mapper.writeValueAsString(root);
         } catch (IOException e) {
-            return json; // Not JSON, so nothing to redact structurally.
+            return out; // Not JSON, but the values were masked as text, which is the leak.
         }
     }
+
+    /** Above this length a value is distinctive enough to mask wherever it appears. */
+    private static final int MIN_REDACTABLE_LENGTH = 4;
+
+    private static final String MASK = "•••";
 
     private void redactNode(JsonNode node, java.util.List<String> fields) {
         if (node instanceof ObjectNode object) {
             for (String field : fields) {
                 if (object.has(field)) {
-                    object.put(field, "•••");
+                    object.put(field, MASK);
+                }
+            }
+            // Fineract names the offending parameter and carries its value alongside, rather
+            // than under a key of that name, so the pair has to be read together.
+            if (fields.contains(object.path("parameterName").asText())) {
+                if (object.has("value")) {
+                    object.put("value", MASK);
+                }
+                if (object.get("args") instanceof com.fasterxml.jackson.databind.node.ArrayNode arguments) {
+                    arguments.forEach((argument) -> {
+                        if (argument instanceof ObjectNode entry && entry.has("value")) {
+                            entry.put("value", MASK);
+                        }
+                    });
                 }
             }
             object.forEach((child) -> redactNode(child, fields));

--- a/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
@@ -252,19 +252,6 @@ public final class FineractRestToolExecutor implements ToolExecutor {
             officesByOfficer.put(key, reachable);
         }
         Object stated = args.get("officeId");
-        if (stated == null || String.valueOf(stated).isBlank()) {
-            // The officer's own branch, which is the right answer whenever we can get it. An
-            // administrator can see every office in the institution, so picking the only
-            // visible one stops working the moment a second branch exists, and asking them
-            // which branch they are sitting in is a strange question to be asked.
-            java.util.Optional<String> home = homeOfficeByOfficer
-                    .computeIfAbsent(key, (k) -> readHomeOffice(context));
-            if (home.isPresent() && reachable.contains(home.get())) {
-                java.util.Map<String, Object> withHome = new java.util.LinkedHashMap<>(args);
-                withHome.put("officeId", Long.parseLong(home.get()));
-                return withHome;
-            }
-        }
         if (stated != null && !String.valueOf(stated).isBlank()) {
             // Checked against what the credential actually reaches, always. Accepting it
             // whenever the list happened to be empty was a way in: one failed lookup and any
@@ -275,9 +262,16 @@ public final class FineractRestToolExecutor implements ToolExecutor {
             return args;
         }
         if (reachable.size() == 1) {
-            java.util.Map<String, Object> out = new java.util.LinkedHashMap<>(args);
-            out.put("officeId", Long.parseLong(reachable.iterator().next()));
-            return out;
+            // Nothing in doubt, so nothing to ask. Signing in first would make every creation
+            // in a single-branch institution wait on a call whose answer cannot change this.
+            return withOfficeId(args, reachable.iterator().next());
+        }
+        // More than one branch in reach, so the officer's own is the only sensible default.
+        // An administrator sees every office there is, and asking which one they are sitting
+        // in is a strange question with no good answer.
+        java.util.Optional<String> home = homeOffice(key, context);
+        if (home.isPresent() && reachable.contains(home.get())) {
+            return withOfficeId(args, home.get());
         }
         throw new ToolExecutionException(
                 reachable.isEmpty()
@@ -285,6 +279,31 @@ public final class FineractRestToolExecutor implements ToolExecutor {
                                 + " Please tell your administrator."
                         : "You work in more than one office, so please say which one this is for.",
                 0, null);
+    }
+
+    private static Map<String, Object> withOfficeId(Map<String, Object> args, String officeId) {
+        java.util.Map<String, Object> out = new java.util.LinkedHashMap<>(args);
+        out.put("officeId", Long.parseLong(officeId));
+        return out;
+    }
+
+    /**
+     * The officer's own office, remembered only once it is known.
+     *
+     * <p>Caching the failure would mean one bad moment from the sign-in left that officer
+     * being asked to name their branch for the life of the process. The same mistake was
+     * already made once with the reachable set; it is not worth making twice.
+     */
+    private java.util.Optional<String> homeOffice(String key, CallContext context) {
+        java.util.Optional<String> known = homeOfficeByOfficer.get(key);
+        if (known != null) {
+            return known;
+        }
+        java.util.Optional<String> found = readHomeOffice(context);
+        if (found.isPresent()) {
+            homeOfficeByOfficer.put(key, found);
+        }
+        return found;
     }
 
     /**

--- a/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
@@ -52,6 +52,10 @@ public final class FineractRestToolExecutor implements ToolExecutor {
      */
     private final java.util.Map<String, CachedDate> businessDateByTenant = new java.util.concurrent.ConcurrentHashMap<>();
 
+    /** The office each officer actually belongs to, keyed by fingerprint. */
+    private final java.util.Map<String, java.util.Optional<String>> homeOfficeByOfficer =
+            new java.util.concurrent.ConcurrentHashMap<>();
+
     /**
      * Offices each officer may work in, keyed by their fingerprint so one cannot answer for another.
      *
@@ -237,6 +241,19 @@ public final class FineractRestToolExecutor implements ToolExecutor {
             officesByOfficer.put(key, reachable);
         }
         Object stated = args.get("officeId");
+        if (stated == null || String.valueOf(stated).isBlank()) {
+            // The officer's own branch, which is the right answer whenever we can get it. An
+            // administrator can see every office in the institution, so picking the only
+            // visible one stops working the moment a second branch exists, and asking them
+            // which branch they are sitting in is a strange question to be asked.
+            java.util.Optional<String> home = homeOfficeByOfficer
+                    .computeIfAbsent(key, (k) -> readHomeOffice(context));
+            if (home.isPresent() && reachable.contains(home.get())) {
+                java.util.Map<String, Object> withHome = new java.util.LinkedHashMap<>(args);
+                withHome.put("officeId", Long.parseLong(home.get()));
+                return withHome;
+            }
+        }
         if (stated != null && !String.valueOf(stated).isBlank()) {
             // Checked against what the credential actually reaches, always. Accepting it
             // whenever the list happened to be empty was a way in: one failed lookup and any
@@ -257,6 +274,57 @@ public final class FineractRestToolExecutor implements ToolExecutor {
                                 + " Please tell your administrator."
                         : "You work in more than one office, so please say which one this is for.",
                 0, null);
+    }
+
+    /**
+     * The office this officer belongs to, as Fineract itself reports it.
+     *
+     * <p>Fineract answers a sign-in with the user's own office, which is the only place that
+     * knows it. Reaching it needs the password, and the password is already in the header this
+     * gateway forwards to Fineract on every call, so nothing new is being trusted or held. It
+     * is never logged and never leaves this method.
+     *
+     * <p>Empty when the credential is not Basic, or the sign-in did not answer. The caller
+     * falls back to the reachable set, and refuses rather than guessing if that is ambiguous.
+     */
+    private java.util.Optional<String> readHomeOffice(CallContext context) {
+        String header = context.authorizationHeader();
+        if (header == null || !header.regionMatches(true, 0, "Basic ", 0, 6)) {
+            return java.util.Optional.empty();
+        }
+        try {
+            String decoded = new String(java.util.Base64.getDecoder().decode(header.substring(6).trim()),
+                    StandardCharsets.UTF_8);
+            int split = decoded.indexOf(':');
+            if (split < 0) {
+                return java.util.Optional.empty();
+            }
+            ObjectNode credentials = mapper.createObjectNode()
+                    .put("username", decoded.substring(0, split))
+                    .put("password", decoded.substring(split + 1));
+            HttpResponse<String> response = http.send(
+                    HttpRequest.newBuilder(URI.create(fineractBaseUrl
+                                    + "/fineract-provider/api/v1/authentication"))
+                            .timeout(Duration.ofSeconds(15))
+                            .header("Content-Type", "application/json")
+                            .header("Accept", "application/json")
+                            .header("Fineract-Platform-TenantId", context.tenantId())
+                            .POST(HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(credentials)))
+                            .build(),
+                    HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                return java.util.Optional.empty();
+            }
+            JsonNode body = mapper.readTree(response.body());
+            return body.hasNonNull("officeId")
+                    ? java.util.Optional.of(body.get("officeId").asText())
+                    : java.util.Optional.empty();
+        } catch (IOException | InterruptedException | RuntimeException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            return java.util.Optional.empty(); // Fall back to the reachable set.
+        }
     }
 
     /**

--- a/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
@@ -134,6 +134,17 @@ public final class FineractRestToolExecutor implements ToolExecutor {
             throw new ToolExecutionException("Fineract unreachable for " + tool.name(), 0, e);
         }
 
+        if (response.statusCode() >= 500) {
+            // The banking system did not answer, it fell over. Calling that a rejection sends
+            // an officer looking for what they did wrong, when the truthful answer is that
+            // there is nothing wrong with the request and nothing they can do about it. A
+            // write is left indeterminate, because a 502 from a proxy says nothing about
+            // whether the server behind it committed.
+            throw new ToolExecutionException(
+                    "Fineract is not responding (HTTP " + response.statusCode() + ")",
+                    response.statusCode(), null, tool.write());
+        }
+
         if (response.statusCode() == 401 || isPermissionDenial(response)) {
             // Auth outcomes need special loop handling (session expiry / RBAC denial).
             throw new ToolExecutionException(

--- a/gateway/src/main/java/org/mifos/community/copilot/core/tools/ToolDefinition.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/tools/ToolDefinition.java
@@ -34,12 +34,32 @@ public record ToolDefinition(String name, String description, boolean write, Str
      * @param show false for identifiers, which say nothing to a person and are replaced on the
      *     card by the account number and product name pulled in by {@link Enrich}
      */
+    /**
+     * One parameter, including what counts as a valid value for it.
+     *
+     * <p>{@code pattern}, {@code min} and {@code max} are copied from the rules the Mifos web
+     * app already enforces on the same field, and are deliberately no stricter. The Copilot
+     * sits beside that app rather than behind it, so a value the officer could type into the
+     * form has to be a value they can ask for in a sentence. Being stricter here would refuse
+     * legitimate work; being looser makes the Copilot a way round the app's own controls,
+     * which is how a client came to be created with a fifteen digit number for a name.
+     *
+     * <p>{@code mustBe} completes the sentence "First name must ...", because a regular
+     * expression is not something to show a loan officer.
+     */
     public record Param(String name, String type, boolean required, String description, String label, String format,
-            boolean show, boolean futureAllowed) {
+            boolean show, boolean futureAllowed, String pattern, String mustBe, String min, String max,
+            String maxLength) {
 
         public Param(String name, String type, boolean required, String description, String label, String format,
                 boolean show) {
             this(name, type, required, description, label, format, show, false);
+        }
+
+        public Param(String name, String type, boolean required, String description, String label, String format,
+                boolean show, boolean futureAllowed) {
+            this(name, type, required, description, label, format, show, futureAllowed, null, null, null, null,
+                    null);
         }
 
         /** The label if the manifest gave one, otherwise the parameter name as a last resort. */

--- a/gateway/src/main/java/org/mifos/community/copilot/core/tools/ToolManifest.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/tools/ToolManifest.java
@@ -27,6 +27,11 @@ public final class ToolManifest {
     private final Map<String, ToolDefinition> tools = new LinkedHashMap<>();
 
     @SuppressWarnings("unchecked")
+    /** A manifest value as text, so a bound written as 1 and one written as '1' both read. */
+    private static String text(Object value) {
+        return value == null ? null : String.valueOf(value);
+    }
+
     public static ToolManifest load(InputStream yamlStream) {
         Map<String, Object> root = new Yaml().load(yamlStream);
         ToolManifest manifest = new ToolManifest();
@@ -43,7 +48,12 @@ public final class ToolManifest {
                         // Shown on the confirmation card unless the manifest hides it, which
                         // it does for identifiers that mean nothing to an officer.
                         !Boolean.FALSE.equals(param.get("show")),
-                        Boolean.TRUE.equals(param.get("futureAllowed"))));
+                        Boolean.TRUE.equals(param.get("futureAllowed")),
+                    text(param.get("pattern")),
+                    text(param.get("mustBe")),
+                    text(param.get("min")),
+                    text(param.get("max")),
+                    text(param.get("maxLength"))));
             }
             ToolDefinition.RestMapping rest = null;
             Map<String, Object> restNode = (Map<String, Object>) entry.get("rest");

--- a/gateway/src/main/java/org/mifos/community/copilot/gateway/web/ChatController.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/gateway/web/ChatController.java
@@ -129,17 +129,33 @@ public class ChatController {
             }
 
             // The loop is blocking (JDK HttpClient streams); run it off the event loop.
-            Schedulers.boundedElastic().schedule(() -> {
-                try {
-                    work.accept(context, sink);
-                } catch (Exception e) {
-                    log.error("Copilot turn failed [correlation={}]", context.correlationId(), e);
-                    sink.emit(StreamEvent.error(ErrorCode.INTERNAL, "Something went wrong on the gateway.", false));
-                    sink.emit(StreamEvent.done(""));
-                } finally {
-                    flux.complete();
-                }
-            });
+            try {
+                Schedulers.boundedElastic().schedule(() -> {
+                    try {
+                        work.accept(context, sink);
+                    } catch (Throwable t) {
+                        // Throwable, not Exception. The stream is closed in the finally either
+                        // way, so anything not caught here ends the turn with no last event at
+                        // all, and the officer is left watching a connection that has quietly
+                        // stopped rather than being told something went wrong.
+                        log.error("Copilot turn failed [correlation={}]", context.correlationId(), t);
+                        sink.emit(StreamEvent.error(ErrorCode.INTERNAL,
+                                "Something went wrong on the gateway.", false));
+                        sink.emit(StreamEvent.done(""));
+                    } finally {
+                        flux.complete();
+                    }
+                });
+            } catch (java.util.concurrent.RejectedExecutionException e) {
+                // Refused before the work started, so the guard inside it never runs. Under
+                // load this is the shape a busy gateway takes, and it deserves a sentence
+                // rather than a stream that opens and closes with nothing in it.
+                log.warn("Copilot turn rejected, scheduler saturated [correlation={}]", context.correlationId());
+                sink.emit(StreamEvent.error(ErrorCode.INTERNAL,
+                        "The Copilot is busy right now. Please try again in a moment.", true));
+                sink.emit(StreamEvent.done(""));
+                flux.complete();
+            }
         }, FluxSink.OverflowStrategy.BUFFER);
     }
 

--- a/gateway/src/main/resources/tools.yaml
+++ b/gateway/src/main/resources/tools.yaml
@@ -15,6 +15,11 @@
 # `redactFields` are masked before results can reach a cloud model.
 #
 # Two things a body may read besides the officer's own arguments:
+# `pattern`, `min` and `max` are copied from the validators the Mifos X web app already
+# applies to the same field, and `mustBe` finishes the sentence "First name must ...". They
+# are deliberately no stricter than the form: the Copilot sits beside that app, so it must
+# not refuse work an officer could do in the UI, and must not become a way round it either.
+#
 #   ${session.x}  a fact the logged-in session owns, such as which office the officer works
 #                 in. The model cannot supply one, which is the point.
 #   defaults:     values read from the record that owns them before the request is built, so a
@@ -26,6 +31,9 @@ tools:
   - name: mifos_client_search
     description: Search for clients by name, account number or external id.
     write: false
+    # A search returns whole matched entities. The name has to survive for the result to be
+    # any use to the officer; the external id is a national id and does not.
+    redactFields: [entityExternalId, externalId, entityMobileNo, mobileNo]
     params:
       - { name: query, type: string, required: true, label: Search, description: Name or account number to search for }
     rest:
@@ -40,7 +48,7 @@ tools:
     rest:
       method: GET
       path: /fineract-provider/api/v1/clients/{clientId}
-    redactFields: [mobileNo, dateOfBirth]
+    redactFields: [mobileNo, dateOfBirth, externalId]
 
   - name: mifos_client_accounts
     description: List every loan and savings account belonging to a client, with balances and statuses.
@@ -92,23 +100,31 @@ tools:
     summary: "Create client {firstname} {lastname}"
     write: true
     params:
-      - { name: firstname, type: string, required: true, label: First name }
-      - { name: lastname, type: string, required: true, label: Last name }
+      # client-general-step.component.ts requires Validators.pattern('(^[A-Za-z]).*') on both.
+      # The pattern is the web app's. The lengths are Fineract's own columns, which the form
+      # does not mention at all, so a long name only failed once the officer had confirmed it.
+      - { name: firstname, type: string, required: true, label: First name, pattern: '^[A-Za-z].*', mustBe: start with a letter, maxLength: '50' }
+      - { name: lastname, type: string, required: true, label: Last name, pattern: '^[A-Za-z].*', mustBe: start with a letter, maxLength: '50' }
       - { name: activationDate, type: string, required: true, label: Activation date, format: date, description: "Date as yyyy-MM-dd, or the word today" }
-      - { name: mobileNo, type: string, required: false, label: Mobile number }
+      - { name: mobileNo, type: string, required: false, label: Mobile number, maxLength: '50' }
       - { name: dateOfBirth, type: string, required: false, label: Date of birth, format: date, description: "Date as yyyy-MM-dd" }
-      - { name: externalId, type: string, required: false, label: External id, description: "The institution's own reference for this client, such as a national id" }
+      # No format rule: the web app's external-id regex is deployment-configured and empty by
+      # default, so it enforces none, and inventing one here would refuse legitimate references.
+      - { name: externalId, type: string, required: false, label: External id, maxLength: '100', description: "The institution's own reference for this client, such as a national id" }
       # Filled from the officer's own credential when only one office is reachable.
       - { name: officeId, type: integer, required: false, label: Office, description: "Only needed when the officer works in more than one office" }
     rest:
       method: POST
       path: /fineract-provider/api/v1/clients
-      # officeId comes from the officer's session. It was a literal 1, which put every client
-      # created through the Copilot into head office whatever branch the officer worked in.
+      # officeId is established from the officer's own credential, never sent by the browser
+      # and never invented by the model. It was a literal 1, which put every client created
+      # through the Copilot into head office whatever branch the officer worked in.
       body: '{"officeId":"${officeId}","firstname":"${firstname}","lastname":"${lastname}","mobileNo":"${mobileNo}","dateOfBirth":"${dateOfBirth}","externalId":"${externalId}","legalFormId":1,"active":true,"activationDate":"${activationDate}","dateFormat":"dd MMMM yyyy","locale":"en"}'
     # A rejected creation comes back echoing what was sent, and that answer is fed to the
-    # model. The read tool masks the same two fields.
-    redactFields: [mobileNo, dateOfBirth]
+    # model. Fineract puts the value in the message text, not under a key of that name, so
+    # these are masked by value as well as by key. externalId is here because this manifest
+    # describes it as a national id, and the read tool masks the same three.
+    redactFields: [mobileNo, dateOfBirth, externalId]
 
   - name: mifos_loan_create
     description: Submit a new loan application for a client. Requires the officer's confirmation.
@@ -117,8 +133,11 @@ tools:
     params:
       - { name: clientId, type: integer, required: true, label: Client, show: false }
       - { name: productId, type: integer, required: true, label: Product, show: false, description: "Loan product id, from mifos_loan_products" }
-      - { name: principal, type: number, required: true, label: Principal, format: money }
-      - { name: numberOfRepayments, type: integer, required: true, label: Repayments, description: Number of monthly instalments }
+      # amountValueValidator() in the web app, which is where this pattern comes from.
+      - { name: principal, type: number, required: true, label: Principal, format: money, pattern: '^\d{1,13}(\.\d{1,6})?$', min: '0.000001', mustBe: 'be an amount, and not a negative one' }
+      # One place the form is looser than the server: the web app allows Validators.min(0), and
+      # Fineract requires strictly more than zero. A loan of no instalments is not a loan.
+      - { name: numberOfRepayments, type: integer, required: true, label: Repayments, min: '1', description: Number of monthly instalments }
       - { name: submittedOnDate, type: string, required: true, label: Submitted on, format: date, description: "Date as yyyy-MM-dd, or today" }
       # The one date that is meant to be in the future. Clamping it to the business date
       # rewrites every instalment on the schedule Fineract derives from it.
@@ -165,7 +184,7 @@ tools:
     params:
       - { name: loanId, type: integer, required: true, label: Loan account, show: false }
       - { name: approvedOnDate, type: string, required: true, label: Approval date, format: date, description: "Date as yyyy-MM-dd, or today" }
-      - { name: approvedLoanAmount, type: number, required: false, label: Approved amount, format: money, description: Approved principal if different from the amount applied for }
+      - { name: approvedLoanAmount, type: number, required: false, label: Approved amount, format: money, pattern: '^\d{1,13}(\.\d{1,6})?$', mustBe: 'be an amount, and not a negative one', description: Approved principal if different from the amount applied for }
     enrich:
       - path: /fineract-provider/api/v1/loans/{loanId}
         currency: currency.code
@@ -186,7 +205,7 @@ tools:
     params:
       - { name: loanId, type: integer, required: true, label: Loan account, show: false }
       - { name: actualDisbursementDate, type: string, required: true, label: Disbursement date, format: date, description: "Date as yyyy-MM-dd, or today" }
-      - { name: transactionAmount, type: number, required: false, label: Amount, format: money, description: Amount to disburse if different from the approved principal }
+      - { name: transactionAmount, type: number, required: false, label: Amount, format: money, pattern: '^\d{1,13}(\.\d{1,6})?$', mustBe: 'be an amount, and not a negative one', description: Amount to disburse if different from the approved principal }
     enrich:
       - path: /fineract-provider/api/v1/loans/{loanId}
         currency: currency.code
@@ -206,7 +225,8 @@ tools:
     write: true
     params:
       - { name: loanId, type: integer, required: true, label: Loan account, show: false }
-      - { name: transactionAmount, type: number, required: true, label: Repayment amount, format: money }
+      # The web app blocks a zero repayment with Validators.min(0.001); so does this.
+      - { name: transactionAmount, type: number, required: true, label: Repayment amount, format: money, pattern: '^\d{1,13}(\.\d{1,6})?$', min: '0.001', mustBe: 'be an amount, and not a negative one' }
       - { name: transactionDate, type: string, required: true, label: Transaction date, format: date, description: "Date as yyyy-MM-dd, or today" }
     enrich:
       - path: /fineract-provider/api/v1/loans/{loanId}

--- a/gateway/src/test/java/org/mifos/community/copilot/core/tools/ArgumentCheckTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/tools/ArgumentCheckTest.java
@@ -130,6 +130,36 @@ class ArgumentCheckTest {
                 .anyMatch((problem) -> problem.contains("Repayments"));
     }
 
+    /**
+     * Declaring a bound is declaring the field numeric.
+     *
+     * <p>A value that is not a number cannot be compared to a minimum, and letting it through
+     * on those grounds meant a card was raised for a loan of "none" repayments. The officer
+     * found out it was nonsense when Fineract said so, which is the thing this whole change
+     * is meant to stop happening.
+     */
+    @Test
+    void aWordWhereANumberBelongsIsRefusedRatherThanSkipped() {
+        Map<String, Object> args = new LinkedHashMap<>();
+        args.put("clientId", 1);
+        args.put("productId", 1);
+        args.put("principal", 12000);
+        args.put("numberOfRepayments", "none");
+        args.put("submittedOnDate", "2026-08-23");
+        args.put("expectedDisbursementDate", "2026-09-15");
+
+        assertThat(ArgumentCheck.problems(tool("mifos_loan_create"), args))
+                .contains("Repayments must be a number.");
+    }
+
+    /** A field with no bound declared is not turned into a number by this. */
+    @Test
+    void aFieldWithNoBoundIsNotForcedToBeNumeric() {
+        assertThat(ArgumentCheck.problems(tool("mifos_client_create"),
+                Map.of("firstname", "Grace", "lastname", "Wanjiru", "activationDate", "2026-08-23",
+                        "mobileNo", "+254 712 345678"))).isEmpty();
+    }
+
     @Test
     void aMissingRequiredValueIsNamedByItsLabelNotItsFieldName() {
         List<String> problems = ArgumentCheck.problems(tool("mifos_client_create"),

--- a/gateway/src/test/java/org/mifos/community/copilot/core/tools/ArgumentCheckTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/tools/ArgumentCheckTest.java
@@ -1,0 +1,225 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at
+ * http://mozilla.org/MPL/2.0/.
+ */
+package org.mifos.community.copilot.core.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Whether a value is one the officer could have typed into the web app.
+ *
+ * <p>Every rule checked here is copied from a validator the Mifos X web app already applies to
+ * the same field. That is the whole design: the Copilot must not refuse work an officer can do
+ * in the form, and must not accept work the form would refuse, because otherwise it is a way
+ * round the app's own controls rather than a companion to it.
+ */
+class ArgumentCheckTest {
+
+    /** The real manifest, so these tests fail if somebody removes a rule from it. */
+    private static final ToolManifest MANIFEST = ToolManifest.load(
+            ArgumentCheckTest.class.getResourceAsStream("/tools.yaml"));
+
+    private static ToolDefinition tool(String name) {
+        return MANIFEST.find(name).orElseThrow();
+    }
+
+    /**
+     * The one a reviewer found by typing it in.
+     *
+     * <p>client-general-step.component.ts puts Validators.pattern('(^[A-Za-z]).*') on firstname,
+     * so the form will not submit this. The Copilot created the client anyway, because it had
+     * no opinion about what a name looks like and Fineract does not check.
+     */
+    @Test
+    void fifteenDigitsIsNotAName() {
+        List<String> problems = ArgumentCheck.problems(tool("mifos_client_create"),
+                Map.of("firstname", "999999999999999", "lastname", "Wanjiru", "activationDate", "2026-08-23"));
+
+        assertThat(problems).isNotEmpty();
+        assertThat(problems.get(0)).as("said in words an officer can act on")
+                .isEqualTo("First name must start with a letter.");
+    }
+
+    @Test
+    void anOrdinaryNameIsFine() {
+        assertThat(ArgumentCheck.problems(tool("mifos_client_create"),
+                Map.of("firstname", "Grace", "lastname", "Wanjiru", "activationDate", "2026-08-23"))).isEmpty();
+    }
+
+    /**
+     * The form only constrains the first character, and so does this.
+     *
+     * <p>Being stricter would be its own bug. Names carry apostrophes, hyphens, accents and
+     * numerals, and an officer who can enter O'Brien-Smith II in the form must be able to ask
+     * for it in a sentence.
+     */
+    @Test
+    void aNameTheFormWouldAcceptIsNotRefusedForBeingUnusual() {
+        for (String name : List.of("O'Brien-Smith", "Ngozi Adichie II", "Zoë", "MacDonald 3rd")) {
+            assertThat(ArgumentCheck.problems(tool("mifos_client_create"),
+                    Map.of("firstname", name, "lastname", "Wanjiru", "activationDate", "2026-08-23")))
+                    .as("the web app would accept %s", name)
+                    .isEmpty();
+        }
+    }
+
+    @Test
+    void aNegativeRepaymentIsRefused() {
+        List<String> problems = ArgumentCheck.problems(tool("mifos_loan_repayment"),
+                Map.of("loanId", 1, "transactionAmount", -500, "transactionDate", "2026-08-23"));
+
+        assertThat(problems).isNotEmpty();
+        assertThat(problems.get(0)).contains("Repayment amount", "not a negative one");
+    }
+
+    /** The web app blocks a zero repayment with Validators.min(0.001), and so does this. */
+    @Test
+    void aZeroRepaymentIsRefused() {
+        assertThat(ArgumentCheck.problems(tool("mifos_loan_repayment"),
+                Map.of("loanId", 1, "transactionAmount", 0, "transactionDate", "2026-08-23")))
+                .isNotEmpty();
+    }
+
+    @Test
+    void anOrdinaryRepaymentIsFine() {
+        assertThat(ArgumentCheck.problems(tool("mifos_loan_repayment"),
+                Map.of("loanId", 1, "transactionAmount", 2500.50, "transactionDate", "2026-08-23"))).isEmpty();
+    }
+
+    /**
+     * A number the model wrote in scientific notation is the same number.
+     *
+     * <p>Jackson will hand back 1.2E7 for a large enough double, and refusing that as "not an
+     * amount" would be the Copilot arguing with itself about notation rather than value.
+     */
+    @Test
+    void anAmountInScientificNotationIsStillAnAmount() {
+        Map<String, Object> args = new LinkedHashMap<>();
+        args.put("clientId", 1);
+        args.put("productId", 1);
+        args.put("principal", 1.2E7);
+        args.put("numberOfRepayments", 12);
+        args.put("submittedOnDate", "2026-08-23");
+        args.put("expectedDisbursementDate", "2026-09-15");
+
+        assertThat(ArgumentCheck.problems(tool("mifos_loan_create"), args)).isEmpty();
+    }
+
+    @Test
+    void aLoanOfZeroInstalmentsIsRefused() {
+        Map<String, Object> args = new LinkedHashMap<>();
+        args.put("clientId", 1);
+        args.put("productId", 1);
+        args.put("principal", 12000);
+        args.put("numberOfRepayments", 0);
+        args.put("submittedOnDate", "2026-08-23");
+        args.put("expectedDisbursementDate", "2026-09-15");
+
+        assertThat(ArgumentCheck.problems(tool("mifos_loan_create"), args))
+                .anyMatch((problem) -> problem.contains("Repayments"));
+    }
+
+    @Test
+    void aMissingRequiredValueIsNamedByItsLabelNotItsFieldName() {
+        List<String> problems = ArgumentCheck.problems(tool("mifos_client_create"),
+                Map.of("lastname", "Wanjiru", "activationDate", "2026-08-23"));
+
+        assertThat(problems).contains("First name is needed.");
+    }
+
+    @Test
+    void anOptionalValueNobodySetIsNotAProblem() {
+        assertThat(ArgumentCheck.problems(tool("mifos_client_create"),
+                Map.of("firstname", "Grace", "lastname", "Wanjiru", "activationDate", "2026-08-23")))
+                .as("mobileNo, dateOfBirth, externalId and officeId are all optional")
+                .isEmpty();
+    }
+
+    /**
+     * The length limit is Fineract's column, not the form's rule.
+     *
+     * <p>The web app puts no maxlength on a name at all. Fineract stores it in a varchar(50).
+     * Without this the officer confirmed a card and then got a database complaint back, which
+     * is a poor way to learn that a name was two characters too long.
+     */
+    @Test
+    void aNameLongerThanTheColumnIsRefusedBeforeTheCardNotAfterIt() {
+        List<String> problems = ArgumentCheck.problems(tool("mifos_client_create"),
+                Map.of("firstname", "M".repeat(51), "lastname", "Kimani", "activationDate", "2026-08-23"));
+
+        assertThat(problems).contains("First name must be 50 characters or fewer.");
+    }
+
+    @Test
+    void aNameExactlyTheLengthOfTheColumnIsFine() {
+        assertThat(ArgumentCheck.problems(tool("mifos_client_create"),
+                Map.of("firstname", "M".repeat(50), "lastname", "Kimani", "activationDate", "2026-08-23"))).isEmpty();
+    }
+
+    /**
+     * One place the form is looser than the server, and the server wins.
+     *
+     * <p>The web app allows Validators.min(0) on the repayment count. Fineract requires
+     * strictly more than zero. Copying the form here would let the Copilot submit something
+     * the server always rejects, which helps nobody.
+     */
+    @Test
+    void aLoanOfNoInstalmentsIsRefusedEvenThoughTheFormWouldAllowIt() {
+        Map<String, Object> args = new LinkedHashMap<>();
+        args.put("clientId", 1);
+        args.put("productId", 1);
+        args.put("principal", 12000);
+        args.put("numberOfRepayments", 0);
+        args.put("submittedOnDate", "2026-08-23");
+        args.put("expectedDisbursementDate", "2026-09-15");
+
+        assertThat(ArgumentCheck.problems(tool("mifos_loan_create"), args))
+                .contains("Repayments must be at least 1.");
+    }
+
+    @Test
+    void aLoanOfNothingIsRefused() {
+        Map<String, Object> args = new LinkedHashMap<>();
+        args.put("clientId", 1);
+        args.put("productId", 1);
+        args.put("principal", 0);
+        args.put("numberOfRepayments", 12);
+        args.put("submittedOnDate", "2026-08-23");
+        args.put("expectedDisbursementDate", "2026-09-15");
+
+        assertThat(ArgumentCheck.problems(tool("mifos_loan_create"), args))
+                .anyMatch((problem) -> problem.startsWith("Principal"));
+    }
+
+    /**
+     * A rule the manifest gets wrong must not take the tool out of service.
+     *
+     * <p>A pattern that will not compile is a mistake in the manifest, and refusing every value
+     * because of it would stop an officer working over a typo nobody has noticed yet.
+     */
+    @Test
+    void aBrokenPatternInTheManifestDoesNotBlockTheOfficer() {
+        ToolManifest broken = ToolManifest.load(new ByteArrayInputStream("""
+                tools:
+                  - name: t
+                    description: d
+                    write: true
+                    params:
+                      - { name: firstname, type: string, required: true, label: First name, pattern: '([unclosed' }
+                    rest: { method: POST, path: "/x" }
+                """.getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(ArgumentCheck.problems(broken.find("t").orElseThrow(), Map.of("firstname", "Grace"))).isEmpty();
+    }
+}

--- a/gateway/src/test/java/org/mifos/community/copilot/core/tools/OfficeDerivationTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/tools/OfficeDerivationTest.java
@@ -47,7 +47,13 @@ class OfficeDerivationTest {
     private String officesBody = ONE_OFFICE;
     private int officesStatus = 200;
 
-    private final CallContext officer = new CallContext("Basic abc", "default", "corr-1");
+    /** The office Fineract reports as this officer's own, or 0 for a server that will not say. */
+    private int homeOffice;
+
+    /** Decodable, because the home-office lookup reads the username and password out of it. */
+    private final CallContext officer = new CallContext("Basic "
+            + java.util.Base64.getEncoder().encodeToString("mifos:password".getBytes(StandardCharsets.UTF_8)),
+            "default", "corr-1");
 
     @BeforeEach
     void startStubFineract() throws IOException {
@@ -66,8 +72,11 @@ class OfficeDerivationTest {
         String path = exchange.getRequestURI().getPath();
         requestedPaths.add(path);
         boolean offices = path.endsWith("/offices");
-        int status = offices ? officesStatus : 200;
-        String body = offices ? officesBody : "{\"clientId\":11,\"resourceId\":11}";
+        boolean signIn = path.endsWith("/authentication");
+        int status = offices ? officesStatus : signIn && homeOffice == 0 ? 404 : 200;
+        String body = offices ? officesBody
+                : signIn ? "{\"username\":\"mifos\",\"officeId\":" + homeOffice + "}"
+                : "{\"clientId\":11,\"resourceId\":11}";
         byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
         exchange.getResponseHeaders().add("Content-Type", "application/json");
         exchange.sendResponseHeaders(status, bytes.length);
@@ -97,6 +106,46 @@ class OfficeDerivationTest {
 
         assertThat(requestedPaths).as("the credential was asked which offices it reaches")
                 .anyMatch((path) -> path.endsWith("/offices"));
+    }
+
+    /**
+     * An officer who can see the whole institution still belongs to one branch.
+     *
+     * <p>Picking the only visible office worked until somebody added a second one, and then an
+     * administrator, who can see every branch there is, got asked which branch they were
+     * sitting in. Fineract answers a sign-in with the user's own office, so that is what a new
+     * client gets, and the reachable set is only there to check the answer is sane.
+     */
+    @Test
+    void aClientLandsInTheOfficersOwnBranchNotTheOnlyVisibleOne() throws Exception {
+        officesBody = TWO_OFFICES;
+        homeOffice = 9;
+        FineractRestToolExecutor executor = new FineractRestToolExecutor(baseUrl);
+
+        executor.execute(clientCreate(), Map.of("firstname", "Grace"), officer, "cop-1");
+
+        assertThat(requestedPaths).as("it asked who the officer is")
+                .anyMatch((path) -> path.endsWith("/authentication"));
+        assertThat(requestedPaths).anyMatch((path) -> path.endsWith("/clients"));
+    }
+
+    /**
+     * A home office outside what the credential reaches is not taken on trust.
+     *
+     * <p>It is checked against the reachable set like anything else, and when it fails that
+     * check the reachable set decides instead. Here that is unambiguous, so the write goes
+     * ahead in the office the credential can actually see rather than the one it claimed.
+     */
+    @Test
+    void aHomeOfficeTheCredentialCannotReachIsNotUsed() throws Exception {
+        officesBody = ONE_OFFICE;   // reaches office 4 only
+        homeOffice = 77;            // but the sign-in claims 77
+        FineractRestToolExecutor executor = new FineractRestToolExecutor(baseUrl);
+
+        executor.execute(clientCreate(), Map.of("firstname", "Grace"), officer, "cop-1");
+
+        assertThat(requestedPaths).as("it fell back rather than trusting the claim")
+                .anyMatch((path) -> path.endsWith("/clients"));
     }
 
     /**

--- a/gateway/src/test/java/org/mifos/community/copilot/core/tools/OfficeDerivationTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/tools/OfficeDerivationTest.java
@@ -42,6 +42,8 @@ class OfficeDerivationTest {
     private HttpServer server;
     private String baseUrl;
     private final List<String> requestedPaths = new ArrayList<>();
+    /** Bodies posted to /clients, so a test can say which office actually went on the wire. */
+    private final List<String> postedClients = new ArrayList<>();
 
     /** What /offices answers with, and whether it answers at all. */
     private String officesBody = ONE_OFFICE;
@@ -79,10 +81,14 @@ class OfficeDerivationTest {
                 : "{\"clientId\":11,\"resourceId\":11}";
         byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
         exchange.getResponseHeaders().add("Content-Type", "application/json");
-        exchange.sendResponseHeaders(status, bytes.length);
-        try (InputStream ignored = exchange.getRequestBody()) {
-            exchange.getResponseBody().write(bytes);
+        try (InputStream request = exchange.getRequestBody()) {
+            String sent = new String(request.readAllBytes(), StandardCharsets.UTF_8);
+            if (path.endsWith("/clients")) {
+                postedClients.add(sent);
+            }
         }
+        exchange.sendResponseHeaders(status, bytes.length);
+        exchange.getResponseBody().write(bytes);
         exchange.close();
     }
 
@@ -106,6 +112,10 @@ class OfficeDerivationTest {
 
         assertThat(requestedPaths).as("the credential was asked which offices it reaches")
                 .anyMatch((path) -> path.endsWith("/offices"));
+        assertThat(requestedPaths).as("and not asked to sign in, since nothing was in doubt")
+                .noneMatch((path) -> path.endsWith("/authentication"));
+        assertThat(postedClients).singleElement().as("the one office it can reach")
+                .asString().contains("\"officeId\":4");
     }
 
     /**
@@ -126,7 +136,8 @@ class OfficeDerivationTest {
 
         assertThat(requestedPaths).as("it asked who the officer is")
                 .anyMatch((path) -> path.endsWith("/authentication"));
-        assertThat(requestedPaths).anyMatch((path) -> path.endsWith("/clients"));
+        assertThat(postedClients).singleElement().as("her own branch, not the first one listed")
+                .asString().contains("\"officeId\":9");
     }
 
     /**
@@ -144,8 +155,8 @@ class OfficeDerivationTest {
 
         executor.execute(clientCreate(), Map.of("firstname", "Grace"), officer, "cop-1");
 
-        assertThat(requestedPaths).as("it fell back rather than trusting the claim")
-                .anyMatch((path) -> path.endsWith("/clients"));
+        assertThat(postedClients).singleElement().as("the reachable office, not the claimed one")
+                .asString().contains("\"officeId\":4").doesNotContain("77");
     }
 
     /**

--- a/gateway/src/test/java/org/mifos/community/copilot/core/tools/OfficeDerivationTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/tools/OfficeDerivationTest.java
@@ -1,0 +1,176 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at
+ * http://mozilla.org/MPL/2.0/.
+ */
+package org.mifos.community.copilot.core.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mifos.community.copilot.core.auth.CallContext;
+
+/**
+ * Which branch a new client lands in, and who gets to decide that.
+ *
+ * <p>It used to be the literal 1, so every client created through the Copilot went to head
+ * office. It is now established from the officer's own credential, by asking Fineract which
+ * offices that credential reaches. The interesting cases are not the happy one. They are what
+ * happens when the question cannot be asked, and whether an office the model named can slip
+ * past on a day when Fineract is having trouble.
+ */
+class OfficeDerivationTest {
+
+    private static final String ONE_OFFICE = "[{\"id\":4,\"name\":\"Nairobi Branch\"}]";
+    private static final String TWO_OFFICES =
+            "[{\"id\":4,\"name\":\"Nairobi Branch\"},{\"id\":9,\"name\":\"Mombasa Branch\"}]";
+
+    private HttpServer server;
+    private String baseUrl;
+    private final List<String> requestedPaths = new ArrayList<>();
+
+    /** What /offices answers with, and whether it answers at all. */
+    private String officesBody = ONE_OFFICE;
+    private int officesStatus = 200;
+
+    private final CallContext officer = new CallContext("Basic abc", "default", "corr-1");
+
+    @BeforeEach
+    void startStubFineract() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", this::respond);
+        server.start();
+        baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    @AfterEach
+    void stopStubFineract() {
+        server.stop(0);
+    }
+
+    private void respond(HttpExchange exchange) throws IOException {
+        String path = exchange.getRequestURI().getPath();
+        requestedPaths.add(path);
+        boolean offices = path.endsWith("/offices");
+        int status = offices ? officesStatus : 200;
+        String body = offices ? officesBody : "{\"clientId\":11,\"resourceId\":11}";
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.sendResponseHeaders(status, bytes.length);
+        try (InputStream ignored = exchange.getRequestBody()) {
+            exchange.getResponseBody().write(bytes);
+        }
+        exchange.close();
+    }
+
+    /** A client-create tool whose body needs an office, which is what triggers the lookup. */
+    private ToolDefinition clientCreate() {
+        return new ToolDefinition("mifos_client_create", "Create a client", true, "Create client {firstname}",
+                List.of(new ToolDefinition.Param("firstname", "string", true, "given name", "First name", null,
+                        true, false),
+                        new ToolDefinition.Param("officeId", "integer", false, "office", "Office", null, false,
+                                false)),
+                new ToolDefinition.RestMapping("POST", "/fineract-provider/api/v1/clients",
+                        "{\"officeId\":\"${officeId}\",\"firstname\":\"${firstname}\"}"),
+                List.of(), List.of(), null, Map.of());
+    }
+
+    @Test
+    void oneReachableOfficeIsTheOfficersOfficeAndNeedsNoAsking() throws Exception {
+        FineractRestToolExecutor executor = new FineractRestToolExecutor(baseUrl);
+
+        executor.execute(clientCreate(), Map.of("firstname", "Grace"), officer, "cop-1");
+
+        assertThat(requestedPaths).as("the credential was asked which offices it reaches")
+                .anyMatch((path) -> path.endsWith("/offices"));
+    }
+
+    /**
+     * The one that matters. A failed lookup must not read as permission.
+     *
+     * <p>Before this, an empty result meant "could not ask" and "reaches nothing" alike, and a
+     * stated office was accepted whenever the list was empty. So a single bad response from
+     * /offices let any office the model named go to the wire unexamined, against the officer's
+     * own credential.
+     */
+    @Test
+    void anOfficeTheModelNamedIsNotAcceptedJustBecauseTheLookupFailed() {
+        officesStatus = 500;
+        FineractRestToolExecutor executor = new FineractRestToolExecutor(baseUrl);
+
+        assertThatThrownBy(() -> executor.execute(clientCreate(),
+                Map.of("firstname", "Grace", "officeId", 99), officer, "cop-1"))
+                .isInstanceOf(ToolExecutionException.class);
+
+        assertThat(requestedPaths).as("nothing was posted").noneMatch((path) -> path.endsWith("/clients"));
+    }
+
+    @Test
+    void anOfficeOutsideWhatTheCredentialReachesIsRefused() {
+        officesBody = TWO_OFFICES;
+        FineractRestToolExecutor executor = new FineractRestToolExecutor(baseUrl);
+
+        assertThatThrownBy(() -> executor.execute(clientCreate(),
+                Map.of("firstname", "Grace", "officeId", 77), officer, "cop-1"))
+                .isInstanceOf(ToolExecutionException.class)
+                .hasMessageContaining("not one you can work in");
+
+        assertThat(requestedPaths).noneMatch((path) -> path.endsWith("/clients"));
+    }
+
+    @Test
+    void anOfficerInSeveralOfficesIsAskedWhichRatherThanGuessedFor() {
+        officesBody = TWO_OFFICES;
+        FineractRestToolExecutor executor = new FineractRestToolExecutor(baseUrl);
+
+        assertThatThrownBy(() -> executor.execute(clientCreate(), Map.of("firstname", "Grace"), officer, "cop-1"))
+                .isInstanceOf(ToolExecutionException.class)
+                .hasMessageContaining("more than one office");
+    }
+
+    @Test
+    void anOfficeThatIsReachableIsAccepted() throws Exception {
+        officesBody = TWO_OFFICES;
+        FineractRestToolExecutor executor = new FineractRestToolExecutor(baseUrl);
+
+        executor.execute(clientCreate(), Map.of("firstname", "Grace", "officeId", 9), officer, "cop-1");
+
+        assertThat(requestedPaths).anyMatch((path) -> path.endsWith("/clients"));
+    }
+
+    /**
+     * A bad minute must not become permanent.
+     *
+     * <p>The reachable set is cached so the lookup costs one call, not one per write. Caching
+     * the failure too would mean a single transient error from /offices left that officer
+     * unable to create a client for as long as the process lived.
+     */
+    @Test
+    void aFailedLookupIsNotRememberedAsTheAnswer() throws Exception {
+        officesStatus = 503;
+        FineractRestToolExecutor executor = new FineractRestToolExecutor(baseUrl);
+
+        assertThatThrownBy(() -> executor.execute(clientCreate(), Map.of("firstname", "Grace"), officer, "cop-1"))
+                .isInstanceOf(ToolExecutionException.class);
+
+        officesStatus = 200;
+        executor.execute(clientCreate(), Map.of("firstname", "Grace"), officer, "cop-2");
+
+        assertThat(requestedPaths).as("the second attempt succeeded once Fineract recovered")
+                .anyMatch((path) -> path.endsWith("/clients"));
+    }
+}

--- a/gateway/src/test/java/org/mifos/community/copilot/core/tools/RedactionPostureTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/tools/RedactionPostureTest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at
+ * http://mozilla.org/MPL/2.0/.
+ */
+package org.mifos.community.copilot.core.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * What every tool says is private, written down in one place on purpose.
+ *
+ * <p>A tool that declares no {@code redactFields} is silently allowed to send whatever
+ * Fineract hands back to a model that may not be running on the bank's own hardware. That is
+ * the right answer for a list of loan products and the wrong one for a client record, and
+ * nothing in the code can tell those apart. Omitting the key looks exactly like deciding
+ * there is nothing to hide.
+ *
+ * <p>So the decision is pinned here instead. Adding a tool, or removing a mask from one, fails
+ * this test until somebody comes and says which it is. That is the whole point: the omission
+ * has to be deliberate rather than accidental, and the reasoning survives in the diff.
+ */
+class RedactionPostureTest {
+
+    private static final ToolManifest MANIFEST = ToolManifest.load(
+            RedactionPostureTest.class.getResourceAsStream("/tools.yaml"));
+
+    /**
+     * Every tool, and what it masks. Checked against sandbox.mifos.community responses.
+     *
+     * <p>The tools masking nothing return account structure, schedules, balances and product
+     * configuration. {@code mifos_loan_details} returns {@code clientName} and deliberately
+     * keeps it: the confirmation card exists so the officer can see whose loan they are
+     * approving, and a card reading "approve the loan for •••" would defeat the pause.
+     */
+    private static final Map<String, List<String>> EXPECTED = expected();
+
+    private static Map<String, List<String>> expected() {
+        Map<String, List<String>> posture = new LinkedHashMap<>();
+        // Reads that carry a person.
+        posture.put("mifos_client_search", List.of("entityExternalId", "externalId", "entityMobileNo", "mobileNo"));
+        posture.put("mifos_client_details", List.of("mobileNo", "dateOfBirth", "externalId"));
+        // Writes that echo what was submitted when Fineract rejects them.
+        posture.put("mifos_client_create", List.of("mobileNo", "dateOfBirth", "externalId"));
+        // Nothing to mask: structure, schedules, balances, product configuration.
+        posture.put("mifos_client_accounts", List.of());
+        posture.put("mifos_loan_details", List.of());
+        posture.put("mifos_loan_schedule", List.of());
+        posture.put("mifos_savings_details", List.of());
+        posture.put("mifos_loan_products", List.of());
+        posture.put("mifos_loan_create", List.of());
+        posture.put("mifos_loan_approve", List.of());
+        posture.put("mifos_loan_disburse", List.of());
+        posture.put("mifos_loan_repayment", List.of());
+        return posture;
+    }
+
+    @Test
+    void everyToolInTheManifestHasHadItsPrivacyDecided() {
+        assertThat(MANIFEST.all().stream().map(ToolDefinition::name))
+                .as("a new tool needs a line in EXPECTED saying what it masks and why")
+                .containsExactlyInAnyOrderElementsOf(EXPECTED.keySet());
+    }
+
+    @Test
+    void noToolHasQuietlyLostAMask() {
+        for (Map.Entry<String, List<String>> entry : EXPECTED.entrySet()) {
+            assertThat(MANIFEST.find(entry.getKey()).orElseThrow().redactFields())
+                    .as("redactFields for %s", entry.getKey())
+                    .containsExactlyInAnyOrderElementsOf(entry.getValue());
+        }
+    }
+
+    /**
+     * The three fields a client record carries that a model has no business seeing.
+     *
+     * <p>Named here rather than only in the manifest, so adding a fourth to one tool and
+     * forgetting the other is caught. They went out unmasked once already, in the prose of a
+     * rejection, and the manifest looked correct the whole time.
+     */
+    @Test
+    void everyToolThatTouchesAClientRecordMasksAllThreeOfThem() {
+        for (String name : List.of("mifos_client_details", "mifos_client_create")) {
+            assertThat(MANIFEST.find(name).orElseThrow().redactFields())
+                    .as("%s masks the phone number, the date of birth and the national id", name)
+                    .contains("mobileNo", "dateOfBirth", "externalId");
+        }
+    }
+}

--- a/gateway/src/test/java/org/mifos/community/copilot/core/tools/RedactionTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/tools/RedactionTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Map;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -62,6 +63,54 @@ class RedactionTest {
         String safe = executor.redact(body, List.of("externalId"), Map.of("externalId", "NID-88213944"));
 
         assertThat(safe).doesNotContain("NID-88213944");
+    }
+
+    /**
+     * A value the server had to escape on its way out.
+     *
+     * <p>Masking used to run over the raw document, so it compared a plain value against an
+     * escaped one and found nothing. The payload came back looking masked, because the named
+     * fields were, while the prose still carried the id in full. Everything is decoded first
+     * now, so how Fineract chose to encode it stops mattering.
+     */
+    @Test
+    void aValueTheServerEscapedIsStillMasked() {
+        FineractRestToolExecutor executor = new FineractRestToolExecutor(BASE_URL);
+        String awkward = "NID\"88213944";
+        String body = "{\"defaultUserMessage\":\"Client with externalId `NID\\\"88213944` already exists\"}";
+
+        String safe = executor.redact(body, List.of("externalId"), Map.of("externalId", awkward));
+
+        assertThat(safe).doesNotContain("88213944");
+    }
+
+    /**
+     * Same again for values the encoder has no choice about.
+     *
+     * <p>The payload is built with Jackson rather than hand-escaped, so exactly the escaping
+     * the server would apply is applied here too. The awkward characters are written as codes
+     * rather than literals so that nothing between here and the JSON quietly reinterprets
+     * them, which is a mistake this test made on its way to being written.
+     */
+    @Test
+    void aValueTheEncoderHadToEscapeIsStillMasked() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        FineractRestToolExecutor executor = new FineractRestToolExecutor(BASE_URL);
+        List<String> awkward = List.of(
+                "DOM" + (char) 92 + "4471",   // backslash
+                "NID" + (char) 34 + "4471",   // double quote
+                "line" + (char) 10 + "4471",  // newline
+                "tab" + (char) 9 + "4471");   // tab
+
+        for (String value : awkward) {
+            String body = mapper.writeValueAsString(mapper.createObjectNode()
+                    .put("defaultUserMessage", "Client with externalId `" + value + "` already exists"));
+            assertThat(body).as("the encoder really did escape it").doesNotContain(value);
+
+            String safe = executor.redact(body, List.of("externalId"), Map.of("externalId", value));
+
+            assertThat(safe).as("masked despite the escaping").doesNotContain("4471");
+        }
     }
 
     @Test

--- a/gateway/src/test/java/org/mifos/community/copilot/core/tools/RedactionTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/tools/RedactionTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at
+ * http://mozilla.org/MPL/2.0/.
+ */
+package org.mifos.community.copilot.core.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * What a rejected write is allowed to tell the model about the client.
+ *
+ * <p>A tool declares which of its fields are private, and the officer's own banking system is
+ * the thing that hands them back. Fineract does not answer a rejection with a tidy object
+ * keyed by parameter name. It answers in prose, with the submitted value written into the
+ * sentence, and again under a value field beside the parameter's name. Masking by key alone
+ * reads that payload, finds no key called mobileNo, and passes the number through to a model
+ * that may not be running on the bank's own hardware.
+ */
+class RedactionTest {
+
+    private static final String BASE_URL = "https://example.invalid";
+
+    /** Verbatim in shape from Fineract's duplicate handling, which echoes what was sent. */
+    private static final String DUPLICATE_MOBILE = """
+            {"developerMessage":"The request caused a data integrity issue to be fired by the database.",
+             "httpStatusCode":"403",
+             "defaultUserMessage":"Client with mobileNo `0712345678` already exists",
+             "userMessageGlobalisationCode":"error.msg.client.duplicate.mobileNo",
+             "errors":[{"developerMessage":"Client with mobileNo `0712345678` already exists",
+                        "defaultUserMessage":"Client with mobileNo `0712345678` already exists",
+                        "userMessageGlobalisationCode":"error.msg.client.duplicate.mobileNo",
+                        "parameterName":"mobileNo",
+                        "value":"0712345678",
+                        "args":[{"value":"0712345678"}]}]}
+            """;
+
+    @Test
+    void aRejectionDoesNotHandTheClientsPhoneNumberToTheModel() {
+        FineractRestToolExecutor executor = new FineractRestToolExecutor(BASE_URL);
+
+        String safe = executor.redact(DUPLICATE_MOBILE, List.of("mobileNo", "dateOfBirth", "externalId"),
+                Map.of("firstname", "Grace", "lastname", "Wanjiru", "mobileNo", "0712345678"));
+
+        assertThat(safe).as("not in the prose, not in the value field, not in the args")
+                .doesNotContain("0712345678");
+        assertThat(safe).as("the officer still learns what went wrong").contains("already exists");
+    }
+
+    @Test
+    void aNationalIdIsMaskedTheSameWayAPhoneNumberIs() {
+        FineractRestToolExecutor executor = new FineractRestToolExecutor(BASE_URL);
+        String body = "{\"defaultUserMessage\":\"Client with externalId `NID-88213944` already exists\","
+                + "\"errors\":[{\"parameterName\":\"externalId\",\"value\":\"NID-88213944\"}]}";
+
+        String safe = executor.redact(body, List.of("externalId"), Map.of("externalId", "NID-88213944"));
+
+        assertThat(safe).doesNotContain("NID-88213944");
+    }
+
+    @Test
+    void maskingByKeyStillWorksForAPlainRead() {
+        FineractRestToolExecutor executor = new FineractRestToolExecutor(BASE_URL);
+        String body = "{\"id\":42,\"displayName\":\"Grace Wanjiru\",\"mobileNo\":\"0712345678\"}";
+
+        String safe = executor.redact(body, List.of("mobileNo"), Map.of());
+
+        assertThat(safe).doesNotContain("0712345678");
+        assertThat(safe).as("the rest of the record survives").contains("Grace Wanjiru");
+    }
+
+    /**
+     * A value short enough that masking it everywhere would do more harm than good.
+     *
+     * <p>An officer whose client id is 1 does not want every 1 in the message replaced. The
+     * point is to stop a phone number or a national id reaching the model, and those are not
+     * three characters long.
+     */
+    @Test
+    void aVeryShortValueIsNotMaskedOutOfTheWholeMessage() {
+        FineractRestToolExecutor executor = new FineractRestToolExecutor(BASE_URL);
+        String body = "{\"defaultUserMessage\":\"Loan 100 is not in a state to be approved on 2026-08-23\"}";
+
+        String safe = executor.redact(body, List.of("mobileNo"), Map.of("mobileNo", "100"));
+
+        assertThat(safe).as("the message is still readable").contains("not in a state to be approved");
+    }
+}


### PR DESCRIPTION
A reviewer typed `999999999999999` into the panel as a client's first name, and the Copilot created the client. The web app will not do that. [client-general-step.component.ts:178](https://github.com/openMF/web-app/blob/main/src/app/clients/client-stepper/client-general-step/client-general-step.component.ts#L178) puts `Validators.pattern('(^[A-Za-z]).*')` on `firstname` and `lastname`, so the form refuses it before it is submitted. Fineract does not check either: the firstname validator is `.notBlank().notExceedingLengthOf(50)` and there is no regex, no character class and no alphabetic requirement anywhere on the client name path.
So the Copilot was not really missing validation. It was a way round the controls the app already has, and that is the thing worth fixing.
A parameter can now say what a valid value looks like. Every rule is copied from a validator the web app already applies to the same field, and it is deliberately no stricter. A name the form accepts has to work in a sentence too, so `O'Brien-Smith`, `Ngozi Adichie II` and `Zoë` all still go through. Being stricter here would be its own bug, refusing work an officer can plainly do in the UI.
Lengths are the exception, and they come from Fineract rather than the form. The web app puts no `maxlength` on a name at all; Fineract stores it in a `varchar(50)`. Without the check, a name two characters too long was only discovered after the officer had read the card and pressed Confirm, and came back as a database complaint. One field goes the other way: the form allows `Validators.min(0)` on the repayment count and Fineract requires strictly more than zero, so the server wins. A loan of no instalments is not a loan.
The check runs before the card is built and before enrichment, because the card is the officer's approval point and a bad value should not cost a lookup. A problem goes back to the model as a tool result rather than as an error, so the assistant explains it and asks for something better instead of the turn ending. Running against the sandbox with a real model, it said: "The first name can't be all numbers, it must start with a letter. Could you give me a valid first name for the new client?"

The rest of this came from an adversarial pass over the work that just merged in #438, where independent agents were asked to prove the fixes wrong rather than confirm them. Two of them were.

**A rejected write handed the client's phone number to the model.** Masking matched key names. Fineract answers a duplicate with `Client with mobileNo \`0712345678\` already exists`, where the number sits in the prose under `defaultUserMessage`, again under `errors[].value`, and again in `errors[].args[].value`, and under no key named `mobileNo` anywhere. Nothing was masked and the whole rejection went into the conversation and on to the model. Values are masked now as well as keys, with short ones matched on a word boundary so a three-character external id is covered without eating the same characters inside a word. `externalId` is masked too, because this manifest describes it as a national id. And `mifos_client_search`, which returns whole matched clients, declared nothing private at all.
**The office check failed open.** `readOffices` returned an empty set both for a lookup that failed and for a credential that genuinely reaches nothing, a stated office was accepted whenever that set was empty, and the empty set was cached with no expiry. So one bad response from `/offices` meant any office the model named went to the wire unexamined, against the officer's own credential, for the life of the process. Those two cases are different things now, and only a real answer is remembered.
**A reader could walk off the end of a conversation.** `ConversationStore.messages` handed out the live `ArrayList` while `append` was adding a message and trimming the oldest back off. The list is briefly one longer than its limit and then shrinks, and the same officer with two tabs open is enough to be reading it at that moment. It surfaced as an exception escaping a decision after the write had already reached Fineract, which is the worst moment available for one. It returns a snapshot now.
Three smaller ones alongside. A dead LLM connection surfaces as an unchecked wrapper rather than the declared failure, and left the officer watching a stream that never ended. The only backstop for a whole turn caught `Exception` rather than `Throwable`, and the scheduling call itself sat outside it, so a saturated scheduler closed the stream with no last event at all. And write arguments sat unredacted in the conversation history, to be replayed to the model on every later round.

Tests 96 to 111. The new ones read the real `tools.yaml` rather than a fixture, so removing a rule from the manifest fails the suite. Verified end to end against sandbox.mifos.community with `openai/gpt-oss-120b` rather than the keyword stand-in: the bad name is refused in words and raises no card, an ordinary name still raises one, and a client created without the panel sending any office landed in the right branch.
One caveat worth stating. In the end-to-end run the model normalised a negative repayment to a positive one before ever calling the tool, so that particular refusal never fired in production and is proven by unit test only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for tool inputs, including formats, ranges, required fields, and length limits.
  * Improved protection of sensitive information in tool responses and conversation history.
  * Improved office access checks, including safer home-office selection and authorization handling.

* **Bug Fixes**
  * Streaming and scheduling failures now return retryable errors and reliably close responses.
  * Conversation messages are safely isolated from internal state.
  * Office lookup failures no longer produce stale access results.

* **Tests**
  * Added coverage for input validation, office authorization, error handling, and sensitive-data redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->