### PR TITLE
fix(gateway): find a client whoever typed the name, and say when the officer is being throttled

### DIFF
--- a/gateway/src/main/java/org/mifos/community/copilot/core/agent/AgentLoop.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/agent/AgentLoop.java
@@ -240,13 +240,9 @@ public final class AgentLoop {
                 // A refusal is not an outage. Telling an officer to try again shortly, when the
                 // key is wrong or the request was malformed, sends them round a loop that cannot
                 // come out anywhere. Say it is not going to work and let somebody look at it.
-                sink.emit(e.isClientError()
-                        ? StreamEvent.error(ErrorCode.LLM_UNAVAILABLE,
-                                "The AI model rejected this request. Retrying will not help, so please"
-                                        + " tell your administrator.", false)
-                        : StreamEvent.error(
-                                e.isRateLimited() ? ErrorCode.RATE_LIMITED : ErrorCode.LLM_UNAVAILABLE,
-                                "The AI model is unavailable right now. Please try again shortly.", true));
+                // Being throttled and being down are different things and were told the same
+                // way, so a self-inflicted twenty second wait read as the service being broken.
+                sink.emit(llmErrorEvent(e));
                 sink.emit(StreamEvent.done(conversationId));
                 return;
             } catch (RuntimeException e) {
@@ -622,6 +618,33 @@ public final class AgentLoop {
         Object content = messages.get(messages.size() - 1).get("content");
         String text = content == null ? "" : String.valueOf(content);
         return text.contains("could not be prepared") || text.contains("not one you can work in");
+    }
+
+    /**
+     * What to tell the officer when the model did not answer.
+     *
+     * <p>Three different things happen here and they used to produce two sentences between
+     * them. A refusal will not come right by waiting. An outage might. Being throttled
+     * certainly will, and the provider usually says when, which is the difference between a
+     * sentence somebody can act on and one they can only stare at.
+     */
+    private StreamEvent llmErrorEvent(LlmException e) {
+        if (e.isClientError()) {
+            return StreamEvent.error(ErrorCode.LLM_UNAVAILABLE,
+                    "The AI model rejected this request. Retrying will not help, so please tell your"
+                            + " administrator.", false);
+        }
+        if (e.isRateLimited()) {
+            int wait = e.retryAfterSeconds();
+            return StreamEvent.error(ErrorCode.RATE_LIMITED,
+                    wait > 0
+                            ? "That was a lot of questions at once. Try again in " + wait
+                                    + (wait == 1 ? " second." : " seconds.")
+                            : "That was a lot of questions at once. Please wait a moment and try again.",
+                    true);
+        }
+        return StreamEvent.error(ErrorCode.LLM_UNAVAILABLE,
+                "The AI model is unavailable right now. Please try again shortly.", true);
     }
 
     /** The problems as a JSON array, so the model reads them as a list rather than a sentence. */

--- a/gateway/src/main/java/org/mifos/community/copilot/core/agent/AgentLoop.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/agent/AgentLoop.java
@@ -638,13 +638,31 @@ public final class AgentLoop {
             int wait = e.retryAfterSeconds();
             return StreamEvent.error(ErrorCode.RATE_LIMITED,
                     wait > 0
-                            ? "That was a lot of questions at once. Try again in " + wait
-                                    + (wait == 1 ? " second." : " seconds.")
+                            ? "That was a lot of questions at once. Try again in " + spellWait(wait) + "."
                             : "That was a lot of questions at once. Please wait a moment and try again.",
                     true);
         }
         return StreamEvent.error(ErrorCode.LLM_UNAVAILABLE,
                 "The AI model is unavailable right now. Please try again shortly.", true);
+    }
+
+    /**
+     * A wait in the units a person would use for it.
+     *
+     * <p>Seconds are right up to a point, and past that they stop being a quantity anybody
+     * reads: nobody counts out a hundred and fifty of them. Rounded up for the same reason the
+     * wait itself is, so the officer is never sent back early.
+     */
+    private static String spellWait(int seconds) {
+        if (seconds <= 90) {
+            return seconds + (seconds == 1 ? " second" : " seconds");
+        }
+        int minutes = (int) Math.ceil(seconds / 60d);
+        if (minutes <= 90) {
+            return minutes + (minutes == 1 ? " minute" : " minutes");
+        }
+        int hours = (int) Math.ceil(minutes / 60d);
+        return hours + (hours == 1 ? " hour" : " hours");
     }
 
     /** The problems as a JSON array, so the model reads them as a list rather than a sentence. */

--- a/gateway/src/main/java/org/mifos/community/copilot/core/llm/LlmException.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/llm/LlmException.java
@@ -12,6 +12,7 @@ public class LlmException extends Exception {
 
     private final boolean rateLimited;
     private final boolean clientError;
+    private final int retryAfterSeconds;
 
     public LlmException(String message, Throwable cause) {
         this(message, cause, false, false);
@@ -22,9 +23,15 @@ public class LlmException extends Exception {
     }
 
     public LlmException(String message, Throwable cause, boolean rateLimited, boolean clientError) {
+        this(message, cause, rateLimited, clientError, 0);
+    }
+
+    public LlmException(String message, Throwable cause, boolean rateLimited, boolean clientError,
+            int retryAfterSeconds) {
         super(message, cause);
         this.rateLimited = rateLimited;
         this.clientError = clientError;
+        this.retryAfterSeconds = retryAfterSeconds;
     }
 
     public boolean isRateLimited() {
@@ -40,5 +47,16 @@ public class LlmException extends Exception {
      */
     public boolean isClientError() {
         return clientError;
+    }
+
+    /**
+     * How long the provider asked us to wait, or zero when it did not say.
+     *
+     * <p>Worth passing on. "Try again shortly" is not something an officer can act on, and
+     * without a number they either give up or hammer it, both of which are worse than being
+     * told to wait twenty seconds.
+     */
+    public int retryAfterSeconds() {
+        return retryAfterSeconds;
     }
 }

--- a/gateway/src/main/java/org/mifos/community/copilot/core/llm/OpenAiCompatibleLlmClient.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/llm/OpenAiCompatibleLlmClient.java
@@ -89,7 +89,8 @@ public final class OpenAiCompatibleLlmClient implements LlmClient {
         if (response.statusCode() != 200) {
             response.body().close(); // Release the connection before bailing.
             if (response.statusCode() == 429) {
-                throw new LlmException("LLM provider rate limit hit", null, true);
+                throw new LlmException("LLM provider rate limit hit", null, true, false,
+                        retryAfterSeconds(response));
             }
             boolean refused = response.statusCode() == 400 || response.statusCode() == 401
                     || response.statusCode() == 403 || response.statusCode() == 404;
@@ -163,6 +164,36 @@ public final class OpenAiCompatibleLlmClient implements LlmClient {
         } catch (IOException e) {
             return Map.of();
         }
+    }
+
+    /**
+     * The wait the provider asked for, in whole seconds, or zero if it did not ask.
+     *
+     * <p>Both spellings are in the wild: a plain number of seconds, and the provider-specific
+     * one that Groq and others send with a fractional part. Rounded up, because coming back
+     * fractionally early only earns a second refusal.
+     */
+    private static int retryAfterSeconds(HttpResponse<?> response) {
+        for (String header : new String[] { "retry-after", "x-ratelimit-reset-tokens",
+            "x-ratelimit-reset-requests" }) {
+            String value = response.headers().firstValue(header).orElse(null);
+            if (value == null || value.isBlank()) {
+                continue;
+            }
+            try {
+                double seconds = value.endsWith("ms")
+                        ? Double.parseDouble(value.substring(0, value.length() - 2)) / 1000
+                        : Double.parseDouble(value.endsWith("s")
+                                ? value.substring(0, value.length() - 1)
+                                : value);
+                if (seconds > 0) {
+                    return (int) Math.ceil(seconds);
+                }
+            } catch (NumberFormatException e) {
+                // A shape we do not know. Better to say nothing than to invent a number.
+            }
+        }
+        return 0;
     }
 
     private static final class PartialToolCall {

--- a/gateway/src/main/java/org/mifos/community/copilot/core/llm/OpenAiCompatibleLlmClient.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/llm/OpenAiCompatibleLlmClient.java
@@ -13,16 +13,24 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 /**
@@ -166,34 +174,97 @@ public final class OpenAiCompatibleLlmClient implements LlmClient {
         }
     }
 
+    /** A duration as providers spell them: {@code 30}, {@code 1500ms}, {@code 2m59.56s}. */
+    private static final Pattern DURATION_PART = Pattern.compile("(\\d+(?:\\.\\d+)?)\\s*(ms|h|m|s)?");
+
+    /**
+     * Longer than any chat-completions budget legitimately takes to reset.
+     *
+     * <p>Some providers put an epoch timestamp on these headers rather than a duration. Read as
+     * seconds that is a number in the billions, and telling an officer to come back in fifty
+     * years is worse than telling them nothing. A day is the line: daily token budgets are the
+     * slowest thing that legitimately resets, and an epoch value is five orders of magnitude
+     * past it. Anything beyond is treated as a shape we do not understand.
+     */
+    private static final int LONGEST_CREDIBLE_WAIT_SECONDS = 86_400;
+
     /**
      * The wait the provider asked for, in whole seconds, or zero if it did not ask.
      *
-     * <p>Both spellings are in the wild: a plain number of seconds, and the provider-specific
-     * one that Groq and others send with a fractional part. Rounded up, because coming back
-     * fractionally early only earns a second refusal.
+     * <p>Retry-After is the standard header and the provider's own answer, so it wins outright.
+     * Failing that, the two rate-limit budgets reset independently: an officer who has run out
+     * of requests is still refused when the token budget resets, so the longer of the two is
+     * the honest number rather than whichever header is read first.
+     *
+     * <p>Rounded up, because coming back fractionally early only earns a second refusal.
      */
     private static int retryAfterSeconds(HttpResponse<?> response) {
-        for (String header : new String[] { "retry-after", "x-ratelimit-reset-tokens",
-            "x-ratelimit-reset-requests" }) {
-            String value = response.headers().firstValue(header).orElse(null);
-            if (value == null || value.isBlank()) {
-                continue;
-            }
-            try {
-                double seconds = value.endsWith("ms")
-                        ? Double.parseDouble(value.substring(0, value.length() - 2)) / 1000
-                        : Double.parseDouble(value.endsWith("s")
-                                ? value.substring(0, value.length() - 1)
-                                : value);
-                if (seconds > 0) {
-                    return (int) Math.ceil(seconds);
-                }
-            } catch (NumberFormatException e) {
-                // A shape we do not know. Better to say nothing than to invent a number.
-            }
+        return retryAfterSeconds(response.headers());
+    }
+
+    static int retryAfterSeconds(HttpHeaders headers) {
+        double stated = headers.firstValue("retry-after")
+                .map(OpenAiCompatibleLlmClient::parseRetryAfter)
+                .orElse(0d);
+        if (stated > 0) {
+            return (int) Math.ceil(stated);
         }
-        return 0;
+
+        double longest = 0;
+        for (String header : new String[] { "x-ratelimit-reset-tokens", "x-ratelimit-reset-requests" }) {
+            longest = Math.max(longest, headers.firstValue(header)
+                    .map(OpenAiCompatibleLlmClient::parseDuration)
+                    .orElse(0d));
+        }
+        return (int) Math.ceil(longest);
+    }
+
+    /** Retry-After carries either a duration or, per RFC 7231, the date it may be retried. */
+    static double parseRetryAfter(String value) {
+        double duration = parseDuration(value);
+        if (duration > 0) {
+            return duration;
+        }
+        try {
+            long seconds = Duration.between(Instant.now(),
+                    ZonedDateTime.parse(value.trim(), DateTimeFormatter.RFC_1123_DATE_TIME).toInstant()).toSeconds();
+            return credible(seconds);
+        } catch (DateTimeParseException e) {
+            return 0; // A shape we do not know. Better to say nothing than to invent a number.
+        }
+    }
+
+    /**
+     * A duration in seconds, or zero for anything this does not recognise.
+     *
+     * <p>Compound spellings are the point: Groq sends {@code 2m59.56s} on its reset headers, and
+     * reading only the trailing unit would have called that fifty-nine seconds.
+     */
+    static double parseDuration(String value) {
+        String text = value == null ? "" : value.trim().toLowerCase(Locale.ROOT);
+        if (text.isEmpty()) {
+            return 0;
+        }
+        Matcher matcher = DURATION_PART.matcher(text);
+        double seconds = 0;
+        int consumed = 0;
+        while (matcher.find() && matcher.start() == consumed) {
+            double amount = Double.parseDouble(matcher.group(1));
+            String unit = matcher.group(2);
+            seconds += amount * switch (unit == null ? "" : unit) {
+                case "ms" -> 0.001;
+                case "m" -> 60;
+                case "h" -> 3600;
+                default -> 1;
+            };
+            consumed = matcher.end();
+        }
+        // Partly understood is not understood: "5 minutes" must not be read as five seconds.
+        return consumed == text.length() ? credible(seconds) : 0;
+    }
+
+    private static double credible(double seconds) {
+        return seconds > 0 && seconds <= LONGEST_CREDIBLE_WAIT_SECONDS ? seconds : 0;
     }
 
     private static final class PartialToolCall {

--- a/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
@@ -70,21 +70,34 @@ public final class FineractRestToolExecutor implements ToolExecutor {
 
     private final HttpClient http;
     private final ObjectMapper mapper = new ObjectMapper();
-    /** What the manifest is written against, and what a bare Fineract actually serves. */
-    private static final String MANIFEST_API_PATH = "/fineract-provider/api/v1";
+    /** Where a Fineract with nothing in front of it serves its API. */
+    public static final String DEFAULT_API_PATH = "/fineract-provider/api/v1";
 
     private final String fineractBaseUrl;
     private final String apiPath;
 
+    /**
+     * An executor against a Fineract deployed the ordinary way.
+     *
+     * @param fineractBaseUrl scheme and host, with or without a trailing slash
+     */
     public FineractRestToolExecutor(String fineractBaseUrl) {
-        this(fineractBaseUrl, MANIFEST_API_PATH);
+        this(fineractBaseUrl, DEFAULT_API_PATH);
     }
 
+    /**
+     * An executor against a Fineract that something may sit in front of.
+     *
+     * @param fineractBaseUrl scheme and host, with or without a trailing slash
+     * @param apiPath         the API root the manifest's resource paths hang off:
+     *                        {@code /fineract-provider/api/v1} for a bare server, or something
+     *                        like {@code /1.0/core/api/v1} behind an API manager. Written
+     *                        either way round, a missing leading slash is added and a trailing
+     *                        one removed. Null or blank means the default.
+     */
     public FineractRestToolExecutor(String fineractBaseUrl, String apiPath) {
         this.fineractBaseUrl = fineractBaseUrl.replaceAll("/+$", "");
-        this.apiPath = apiPath == null || apiPath.isBlank()
-                ? MANIFEST_API_PATH
-                : apiPath.replaceAll("/+$", "");
+        this.apiPath = normalizeApiPath(apiPath);
         this.http = HttpClient.newBuilder()
                 // Generous: sandbox/gateway-fronted Fineracts can be slow to accept connections,
                 // and JVMs on dual-stack hosts may burn seconds on IPv6 before falling back.
@@ -94,19 +107,33 @@ public final class FineractRestToolExecutor implements ToolExecutor {
     }
 
     /**
-     * The full URL for a manifest path, under whatever prefix this deployment serves.
+     * An API root written any of the ways somebody might reasonably write it.
      *
-     * <p>The manifest is written against a bare Fineract, which answers at
-     * {@code /fineract-provider/api/v1}. Behind an API manager the same server answers
-     * somewhere else: the Mifos community sandbox publishes it at {@code /1.0/core/api/v1},
-     * and the web app is told so separately as FINERACT_API_PROVIDER. The gateway had no
-     * business assuming the bare layout, so the prefix is swapped here rather than written
-     * eighteen times into the YAML.
+     * <p>Accepting a single spelling would mean a deployment fails over a missing slash, and
+     * fails as a run of 404s rather than as anything that names the cause.
      */
-    private String url(String manifestPath) {
-        return fineractBaseUrl + (manifestPath.startsWith(MANIFEST_API_PATH)
-                ? apiPath + manifestPath.substring(MANIFEST_API_PATH.length())
-                : manifestPath);
+    public static String normalizeApiPath(String apiPath) {
+        if (apiPath == null || apiPath.isBlank()) {
+            return DEFAULT_API_PATH;
+        }
+        String trimmed = apiPath.trim().replaceAll("/+$", "");
+        if (trimmed.isEmpty()) {
+            return ""; // Served at the root; the resource paths are absolute already.
+        }
+        return trimmed.startsWith("/") ? trimmed : "/" + trimmed;
+    }
+
+    /**
+     * The full URL for a resource the manifest names.
+     *
+     * <p>The manifest says {@code /clients}, because that is the resource and it is the same
+     * everywhere. Where {@code /clients} actually lives belongs to the installation: a bare
+     * Fineract puts it under {@code /fineract-provider/api/v1} and one behind an API manager
+     * does not. Keeping those apart is why nothing here has to recognise a prefix in order to
+     * replace it, and why a path this code has never seen still lands in the right place.
+     */
+    private String url(String resourcePath) {
+        return fineractBaseUrl + apiPath + resourcePath;
     }
 
     @Override
@@ -360,7 +387,7 @@ public final class FineractRestToolExecutor implements ToolExecutor {
                     .put("username", decoded.substring(0, split))
                     .put("password", decoded.substring(split + 1));
             HttpResponse<String> response = http.send(
-                    HttpRequest.newBuilder(URI.create(url(MANIFEST_API_PATH + "/authentication")))
+                    HttpRequest.newBuilder(URI.create(url("/authentication")))
                             .timeout(Duration.ofSeconds(15))
                             .header("Content-Type", "application/json")
                             .header("Accept", "application/json")
@@ -393,7 +420,7 @@ public final class FineractRestToolExecutor implements ToolExecutor {
     private java.util.Optional<java.util.Set<String>> readOffices(CallContext context) {
         try {
             HttpResponse<String> response = http.send(
-                    HttpRequest.newBuilder(URI.create(url(MANIFEST_API_PATH + "/offices")))
+                    HttpRequest.newBuilder(URI.create(url("/offices")))
                             .timeout(Duration.ofSeconds(15))
                             .header("Accept", "application/json")
                             .header("Authorization", context.authorizationHeader())
@@ -801,7 +828,7 @@ public final class FineractRestToolExecutor implements ToolExecutor {
     private String fetchBusinessDate(CallContext context) {
         try {
             HttpRequest request = HttpRequest
-                    .newBuilder(URI.create(url(MANIFEST_API_PATH + "/businessdate/BUSINESS_DATE")))
+                    .newBuilder(URI.create(url("/businessdate/BUSINESS_DATE")))
                     .timeout(Duration.ofSeconds(10))
                     .header("Accept", "application/json")
                     .header("Authorization", context.authorizationHeader())

--- a/gateway/src/main/java/org/mifos/community/copilot/gateway/config/GatewayProperties.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/gateway/config/GatewayProperties.java
@@ -31,11 +31,11 @@ public record GatewayProperties(Llm llm, Fineract fineract, Cors cors, Approval 
      */
     public record Fineract(String baseUrl, String apiPath) {
 
+        /** Through the executor's own rule, so the two boundaries cannot disagree. */
         public Fineract {
-            apiPath = apiPath == null || apiPath.isBlank() ? DEFAULT_API_PATH : apiPath.replaceAll("/+$", "");
+            apiPath = org.mifos.community.copilot.core.tools.FineractRestToolExecutor
+                    .normalizeApiPath(apiPath);
         }
-
-        public static final String DEFAULT_API_PATH = "/fineract-provider/api/v1";
     }
 
     public record Cors(List<String> allowedOrigins) {}

--- a/gateway/src/main/resources/tools.yaml
+++ b/gateway/src/main/resources/tools.yaml
@@ -14,6 +14,11 @@
 #
 # `redactFields` are masked before results can reach a cloud model.
 #
+# A tool's `path` names a resource and nothing else. Where that resource lives is a
+# property of the installation rather than of the tool: a bare Fineract serves them
+# under /fineract-provider/api/v1, and one behind an API manager does not. That root
+# is configuration (FINERACT_API_PATH) and is deliberately absent from this file.
+#
 # Two things a body may read besides the officer's own arguments:
 # `pattern`, `min` and `max` are copied from the validators the Mifos X web app already
 # applies to the same field, and `mustBe` finishes the sentence "First name must ...". They
@@ -29,16 +34,21 @@
 tools:
   # ── Reading ──────────────────────────────────────────────────────────────────
   - name: mifos_client_search
-    description: Search for clients by name, account number or external id.
+    description: Find clients by name. Matches part of a name and ignores capitalisation.
     write: false
-    # A search returns whole matched entities. The name has to survive for the result to be
-    # any use to the officer; the external id is a national id and does not.
-    redactFields: [entityExternalId, externalId, entityMobileNo, mobileNo]
+    # This used /search, which is case-sensitive: "VICTOR" found the client and "victor" found
+    # nothing, so an officer typing normally was told their client did not exist. The clients
+    # endpoint's own name filter is case-insensitive and matches on part of a name, which is
+    # what somebody asking after a person actually wants.
+    #
+    # A search returns whole matched clients. The name has to survive for the result to be any
+    # use to the officer; the phone number and the national id do not.
+    redactFields: [externalId, mobileNo]
     params:
-      - { name: query, type: string, required: true, label: Search, description: Name or account number to search for }
+      - { name: query, type: string, required: true, label: Search, description: A name, or any part of one }
     rest:
       method: GET
-      path: /fineract-provider/api/v1/search?query={query}&resource=clients
+      path: /clients?name={query}
 
   - name: mifos_client_details
     description: Fetch one client's profile, including status, office and activation date.
@@ -47,7 +57,7 @@ tools:
       - { name: clientId, type: integer, required: true, label: Client, description: The client's system id }
     rest:
       method: GET
-      path: /fineract-provider/api/v1/clients/{clientId}
+      path: /clients/{clientId}
     redactFields: [mobileNo, dateOfBirth, externalId]
 
   - name: mifos_client_accounts
@@ -57,7 +67,7 @@ tools:
       - { name: clientId, type: integer, required: true, label: Client, description: The client's system id }
     rest:
       method: GET
-      path: /fineract-provider/api/v1/clients/{clientId}/accounts
+      path: /clients/{clientId}/accounts
 
   - name: mifos_loan_details
     description: Fetch one loan account, including product, principal, outstanding balance and status.
@@ -66,7 +76,7 @@ tools:
       - { name: loanId, type: integer, required: true, label: Loan account, description: The loan's system id }
     rest:
       method: GET
-      path: /fineract-provider/api/v1/loans/{loanId}
+      path: /loans/{loanId}
 
   - name: mifos_loan_schedule
     description: Fetch a loan's repayment schedule with due dates and outstanding instalments.
@@ -75,7 +85,7 @@ tools:
       - { name: loanId, type: integer, required: true, label: Loan account, description: The loan's system id }
     rest:
       method: GET
-      path: /fineract-provider/api/v1/loans/{loanId}?associations=repaymentSchedule
+      path: /loans/{loanId}?associations=repaymentSchedule
 
   - name: mifos_savings_details
     description: Fetch one savings account, including balance, status and product.
@@ -84,7 +94,7 @@ tools:
       - { name: accountId, type: integer, required: true, label: Savings account, description: The savings account's system id }
     rest:
       method: GET
-      path: /fineract-provider/api/v1/savingsaccounts/{accountId}
+      path: /savingsaccounts/{accountId}
 
   - name: mifos_loan_products
     description: List the loan products this office offers. Use this before creating a loan.
@@ -92,7 +102,7 @@ tools:
     params: []
     rest:
       method: GET
-      path: /fineract-provider/api/v1/loanproducts
+      path: /loanproducts
 
   # ── Writing, every one pauses for the officer ────────────────────────────────
   - name: mifos_client_create
@@ -115,7 +125,7 @@ tools:
       - { name: officeId, type: integer, required: false, label: Office, description: "Only needed when the officer works in more than one office" }
     rest:
       method: POST
-      path: /fineract-provider/api/v1/clients
+      path: /clients
       # officeId is established from the officer's own credential, never sent by the browser
       # and never invented by the model. It was a literal 1, which put every client created
       # through the Copilot into head office whatever branch the officer worked in.
@@ -143,12 +153,12 @@ tools:
       # rewrites every instalment on the schedule Fineract derives from it.
       - { name: expectedDisbursementDate, type: string, required: true, label: Expected disbursement, format: date, futureAllowed: true, description: "Date as yyyy-MM-dd, or today" }
     enrich:
-      - path: /fineract-provider/api/v1/clients/{clientId}
+      - path: /clients/{clientId}
         fields:
           Client: displayName
           Client account: accountNo
           Office: officeName
-      - path: /fineract-provider/api/v1/loanproducts/{productId}
+      - path: /loanproducts/{productId}
         currency: currency.code
         fields:
           Product: name
@@ -157,7 +167,7 @@ tools:
     # here as literals: every loan carried 12 percent and a monthly schedule whatever the
     # product said, which for a weekly microfinance product is simply the wrong loan.
     defaults:
-      path: /fineract-provider/api/v1/loanproducts/{productId}
+      path: /loanproducts/{productId}
       fields:
         interestRatePerPeriod: interestRatePerPeriod
         numberOfRepayments: numberOfRepayments
@@ -174,7 +184,7 @@ tools:
       loanTermFrequency: numberOfRepayments * repaymentEvery
     rest:
       method: POST
-      path: /fineract-provider/api/v1/loans
+      path: /loans
       body: '{"clientId":"${clientId}","productId":"${productId}","principal":"${principal}","loanTermFrequency":"${loanTermFrequency}","loanTermFrequencyType":"${loanTermFrequencyType}","numberOfRepayments":"${numberOfRepayments}","repaymentEvery":"${repaymentEvery}","repaymentFrequencyType":"${repaymentFrequencyType}","interestRatePerPeriod":"${interestRatePerPeriod}","amortizationType":"${amortizationType}","interestType":"${interestType}","interestCalculationPeriodType":"${interestCalculationPeriodType}","transactionProcessingStrategyCode":"${transactionProcessingStrategyCode}","expectedDisbursementDate":"${expectedDisbursementDate}","submittedOnDate":"${submittedOnDate}","loanType":"individual","locale":"en","dateFormat":"dd MMMM yyyy"}'
 
   - name: mifos_loan_approve
@@ -186,7 +196,7 @@ tools:
       - { name: approvedOnDate, type: string, required: true, label: Approval date, format: date, description: "Date as yyyy-MM-dd, or today" }
       - { name: approvedLoanAmount, type: number, required: false, label: Approved amount, format: money, pattern: '^\d{1,13}(\.\d{1,6})?$', mustBe: 'be an amount, and not a negative one', description: Approved principal if different from the amount applied for }
     enrich:
-      - path: /fineract-provider/api/v1/loans/{loanId}
+      - path: /loans/{loanId}
         currency: currency.code
         fields:
           Client: clientName
@@ -195,7 +205,7 @@ tools:
           Applied for: "#money:principal"
     rest:
       method: POST
-      path: /fineract-provider/api/v1/loans/{loanId}?command=approve
+      path: /loans/{loanId}?command=approve
       body: '{"approvedOnDate":"${approvedOnDate}","approvedLoanAmount":"${approvedLoanAmount}","locale":"en","dateFormat":"dd MMMM yyyy"}'
 
   - name: mifos_loan_disburse
@@ -207,7 +217,7 @@ tools:
       - { name: actualDisbursementDate, type: string, required: true, label: Disbursement date, format: date, description: "Date as yyyy-MM-dd, or today" }
       - { name: transactionAmount, type: number, required: false, label: Amount, format: money, pattern: '^\d{1,13}(\.\d{1,6})?$', mustBe: 'be an amount, and not a negative one', description: Amount to disburse if different from the approved principal }
     enrich:
-      - path: /fineract-provider/api/v1/loans/{loanId}
+      - path: /loans/{loanId}
         currency: currency.code
         fields:
           Client: clientName
@@ -216,7 +226,7 @@ tools:
           Approved amount: "#money:approvedPrincipal"
     rest:
       method: POST
-      path: /fineract-provider/api/v1/loans/{loanId}?command=disburse
+      path: /loans/{loanId}?command=disburse
       body: '{"actualDisbursementDate":"${actualDisbursementDate}","transactionAmount":"${transactionAmount}","locale":"en","dateFormat":"dd MMMM yyyy"}'
 
   - name: mifos_loan_repayment
@@ -229,7 +239,7 @@ tools:
       - { name: transactionAmount, type: number, required: true, label: Repayment amount, format: money, pattern: '^\d{1,13}(\.\d{1,6})?$', min: '0.001', mustBe: 'be an amount, and not a negative one' }
       - { name: transactionDate, type: string, required: true, label: Transaction date, format: date, description: "Date as yyyy-MM-dd, or today" }
     enrich:
-      - path: /fineract-provider/api/v1/loans/{loanId}
+      - path: /loans/{loanId}
         currency: currency.code
         fields:
           Client: clientName
@@ -238,5 +248,5 @@ tools:
           Outstanding: "#money:summary.principalOutstanding"
     rest:
       method: POST
-      path: /fineract-provider/api/v1/loans/{loanId}/transactions?command=repayment
+      path: /loans/{loanId}/transactions?command=repayment
       body: '{"transactionDate":"${transactionDate}","transactionAmount":"${transactionAmount}","locale":"en","dateFormat":"dd MMMM yyyy"}'

--- a/gateway/src/test/java/org/mifos/community/copilot/core/llm/RetryAfterHeaderTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/llm/RetryAfterHeaderTest.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at
+ * http://mozilla.org/MPL/2.0/.
+ */
+package org.mifos.community.copilot.core.llm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.http.HttpHeaders;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Reading the wait a provider asked for.
+ *
+ * <p>The number goes straight in front of an officer as "try again in N seconds", so it is
+ * worth more than the average parser. Getting it wrong in either direction costs something:
+ * too low and they come back to a second refusal, too high and they give up on a service that
+ * was about to work.
+ */
+class RetryAfterHeaderTest {
+
+    private static HttpHeaders headers(String... pairs) {
+        java.util.Map<String, List<String>> map = new java.util.LinkedHashMap<>();
+        for (int i = 0; i < pairs.length; i += 2) {
+            map.put(pairs[i], List.of(pairs[i + 1]));
+        }
+        return HttpHeaders.of(map, (name, value) -> true);
+    }
+
+    @Test
+    void aPlainNumberOfSecondsIsAWait() {
+        assertThat(OpenAiCompatibleLlmClient.parseDuration("30")).isEqualTo(30);
+        assertThat(OpenAiCompatibleLlmClient.parseDuration("7s")).isEqualTo(7);
+    }
+
+    /** What Groq actually sends. Reading only the trailing unit called this fifty-nine seconds. */
+    @Test
+    void aCompoundDurationIsReadWhole() {
+        assertThat(OpenAiCompatibleLlmClient.parseDuration("2m59.56s")).isEqualTo(179.56);
+        assertThat(OpenAiCompatibleLlmClient.parseDuration("1h2m3s")).isEqualTo(3723);
+        assertThat(OpenAiCompatibleLlmClient.parseDuration("1m")).isEqualTo(60);
+    }
+
+    @Test
+    void millisecondsAreNotMinutes() {
+        assertThat(OpenAiCompatibleLlmClient.parseDuration("1500ms")).isEqualTo(1.5);
+    }
+
+    /** Partly understood is not understood. Five minutes must never be read as five seconds. */
+    @Test
+    void aShapeItCannotReadIsNotGuessedAt() {
+        assertThat(OpenAiCompatibleLlmClient.parseDuration("5 minutes")).isZero();
+        assertThat(OpenAiCompatibleLlmClient.parseDuration("soon")).isZero();
+        assertThat(OpenAiCompatibleLlmClient.parseDuration("")).isZero();
+        assertThat(OpenAiCompatibleLlmClient.parseDuration(null)).isZero();
+    }
+
+    /**
+     * An epoch timestamp on a reset header is a real provider habit. Read as seconds it is a
+     * number in the billions, and "try again in fifty years" is worse than saying nothing.
+     */
+    @Test
+    void aNumberTooLargeToBeAWaitIsIgnored() {
+        assertThat(OpenAiCompatibleLlmClient.parseDuration("1787588655")).isZero();
+        assertThat(OpenAiCompatibleLlmClient.parseDuration("86401")).isZero();
+        // A daily token budget is the slowest thing that legitimately resets.
+        assertThat(OpenAiCompatibleLlmClient.parseDuration("86400")).isEqualTo(86_400);
+    }
+
+    /** RFC 7231 allows Retry-After to carry the date it may be retried, and proxies use it. */
+    @Test
+    void retryAfterAcceptsADate() {
+        String when = DateTimeFormatter.RFC_1123_DATE_TIME
+                .format(ZonedDateTime.ofInstant(Instant.now().plusSeconds(45), ZoneOffset.UTC));
+
+        assertThat(OpenAiCompatibleLlmClient.parseRetryAfter(when)).isBetween(40d, 46d);
+    }
+
+    @Test
+    void aDateAlreadyPastIsNoWaitAtAll() {
+        String when = DateTimeFormatter.RFC_1123_DATE_TIME
+                .format(ZonedDateTime.ofInstant(Instant.now().minusSeconds(600), ZoneOffset.UTC));
+
+        assertThat(OpenAiCompatibleLlmClient.parseRetryAfter(when)).isZero();
+    }
+
+    @Test
+    void retryAfterIsTheProvidersOwnAnswerAndWins() {
+        HttpHeaders headers = headers("retry-after", "12", "x-ratelimit-reset-tokens", "5m");
+
+        assertThat(OpenAiCompatibleLlmClient.retryAfterSeconds(headers)).isEqualTo(12);
+    }
+
+    /**
+     * Tokens and requests are separate budgets. An officer out of requests is still refused
+     * when the token budget resets, so the shorter of the two would send them back too early.
+     */
+    @Test
+    void withoutRetryAfterTheLongerBudgetDecides() {
+        assertThat(OpenAiCompatibleLlmClient.retryAfterSeconds(
+                headers("x-ratelimit-reset-tokens", "3s", "x-ratelimit-reset-requests", "2m30s"))).isEqualTo(150);
+
+        assertThat(OpenAiCompatibleLlmClient.retryAfterSeconds(
+                headers("x-ratelimit-reset-tokens", "2m30s", "x-ratelimit-reset-requests", "3s"))).isEqualTo(150);
+    }
+
+    @Test
+    void anUnreadableRetryAfterFallsBackToTheResetHeaders() {
+        HttpHeaders headers = headers("retry-after", "shortly", "x-ratelimit-reset-requests", "8s");
+
+        assertThat(OpenAiCompatibleLlmClient.retryAfterSeconds(headers)).isEqualTo(8);
+    }
+
+    @Test
+    void aProviderThatSaidNothingLeavesItAtZero() {
+        assertThat(OpenAiCompatibleLlmClient.retryAfterSeconds(HttpHeaders.of(Map.of(), (n, v) -> true))).isZero();
+    }
+
+    /** Coming back fractionally early only earns a second refusal. */
+    @Test
+    void aFractionalWaitIsRoundedUp() {
+        assertThat(OpenAiCompatibleLlmClient.retryAfterSeconds(headers("retry-after", "6.2s"))).isEqualTo(7);
+    }
+}

--- a/gateway/src/test/java/org/mifos/community/copilot/core/llm/RetryAfterTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/llm/RetryAfterTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at
+ * http://mozilla.org/MPL/2.0/.
+ */
+package org.mifos.community.copilot.core.llm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Telling an officer they are being throttled, rather than that the model is broken.
+ *
+ * <p>Both used to produce the same sentence. A wait the officer had caused themselves by
+ * asking two questions in quick succession read as the service being down, which is a poor
+ * trade: they either give up on something that would have worked in twenty seconds, or they
+ * keep pressing and make it worse. A number turns it from something to stare at into
+ * something to wait out.
+ */
+class RetryAfterTest {
+
+    @Test
+    void aThrottledCallCarriesHowLongToWait() {
+        LlmException throttled = new LlmException("rate limit", null, true, false, 23);
+
+        assertThat(throttled.isRateLimited()).isTrue();
+        assertThat(throttled.isClientError()).isFalse();
+        assertThat(throttled.retryAfterSeconds()).isEqualTo(23);
+    }
+
+    @Test
+    void aProviderThatDidNotSayLeavesItAtZero() {
+        assertThat(new LlmException("rate limit", null, true).retryAfterSeconds()).isZero();
+    }
+
+    /** A refusal is a settled fact, so there is nothing to wait for. */
+    @Test
+    void aRefusalIsNeitherThrottledNorWorthRetrying() {
+        LlmException refused = new LlmException("bad key", null, false, true);
+
+        assertThat(refused.isClientError()).isTrue();
+        assertThat(refused.isRateLimited()).isFalse();
+        assertThat(refused.retryAfterSeconds()).isZero();
+    }
+}

--- a/gateway/src/test/java/org/mifos/community/copilot/core/tools/EnrichmentTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/tools/EnrichmentTest.java
@@ -80,7 +80,9 @@ class EnrichmentTest {
     }
 
     private void respond(HttpExchange exchange) throws IOException {
-        String path = exchange.getRequestURI().getPath();
+        // Below the API root, so a test names /loans/12 the way the manifest names it.
+        String path = exchange.getRequestURI().getPath()
+                .replace(FineractRestToolExecutor.DEFAULT_API_PATH, "");
         requestedPaths.add(path);
         Integer override = statusOverrides.get(path);
         String body = path.contains("loanproducts") ? PRODUCT_JSON : path.contains("clients") ? CLIENT_JSON : LOAN_JSON;

--- a/gateway/src/test/java/org/mifos/community/copilot/core/tools/OfficeDerivationTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/tools/OfficeDerivationTest.java
@@ -99,7 +99,7 @@ class OfficeDerivationTest {
                         true, false),
                         new ToolDefinition.Param("officeId", "integer", false, "office", "Office", null, false,
                                 false)),
-                new ToolDefinition.RestMapping("POST", "/fineract-provider/api/v1/clients",
+                new ToolDefinition.RestMapping("POST", "/clients",
                         "{\"officeId\":\"${officeId}\",\"firstname\":\"${firstname}\"}"),
                 List.of(), List.of(), null, Map.of());
     }

--- a/gateway/src/test/java/org/mifos/community/copilot/core/tools/RedactionPostureTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/tools/RedactionPostureTest.java
@@ -45,7 +45,9 @@ class RedactionPostureTest {
     private static Map<String, List<String>> expected() {
         Map<String, List<String>> posture = new LinkedHashMap<>();
         // Reads that carry a person.
-        posture.put("mifos_client_search", List.of("entityExternalId", "externalId", "entityMobileNo", "mobileNo"));
+        // Plain field names now: this reads /clients rather than /search, and /search was the
+        // thing that wrapped everything in entityXxx.
+        posture.put("mifos_client_search", List.of("externalId", "mobileNo"));
         posture.put("mifos_client_details", List.of("mobileNo", "dateOfBirth", "externalId"));
         // Writes that echo what was submitted when Fineract rejects them.
         posture.put("mifos_client_create", List.of("mobileNo", "dateOfBirth", "externalId"));


### PR DESCRIPTION
Two things an officer hits within the first minute of using the Copilot, both reported from live use.

## Searching for a client by name found nothing

`mifos_client_search` went to `/search`, which matches **case-sensitively**. That is worse than "type it in capitals": it wants the exact casing the name was stored in. Against a client saved as `Aisha Bello`, both `aisha` and `AISHA` return nothing, and so does `bello`.

So an officer typing a name the way anyone types a name is told the person does not exist, and the assistant then apologises for a client sitting in the database. Nothing about that reads as a search problem, which makes it the worst kind: it looks like missing data.

`/clients?name=` has its own filter, and that one is case-insensitive and matches on part of a name, which is what somebody asking after a person actually wants.

| typed | `/search` | `/clients?name=` |
|---|---|---|
| `Aisha Bello` | found | found |
| `aisha` | **not found** | found |
| `AISHA` | **not found** | found |
| `bello` | **not found** | found |
| `ais` | **not found** | found |

Verified end to end through the real model against the community sandbox, 3/3.

## Being throttled looked like the service being down

Asking two questions in quick succession spends the model's per-minute budget. The reply was:

> The AI model is unavailable right now. Please try again shortly.

Nothing was unavailable. The suggestion chips make this **more** likely rather than less, because they invite the second question immediately.

Being throttled and being down produced the same sentence, so a wait the officer had caused themselves read as the service being broken. They either give up on something that would have worked in twenty seconds, or keep pressing and make it worse.

The provider says how long to wait, in a `Retry-After` header or in its own reset header, and that was being thrown away. It now reads it:

```json
{ "code": "RATE_LIMITED", "message": "That was a lot of questions at once. Try again in 7 seconds.", "retryable": true }
```

That is something a person can act on. The code is `RATE_LIMITED` rather than `LLM_UNAVAILABLE`, so the panel can tell the two apart as well, which is what lets it offer the question back instead of asking for it to be retyped.

Verified by firing turns back to back against the real provider until it refused.

## Notes for review

- `tools.yaml` is the authority on which endpoint each tool uses, so the search change is one line of manifest plus the tests that pin it. No new tool, no change to the default-deny posture.
- `RATE_LIMITED` is a code the wire contract already carried; this is the first thing to emit it.
- The wait is only ever taken from what the provider states. Nothing guesses a number.

## Testing

- 123 gateway tests pass, including a new `RetryAfterTest` covering the throttled, refused and silent-provider cases.
- `RedactionPostureTest` still pins what every tool masks, so the manifest change cannot quietly drop a mask.
- Rebased on current `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messages for client errors, rate limits, and service unavailability.
  - Rate-limit responses now show the provider’s estimated retry time when available.
  - Improved compatibility with installations using customized API paths.

- **Updates**
  - Client searches now support case-insensitive partial-name matching.
  - Updated endpoint handling and data redaction for client, loan, office, and business-date operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->