### PR TITLE
docs(gateway): document FINERACT_API_PATH and the rest of the configuration

### DIFF
--- a/gateway/README.md
+++ b/gateway/README.md
@@ -102,12 +102,42 @@ Point the web-app at it: `copilotMcpBaseUrl: 'http://localhost:8090'`.
 | Env var | Default | Meaning |
 |---|---|---|
 | `COPILOT_PORT` | `8090` | Listen port |
-| `COPILOT_LLM_PROVIDER` | `mock` | `mock` \| `groq` \| `ollama` (or any OpenAI-compatible via `COPILOT_LLM_BASE_URL`) |
-| `COPILOT_LLM_API_KEY` | — | Provider key — **server-side only** |
+| `COPILOT_LLM_PROVIDER` | `mock` | `mock` \| `groq` \| `openai` \| `ollama`. Anything else OpenAI-compatible works too, by supplying `COPILOT_LLM_BASE_URL` |
+| `COPILOT_LLM_API_KEY` | — | Provider key — **server-side only**. Not needed for `mock` |
 | `COPILOT_LLM_MODEL` | `qwen/qwen3.6-27b` | Model id |
+| `COPILOT_LLM_BASE_URL` | — | Only for an OpenAI-compatible engine the gateway does not know by name: Azure OpenAI, vLLM, OpenRouter, a private gateway. Leave unset for `groq`, `openai` and `ollama`, which resolve their own. Set, it overrides the provider's default |
 | `FINERACT_BASE_URL` | `https://sandbox.mifos.community` | The Fineract the tools call. **Must be the same Fineract the web-app is configured against**, or the drift guard refuses to run |
+| `FINERACT_API_PATH` | `/fineract-provider/api/v1` | Where that Fineract publishes its API, under the base URL. See below |
 | `COPILOT_ALLOWED_ORIGINS` | `http://localhost:4200` | CORS allow-list (comma-separated) |
 | `COPILOT_DATA_RESIDENCY` | `cloud` | Operator's explicit acknowledgement of where tool results flow |
+| `COPILOT_APPROVAL_TTL_SECONDS` | `300` | How long a pending confirmation card stays approvable before it expires |
+
+#### Pointing at a Fineract behind an API manager
+
+`FINERACT_BASE_URL` and `FINERACT_API_PATH` are separate because they answer different
+questions: *which* Fineract, and *where it publishes its API*. A bare Fineract answers on the
+default path, so most deployments never set the second one. Behind an API manager it does not,
+and the same server is republished somewhere else entirely.
+
+The community sandbox is the example to hand. Both of these reach the same Fineract:
+
+```bash
+# a bare Fineract
+FINERACT_BASE_URL=https://sandbox.mifos.community
+FINERACT_API_PATH=/fineract-provider/api/v1      # the default, so it can be omitted
+
+# the same server behind the community API manager
+FINERACT_BASE_URL=https://apis.mifos.community
+FINERACT_API_PATH=/1.0/core/api/v1
+```
+
+Getting this wrong looks like the gateway being broken rather than misconfigured: every tool
+call returns 404 and the assistant reports that a client who exists cannot be found. If tools
+fail while `/health` is happy, check this pair first.
+
+Whatever the web-app is configured against has to match `FINERACT_BASE_URL`. The web-app sends
+its own backend origin on every turn and the gateway refuses to run when the two differ, so a
+Copilot can never write to a different bank than the one on the officer's screen.
 
 ### Endpoints (wire contract v1)
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -171,7 +171,7 @@ call, which is to say `loanId 12` and `28000`, and that is not something anyone 
     - { name: approvedOnDate, type: string, required: true, label: Approval date, format: date }
     - { name: approvedLoanAmount, type: number, label: Approved amount, format: money }
   enrich:
-    - path: /fineract-provider/api/v1/loans/{loanId}
+    - path: /loans/{loanId}
       currency: currency.code
       fields:
         Client: clientName
@@ -180,7 +180,7 @@ call, which is to say `loanId 12` and `28000`, and that is not something anyone 
         Applied for: "#money:principal"
   rest:
     method: POST
-    path: /fineract-provider/api/v1/loans/{loanId}?command=approve
+    path: /loans/{loanId}?command=approve
     body: '{"approvedOnDate":"${approvedOnDate}", ...}'
 ```
 
@@ -190,6 +190,11 @@ call, which is to say `loanId 12` and `28000`, and that is not something anyone 
 | `format` | `money` or `date`, so `28000` is shown as `USD 28,000.00` and `today` as `21 August 2026` |
 | `show: false` | Hides an identifier. An account number and a product name mean something to a person; a database id does not |
 | `enrich` | Reads performed with the officer's own credential before the card is shown, so it can name the account, the product and the client. A list, because approving a new loan means naming both the client and the product and those live behind different endpoints |
+
+Every `path` in the manifest is relative to the resource root, never the whole URL. The gateway
+joins `FINERACT_BASE_URL` and `FINERACT_API_PATH` in front of it, so writing the API root into
+a tool here would produce it twice and every call would 404. Which root to use is a property of
+the deployment, not of the tool, which is why it is configuration.
 | `enrich[].currency` | Dotted path to the currency the record is held in, which is where the `USD` prefix comes from |
 | `fields` | Card row label to a dotted path in the response. Prefix a path with `#money:` to format it as an amount |
 | `summary` | The card's one-line title. `{clientName}` and `{productName}` are filled from the enrichment |


### PR DESCRIPTION
@victor-romero asked where `FINERACT_BASE_URL` and `FINERACT_API_PATH` are documented.

`FINERACT_BASE_URL` is in the config table. **`FINERACT_API_PATH` was not documented anywhere.** It appeared only in `application.yaml` and in a code comment inside `tools.yaml`. I added the variable in #440 and never wrote it up.

## Why this one matters

It is the variable an operator is most likely to need and least likely to guess. A bare Fineract answers on the default path, so most deployments never set it. Behind an API manager the same server is republished somewhere else entirely, and nothing told anyone that.

Getting it wrong does not look like a configuration problem. `/health` stays happy, because it does not touch Fineract, while every tool call returns 404 and the assistant reports that a client who plainly exists cannot be found.

The docs now carry a worked example, using the community sandbox because it publishes the same Fineract both ways:

```bash
# a bare Fineract
FINERACT_BASE_URL=https://sandbox.mifos.community
FINERACT_API_PATH=/fineract-provider/api/v1      # the default, so it can be omitted

# the same server behind the community API manager
FINERACT_BASE_URL=https://apis.mifos.community
FINERACT_API_PATH=/1.0/core/api/v1
```

Both pairs verified against the live server, `200` on `/offices`.

## Also fixed, same defect

Two more variables were undocumented for the same reason, and the provider list had drifted from the code:

| | |
|---|---|
| `COPILOT_LLM_BASE_URL` | existed only as a footnote inside another row, now its own entry saying when it is and is not needed |
| `COPILOT_APPROVAL_TTL_SECONDS` | undocumented; it controls how long a pending confirmation card stays approvable |
| `COPILOT_LLM_PROVIDER` | listed `mock \| groq \| ollama`. The code has accepted `openai` for some time |

Every one of the ten variables in `application.yaml` is now in the table. I checked by extracting them from the yaml and asserting each appears in the README, rather than by reading it over.

Documentation only, no code change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented OpenAI as a supported language model provider.
  * Added guidance for optional server-side provider API keys.
  * Added configuration details for Fineract API paths and approval-card expiration.
  * Explained setup and troubleshooting for Fineract deployments behind API managers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->