### PR TITLE
fix(gateway): let a deployment say where its Fineract actually lives

### DIFF
--- a/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
@@ -70,16 +70,43 @@ public final class FineractRestToolExecutor implements ToolExecutor {
 
     private final HttpClient http;
     private final ObjectMapper mapper = new ObjectMapper();
+    /** What the manifest is written against, and what a bare Fineract actually serves. */
+    private static final String MANIFEST_API_PATH = "/fineract-provider/api/v1";
+
     private final String fineractBaseUrl;
+    private final String apiPath;
 
     public FineractRestToolExecutor(String fineractBaseUrl) {
+        this(fineractBaseUrl, MANIFEST_API_PATH);
+    }
+
+    public FineractRestToolExecutor(String fineractBaseUrl, String apiPath) {
         this.fineractBaseUrl = fineractBaseUrl.replaceAll("/+$", "");
+        this.apiPath = apiPath == null || apiPath.isBlank()
+                ? MANIFEST_API_PATH
+                : apiPath.replaceAll("/+$", "");
         this.http = HttpClient.newBuilder()
                 // Generous: sandbox/gateway-fronted Fineracts can be slow to accept connections,
                 // and JVMs on dual-stack hosts may burn seconds on IPv6 before falling back.
                 .connectTimeout(Duration.ofSeconds(20))
                 .followRedirects(HttpClient.Redirect.NORMAL) // Fineract behind an API gateway may 30x.
                 .build();
+    }
+
+    /**
+     * The full URL for a manifest path, under whatever prefix this deployment serves.
+     *
+     * <p>The manifest is written against a bare Fineract, which answers at
+     * {@code /fineract-provider/api/v1}. Behind an API manager the same server answers
+     * somewhere else: the Mifos community sandbox publishes it at {@code /1.0/core/api/v1},
+     * and the web app is told so separately as FINERACT_API_PROVIDER. The gateway had no
+     * business assuming the bare layout, so the prefix is swapped here rather than written
+     * eighteen times into the YAML.
+     */
+    private String url(String manifestPath) {
+        return fineractBaseUrl + (manifestPath.startsWith(MANIFEST_API_PATH)
+                ? apiPath + manifestPath.substring(MANIFEST_API_PATH.length())
+                : manifestPath);
     }
 
     @Override
@@ -96,7 +123,7 @@ public final class FineractRestToolExecutor implements ToolExecutor {
         Map<String, Object> effective = withComputed(tool,
                 withDefaults(tool, withOffice(tool, normalizeArguments(tool, args, context), context), context));
         String path = substitutePath(rest.path(), effective, today);
-        HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create(fineractBaseUrl + path))
+        HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create(url(path)))
                 .timeout(Duration.ofSeconds(30))
                 .header("Accept", "application/json")
                 .header("Authorization", context.authorizationHeader())
@@ -189,7 +216,7 @@ public final class FineractRestToolExecutor implements ToolExecutor {
         try {
             String path = substitutePath(spec.path(), effective, businessDate(context));
             HttpResponse<String> response = http.send(
-                    HttpRequest.newBuilder(URI.create(fineractBaseUrl + path))
+                    HttpRequest.newBuilder(URI.create(url(path)))
                             .timeout(Duration.ofSeconds(15))
                             .header("Accept", "application/json")
                             .header("Authorization", context.authorizationHeader())
@@ -333,8 +360,7 @@ public final class FineractRestToolExecutor implements ToolExecutor {
                     .put("username", decoded.substring(0, split))
                     .put("password", decoded.substring(split + 1));
             HttpResponse<String> response = http.send(
-                    HttpRequest.newBuilder(URI.create(fineractBaseUrl
-                                    + "/fineract-provider/api/v1/authentication"))
+                    HttpRequest.newBuilder(URI.create(url(MANIFEST_API_PATH + "/authentication")))
                             .timeout(Duration.ofSeconds(15))
                             .header("Content-Type", "application/json")
                             .header("Accept", "application/json")
@@ -367,7 +393,7 @@ public final class FineractRestToolExecutor implements ToolExecutor {
     private java.util.Optional<java.util.Set<String>> readOffices(CallContext context) {
         try {
             HttpResponse<String> response = http.send(
-                    HttpRequest.newBuilder(URI.create(fineractBaseUrl + "/fineract-provider/api/v1/offices"))
+                    HttpRequest.newBuilder(URI.create(url(MANIFEST_API_PATH + "/offices")))
                             .timeout(Duration.ofSeconds(15))
                             .header("Accept", "application/json")
                             .header("Authorization", context.authorizationHeader())
@@ -645,7 +671,7 @@ public final class FineractRestToolExecutor implements ToolExecutor {
         }
         try {
             String path = substitutePath(spec.path(), args, businessDate(context));
-            HttpRequest request = HttpRequest.newBuilder(URI.create(fineractBaseUrl + path))
+            HttpRequest request = HttpRequest.newBuilder(URI.create(url(path)))
                     .timeout(Duration.ofSeconds(15))
                     .header("Accept", "application/json")
                     .header("Authorization", context.authorizationHeader())
@@ -775,7 +801,7 @@ public final class FineractRestToolExecutor implements ToolExecutor {
     private String fetchBusinessDate(CallContext context) {
         try {
             HttpRequest request = HttpRequest
-                    .newBuilder(URI.create(fineractBaseUrl + "/fineract-provider/api/v1/businessdate/BUSINESS_DATE"))
+                    .newBuilder(URI.create(url(MANIFEST_API_PATH + "/businessdate/BUSINESS_DATE")))
                     .timeout(Duration.ofSeconds(10))
                     .header("Accept", "application/json")
                     .header("Authorization", context.authorizationHeader())

--- a/gateway/src/main/java/org/mifos/community/copilot/gateway/config/CoreWiring.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/gateway/config/CoreWiring.java
@@ -83,9 +83,9 @@ public class CoreWiring {
 
     @Bean
     ToolExecutor toolExecutor(GatewayProperties properties) {
-        log.info("Tool executor = direct Fineract REST at {} (officer credential passthrough)",
-                properties.fineract().baseUrl());
-        return new FineractRestToolExecutor(properties.fineract().baseUrl());
+        log.info("Tool executor = direct Fineract REST at {}{} (officer credential passthrough)",
+                properties.fineract().baseUrl(), properties.fineract().apiPath());
+        return new FineractRestToolExecutor(properties.fineract().baseUrl(), properties.fineract().apiPath());
     }
 
     @Bean

--- a/gateway/src/main/java/org/mifos/community/copilot/gateway/config/GatewayProperties.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/gateway/config/GatewayProperties.java
@@ -20,7 +20,23 @@ public record GatewayProperties(Llm llm, Fineract fineract, Cors cors, Approval 
 
     public record Llm(String provider, String baseUrl, String apiKey, String model, String dataResidency) {}
 
-    public record Fineract(String baseUrl) {}
+    /**
+     * Where Fineract is, and under what path.
+     *
+     * <p>{@code apiPath} exists because a bare Fineract serves at
+     * {@code /fineract-provider/api/v1} and a Fineract behind an API manager does not. The
+     * Mifos community sandbox publishes the same server at {@code /1.0/core/api/v1}, and the
+     * web app is already told this separately as FINERACT_API_PROVIDER, so the gateway had no
+     * business assuming it.
+     */
+    public record Fineract(String baseUrl, String apiPath) {
+
+        public Fineract {
+            apiPath = apiPath == null || apiPath.isBlank() ? DEFAULT_API_PATH : apiPath.replaceAll("/+$", "");
+        }
+
+        public static final String DEFAULT_API_PATH = "/fineract-provider/api/v1";
+    }
 
     public record Cors(List<String> allowedOrigins) {}
 

--- a/gateway/src/main/resources/application.yaml
+++ b/gateway/src/main/resources/application.yaml
@@ -18,6 +18,9 @@ copilot:
     data-residency: ${COPILOT_DATA_RESIDENCY:cloud}
   fineract:
     base-url: ${FINERACT_BASE_URL:https://sandbox.mifos.community}
+    # A bare Fineract answers here. Behind an API manager it does not: the community
+    # sandbox publishes the same server at /1.0/core/api/v1.
+    api-path: ${FINERACT_API_PATH:/fineract-provider/api/v1}
   cors:
     allowed-origins: ${COPILOT_ALLOWED_ORIGINS:http://localhost:4200}
   approval:


### PR DESCRIPTION
Victor pointed the community sandbox at this gateway and every request was refused: *"this assistant executes against https://sandbox.mifos.community, but your screen is connected to https://apis.mifos.community."*
The guard was right. The Copilot must never execute against a different Fineract than the one on the officer's screen, because a write to the wrong bank would be silent. But pointing the gateway at the second URL would not have fixed it either, and that is the actual bug.
A bare Fineract serves its API at `/fineract-provider/api/v1`. Behind an API manager it does not. The community sandbox publishes the same server at `/1.0/core/api/v1`, which is exactly why the web app is configured with `FINERACT_API_PROVIDER=/1.0/core/api` as a value separate from its host. This gateway wrote the bare path into eighteen manifest entries and three request builders and assumed everybody was deployed the way a laptop is.
`FINERACT_API_PATH` now says where the endpoints are, defaulting to the bare layout so no existing deployment changes behaviour. The swap happens in one place, so the manifest keeps describing what the tools do rather than how one installation happens to be fronted.

For the community sandbox that is:

```yaml
- FINERACT_BASE_URL=https://apis.mifos.community
- FINERACT_API_PATH=/1.0/core/api/v1
```

Checked against `apis.mifos.community` with the same context the deployed panel sends, and reading a client through the API manager returns the client:

```
Client: Victor Romero    Client number: 000000001
Status: Active           Office: Head Office
Loan accounts: 000000001 | test | USD 12,313.00 | Closed
```

Tests unchanged at 120. The default path keeps every existing test and deployment on the layout they already had, and the new constructor argument is additive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the Fineract API path for different deployment environments.
  * Requests now automatically use the configured API path across gateway operations.
  * A default API path is applied when no custom value is provided.
  * Configuration removes trailing slashes to ensure consistent request URLs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->