### PR TITLE
fix(gateway): client search returns every client in the office

### DIFF
--- a/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
@@ -674,22 +674,82 @@ public final class FineractRestToolExecutor implements ToolExecutor {
     }
 
     /**
+     * Whether the typing already says where the capitals belong.
+     *
+     * <p>True for anything with a capital that is not starting a word, which is the shape of a
+     * name somebody has spelled deliberately. All lower case and all upper case both say
+     * nothing, and are the two ways a name gets typed when nobody is thinking about it.
+     */
+    private static boolean carriesItsOwnCasing(String typed) {
+        // SHOUTED is not deliberate, it is a caps-lock key. Without this, every capital after
+        // the first letter reads as meaningful and AISHA would be sent through untouched.
+        boolean anyLowerCase = false;
+        for (int i = 0; i < typed.length(); i++) {
+            if (Character.isLowerCase(typed.charAt(i))) {
+                anyLowerCase = true;
+                break;
+            }
+        }
+        if (!anyLowerCase) {
+            return false;
+        }
+
+        boolean startOfWord = true;
+        boolean wordBeganCapitalised = false;
+        boolean afterALowerCaseWord = false;
+        for (int i = 0; i < typed.length(); i++) {
+            char c = typed.charAt(i);
+            if (!Character.isLetter(c)) {
+                startOfWord = true;
+                continue;
+            }
+            if (Character.isUpperCase(c)) {
+                // A capital inside a word is only meaningful when the word opened with one.
+                // McDonald and MacLeod look like this; aIsHa is a key held down, and reading
+                // that as a spelling would leave the officer searching for nobody.
+                if (!startOfWord && wordBeganCapitalised) {
+                    return true;
+                }
+                if (startOfWord && afterALowerCaseWord) {
+                    return true; // A capitalised word following a lower-case one: de la Cruz.
+                }
+            } else if (startOfWord) {
+                afterALowerCaseWord = true;
+            }
+            if (startOfWord) {
+                wordBeganCapitalised = Character.isUpperCase(c);
+            }
+            startOfWord = false;
+        }
+        return false;
+    }
+
+    /**
      * A name in the casing Fineract stores names in, so a filter that is case-sensitive
      * still finds the person.
      *
-     * <p>An officer types aisha, AISHA or aIsHa and means the same woman. The clients
-     * resource matches displayName literally, so on a case-sensitive collation every one of
-     * those returns nothing and the assistant reports that a client sitting in the database
-     * does not exist. Each word is capitalised the way a name is entered on the form that
-     * created it.
+     * <p>An officer types aisha, AISHA or aIsHa and means the same woman. The clients resource
+     * matches displayName literally, so on a case-sensitive collation every one of those
+     * returns nothing and the assistant reports that a client sitting in the database does not
+     * exist. Where the typing carries no information about where the capitals go, each word is
+     * capitalised the way a name is entered on the form that created it.
      *
-     * <p>This is a normalisation, not a correction: a name genuinely stored against unusual
-     * casing is still found by typing it that way, because a word already in that shape is
-     * returned unchanged.
+     * <p>Where it does carry that information, it is left alone. McDonald, de la Cruz and
+     * O'Connor all have capitals somewhere a general rule would not put them, and rewriting
+     * them to Mcdonald, De La Cruz and O'connor finds nobody at all. Somebody who typed a
+     * capital in the middle of a word has said something, and this is not the place to
+     * overrule them.
+     *
+     * <p>The case it cannot help with is a name like mcdonald typed all in one case: there is
+     * no way to know the D is a capital, and finding it needs a case-insensitive collation on
+     * the Fineract side.
      */
     static String asStoredName(String typed) { // package-private for tests
         if (typed == null || typed.isBlank()) {
             return typed == null ? "" : typed;
+        }
+        if (carriesItsOwnCasing(typed)) {
+            return typed;
         }
         StringBuilder out = new StringBuilder(typed.length());
         boolean startOfWord = true;

--- a/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/tools/FineractRestToolExecutor.java
@@ -653,9 +653,58 @@ public final class FineractRestToolExecutor implements ToolExecutor {
                 out.put(entry.getKey(), value);
                 continue;
             }
+            if (isNameParam(tool, entry.getKey())) {
+                out.put(entry.getKey(), asStoredName(String.valueOf(value)));
+                continue;
+            }
             out.put(entry.getKey(), normalizeValue(entry.getKey(), value, today, futureAllowed(tool, entry.getKey())));
         }
         return out;
+    }
+
+    private boolean isNameParam(ToolDefinition tool, String param) {
+        if (tool == null || tool.params() == null) {
+            return false;
+        }
+        return tool.params().stream()
+                .filter((p) -> p.name().equals(param))
+                .findFirst()
+                .map(ToolDefinition.Param::isName)
+                .orElse(false);
+    }
+
+    /**
+     * A name in the casing Fineract stores names in, so a filter that is case-sensitive
+     * still finds the person.
+     *
+     * <p>An officer types aisha, AISHA or aIsHa and means the same woman. The clients
+     * resource matches displayName literally, so on a case-sensitive collation every one of
+     * those returns nothing and the assistant reports that a client sitting in the database
+     * does not exist. Each word is capitalised the way a name is entered on the form that
+     * created it.
+     *
+     * <p>This is a normalisation, not a correction: a name genuinely stored against unusual
+     * casing is still found by typing it that way, because a word already in that shape is
+     * returned unchanged.
+     */
+    static String asStoredName(String typed) { // package-private for tests
+        if (typed == null || typed.isBlank()) {
+            return typed == null ? "" : typed;
+        }
+        StringBuilder out = new StringBuilder(typed.length());
+        boolean startOfWord = true;
+        for (int i = 0; i < typed.length(); i++) {
+            char c = typed.charAt(i);
+            if (Character.isLetter(c)) {
+                out.append(startOfWord ? Character.toUpperCase(c) : Character.toLowerCase(c));
+                startOfWord = false;
+            } else {
+                // Spaces, hyphens and apostrophes all begin a new word in a name.
+                out.append(c);
+                startOfWord = true;
+            }
+        }
+        return out.toString();
     }
 
     private boolean futureAllowed(ToolDefinition tool, String param) {

--- a/gateway/src/main/java/org/mifos/community/copilot/core/tools/ToolDefinition.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/tools/ToolDefinition.java
@@ -71,6 +71,11 @@ public record ToolDefinition(String name, String description, boolean write, Str
             return "money".equalsIgnoreCase(format);
         }
 
+        /** A person's name, which Fineract stores and matches in its own casing. */
+        public boolean isName() {
+            return "name".equalsIgnoreCase(format);
+        }
+
         public boolean isDate() {
             return "date".equalsIgnoreCase(format);
         }

--- a/gateway/src/main/resources/tools.yaml
+++ b/gateway/src/main/resources/tools.yaml
@@ -42,7 +42,10 @@ tools:
     # displayName is the filter the clients resource actually binds, and it matches on part
     # of a name. There is no bound filter called name: passing one is silently dropped and
     # every client in the office comes back, which is worse than the problem being fixed.
-    # The casing is handled on our side, by format: name below.
+    # The casing is handled on our side, by format: name below: a name typed in one case is
+    # capitalised, and a name typed with capitals inside it is left exactly as written, since
+    # McDonald and de la Cruz do not survive a general rule. A name whose internal capitals
+    # are typed flat still needs a case-insensitive collation on the Fineract side.
     #
     # A search returns whole matched clients. The name has to survive for the result to be any
     # use to the officer; the phone number and the national id do not.

--- a/gateway/src/main/resources/tools.yaml
+++ b/gateway/src/main/resources/tools.yaml
@@ -34,21 +34,25 @@
 tools:
   # ── Reading ──────────────────────────────────────────────────────────────────
   - name: mifos_client_search
-    description: Find clients by name. Matches part of a name and ignores capitalisation.
+    description: Find clients by name. Matches part of a name, however it was typed.
     write: false
-    # This used /search, which is case-sensitive: "VICTOR" found the client and "victor" found
-    # nothing, so an officer typing normally was told their client did not exist. The clients
-    # endpoint's own name filter is case-insensitive and matches on part of a name, which is
-    # what somebody asking after a person actually wants.
+    # This used /search, which matches literally: "Victor" found the client and "victor"
+    # found nothing, so an officer typing normally was told their client did not exist.
+    #
+    # displayName is the filter the clients resource actually binds, and it matches on part
+    # of a name. There is no bound filter called name: passing one is silently dropped and
+    # every client in the office comes back, which is worse than the problem being fixed.
+    # The casing is handled on our side, by format: name below.
     #
     # A search returns whole matched clients. The name has to survive for the result to be any
     # use to the officer; the phone number and the national id do not.
     redactFields: [externalId, mobileNo]
     params:
-      - { name: query, type: string, required: true, label: Search, description: A name, or any part of one }
+      - { name: query, type: string, required: true, label: Search, format: name,
+          description: A name, or any part of one }
     rest:
       method: GET
-      path: /clients?name={query}
+      path: /clients?displayName={query}
 
   - name: mifos_client_details
     description: Fetch one client's profile, including status, office and activation date.

--- a/gateway/src/test/java/org/mifos/community/copilot/core/tools/ClientSearchTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/tools/ClientSearchTest.java
@@ -69,6 +69,27 @@ class ClientSearchTest {
         assertThat(FineractRestToolExecutor.asStoredName("MARIA DE SOUZA")).isEqualTo("Maria De Souza");
     }
 
+    /**
+     * Confirmed against a real Fineract: displayName=McDonald finds Ronald McDonald and
+     * displayName=Mcdonald finds nobody. Capitalising every word is the wrong answer for any
+     * name that keeps a capital somewhere a general rule would not put one.
+     */
+    @Test
+    void aNameSpelledDeliberatelyIsLeftAlone() {
+        assertThat(FineractRestToolExecutor.asStoredName("McDonald")).isEqualTo("McDonald");
+        assertThat(FineractRestToolExecutor.asStoredName("O'Connor")).isEqualTo("O'Connor");
+        assertThat(FineractRestToolExecutor.asStoredName("de la Cruz")).isEqualTo("de la Cruz");
+        assertThat(FineractRestToolExecutor.asStoredName("van der Berg")).isEqualTo("van der Berg");
+        assertThat(FineractRestToolExecutor.asStoredName("Ronald McDonald")).isEqualTo("Ronald McDonald");
+    }
+
+    /** Typing it all one way says nothing about the capitals, so there is nothing to preserve. */
+    @Test
+    void aNameTypedFlatIsStillCapitalised() {
+        assertThat(FineractRestToolExecutor.asStoredName("ronald mcdonald")).isEqualTo("Ronald Mcdonald");
+        assertThat(FineractRestToolExecutor.asStoredName("DE LA CRUZ")).isEqualTo("De La Cruz");
+    }
+
     /** Hyphens and apostrophes start a word in a name as surely as a space does. */
     @Test
     void punctuationInsideANameStartsANewWord() {

--- a/gateway/src/test/java/org/mifos/community/copilot/core/tools/ClientSearchTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/tools/ClientSearchTest.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at
+ * http://mozilla.org/MPL/2.0/.
+ */
+package org.mifos.community.copilot.core.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Looking a client up by name.
+ *
+ * <p>This exists because of a bug that a test would have caught and a manual check did not.
+ * Search was moved to a query parameter Fineract does not bind, so the filter was dropped and
+ * every client in the office came back. Checked by hand against a database holding one client,
+ * where "filtered to the one match" and "ignored the filter and returned all one of them" are
+ * the same number, so it read as a pass.
+ *
+ * <p>The lesson is in {@link #theFilterIsOneFineractActuallyBinds()}: pin the parameter name,
+ * because a wrong one fails silently and open.
+ */
+class ClientSearchTest {
+
+    private static final ToolManifest MANIFEST = ToolManifest.load(ClientSearchTest.class.getResourceAsStream("/tools.yaml"));
+
+    private static ToolDefinition searchTool() {
+        return MANIFEST.find("mifos_client_search").orElseThrow();
+    }
+
+    /**
+     * An unbound parameter is not an error to Fineract, it is silently dropped, and the tool
+     * then hands the model every client in the office instead of the one being asked about.
+     */
+    @Test
+    void theFilterIsOneFineractActuallyBinds() {
+        String path = searchTool().rest().path();
+
+        assertThat(path).isEqualTo("/clients?displayName={query}");
+        assertThat(path).doesNotContain("?name=");
+    }
+
+    @Test
+    void theQueryIsDeclaredAsAName() {
+        ToolDefinition.Param query = searchTool().params().stream()
+                .filter((p) -> p.name().equals("query"))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(query.isName()).isTrue();
+        assertThat(query.required()).isTrue();
+    }
+
+    /** An officer types a name the way people type names, and means the same person each time. */
+    @Test
+    void howeverItIsTypedItGoesOnTheWireAsAName() {
+        assertThat(FineractRestToolExecutor.asStoredName("aisha")).isEqualTo("Aisha");
+        assertThat(FineractRestToolExecutor.asStoredName("AISHA")).isEqualTo("Aisha");
+        assertThat(FineractRestToolExecutor.asStoredName("aIsHa")).isEqualTo("Aisha");
+        assertThat(FineractRestToolExecutor.asStoredName("Aisha")).isEqualTo("Aisha");
+    }
+
+    @Test
+    void everyWordOfAFullNameIsANameInItsOwnRight() {
+        assertThat(FineractRestToolExecutor.asStoredName("aisha bello")).isEqualTo("Aisha Bello");
+        assertThat(FineractRestToolExecutor.asStoredName("MARIA DE SOUZA")).isEqualTo("Maria De Souza");
+    }
+
+    /** Hyphens and apostrophes start a word in a name as surely as a space does. */
+    @Test
+    void punctuationInsideANameStartsANewWord() {
+        assertThat(FineractRestToolExecutor.asStoredName("anne-marie")).isEqualTo("Anne-Marie");
+        assertThat(FineractRestToolExecutor.asStoredName("o'brien")).isEqualTo("O'Brien");
+    }
+
+    @Test
+    void nothingTypedIsNothingSent() {
+        assertThat(FineractRestToolExecutor.asStoredName("")).isEmpty();
+        assertThat(FineractRestToolExecutor.asStoredName(null)).isEmpty();
+    }
+
+    /** Searching is a read. It must never have become anything else. */
+    @Test
+    void searchingForSomebodyChangesNothing() {
+        assertThat(searchTool().write()).isFalse();
+        assertThat(searchTool().rest().method()).isEqualTo("GET");
+    }
+
+    /**
+     * A search returns whole client records. The name has to survive or the answer is useless,
+     * but the phone number and the national id are nobody's business here.
+     */
+    @Test
+    void aSearchStillHidesWhatTheOfficerDidNotAskFor() {
+        assertThat(searchTool().redactFields()).containsExactlyInAnyOrder("externalId", "mobileNo");
+    }
+}


### PR DESCRIPTION
Follow-up to #443, which I got wrong. It is on `main` now, so this is worth taking quickly.

## What is broken

#443 moved client search from `/search` to `/clients?name={query}`. Fineract binds no filter called `name` on that resource. It is not an error, it is silently dropped, so the endpoint returns **every client in the office** and the tool hands that whole list to the model, which then picks something out of it.

Against the community sandbox with four clients:

| request | returns |
|---|---|
| `/clients?name=aisha` | all 4 |
| `/clients?name=NotExist` | all 4 |
| `/clients?name=zzzzz` | all 4 |

So an officer asking after one client gets a confident answer assembled from a list of everyone. At one client it looks correct. At a thousand it is wrong, and it puts every client's record in front of the model to answer a question about one of them.

## How it got through

I checked it by hand against a database holding exactly one client. With one row, "filtered to the one match" and "ignored the filter and returned all one of them" are the same number, so it read as a pass, and I reported it as verified. It only surfaced when a later test seeded four clients and a rejection check started matching records it had never created.

A reviewer had flagged the parameter on #443 and suggested `displayName`. I dismissed it using that same one-row evidence. They were right.

## The fix

`displayName` is the filter the resource actually binds, and it matches on part of a name:

| request | returns |
|---|---|
| `/clients?displayName=Aisha` | Aisha Bello |
| `/clients?displayName=Bello` | Aisha Bello |
| `/clients?displayName=zzzzz` | nothing |

It is case-sensitive on a case-sensitive collation, which is the original complaint from #443 and still real. So the casing is handled here rather than wished away: the manifest marks the parameter `format: name`, and a name is normalised to the casing a name is entered in before it goes on the wire. Hyphens and apostrophes begin a word, so `anne-marie` and `o'brien` survive it.

Verified end to end through the gateway and a live model, against the sandbox with four clients:

```
"search for the client aisha"   -> Aisha Bello, and nobody else
"search for the client okafor"  -> Amara Okafor, and nobody else
```

and directly against Fineract: `aisha`, `AISHA`, `aIsHa` and `bello` each return Aisha Bello alone.

## Tests

`ClientSearchTest` pins the query parameter to `displayName` and asserts the path does not contain `?name=`, because that is the specific mistake, and a wrong parameter name fails silently and open rather than throwing. It also covers the casing, punctuation inside names, empty input, and that search is still a read that redacts `externalId` and `mobileNo`.

143 gateway tests pass.

## Note for reviewers

`firstname` and `lastname` are also unbound on this resource and behave the same way, returning everything. Worth knowing before anyone reaches for them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Client search now supports partial matches using display names.
  - Names entered for supported searches are formatted consistently for improved matching.
  - Search handling now supports names containing spaces, hyphens, and apostrophes.

- **Bug Fixes**
  - Improved handling of empty client-search input.
  - Client search continues to use read-only retrieval while excluding sensitive external ID and mobile-number details from results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->