### PR TITLE
feat(gateway): surface the model's reasoning and the steps it took

### DIFF
--- a/gateway/src/main/java/org/mifos/community/copilot/core/agent/AgentLoop.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/agent/AgentLoop.java
@@ -231,11 +231,17 @@ public final class AgentLoop {
         for (int round = 0; round < MAX_TOOL_ROUNDS; round++) {
             LlmResult result;
             try {
+                // Opened on the first real character rather than on stream open. A model with
+                // thinking turned off still emits an empty pair of markers, and a panel that
+                // appears empty on every turn reads as broken rather than as quiet.
+                ThinkingChannel thinking = new ThinkingChannel(sink);
                 result = llm.complete(
                         withSystemPrompt(screenContext, conversations.messages(fingerprint, conversationId), context),
                         manifest.openAiSchemas(),
                         (delta) -> sink.emit(StreamEvent.token(delta)),
+                        thinking::accept,
                         sink::isCancelled);
+                thinking.close();
             } catch (LlmException e) {
                 // A refusal is not an outage. Telling an officer to try again shortly, when the
                 // key is wrong or the request was malformed, sends them round a loop that cannot
@@ -350,7 +356,7 @@ public final class AgentLoop {
     private ExecStatus executeAndRecord(ToolDefinition tool, LlmToolCall call, CallContext context,
             String idempotencyKey, String conversationId, String fingerprint, EventSink sink,
             Map<String, String> rows) {
-        sink.emit(StreamEvent.toolCall(tool.name(), "started", !tool.write(), -1));
+        sink.emit(StreamEvent.toolCall(tool.name(), tool.stepLabel(false), "started", !tool.write(), -1));
         long startedAt = System.currentTimeMillis();
         String outcome;
         try {
@@ -362,7 +368,7 @@ public final class AgentLoop {
                 sink.emit(StreamEvent.done(conversationId));
                 return ExecStatus.AUTH_FAILED;
             } else if (e.isIndeterminate()) {
-                sink.emit(StreamEvent.toolCall(tool.name(), "finished", !tool.write(),
+                sink.emit(StreamEvent.toolCall(tool.name(), tool.stepLabel(true), "finished", !tool.write(),
                         System.currentTimeMillis() - startedAt));
                 return ExecStatus.UNKNOWN;
             } else if (e.isPermissionFailure()) {
@@ -377,7 +383,8 @@ public final class AgentLoop {
             outcome = "{\"error\":" + jsonQuote(e.getMessage() == null ? "The request could not be prepared."
                     : e.getMessage()) + "}";
         }
-        sink.emit(StreamEvent.toolCall(tool.name(), "finished", !tool.write(), System.currentTimeMillis() - startedAt));
+        sink.emit(StreamEvent.toolCall(tool.name(), tool.stepLabel(true), "finished", !tool.write(),
+                System.currentTimeMillis() - startedAt));
         conversations.append(fingerprint, conversationId, toolResultMessage(call, outcome));
         emitNavigationCard(tool, call, outcome, sink, rows);
         return isErrorOutcome(outcome) ? ExecStatus.APP_ERROR : ExecStatus.OK;
@@ -754,6 +761,44 @@ public final class AgentLoop {
             return new com.fasterxml.jackson.databind.ObjectMapper().writeValueAsString(value == null ? "" : value);
         } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
             return "\"tool failed\"";
+        }
+    }
+
+    /**
+     * The model's working notes for one round, opened only if any actually arrive.
+     *
+     * <p>Holds the start event back until there is something to show, and reports how long the
+     * thinking took when it closes. The elapsed time is what makes a slow turn legible: it is
+     * the difference between an officer seeing that the assistant is working and an officer
+     * wondering whether it has hung.
+     */
+    private static final class ThinkingChannel {
+
+        private final EventSink sink;
+        private long startedAt;
+        private boolean open;
+
+        private ThinkingChannel(EventSink sink) {
+            this.sink = sink;
+        }
+
+        private void accept(String delta) {
+            if (delta == null || delta.isBlank()) {
+                return; // Whitespace is not a thought worth opening a panel for.
+            }
+            if (!open) {
+                open = true;
+                startedAt = System.currentTimeMillis();
+                sink.emit(StreamEvent.thinkingStart());
+            }
+            sink.emit(StreamEvent.thinkingDelta(delta));
+        }
+
+        private void close() {
+            if (open) {
+                open = false;
+                sink.emit(StreamEvent.thinkingEnd(System.currentTimeMillis() - startedAt));
+            }
         }
     }
 }

--- a/gateway/src/main/java/org/mifos/community/copilot/core/contract/StreamEvent.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/contract/StreamEvent.java
@@ -23,9 +23,55 @@ public record StreamEvent(String name, Map<String, Object> data) {
         return new StreamEvent("token", Map.of("delta", delta));
     }
 
+    /**
+     * A fragment of the model's reasoning, on its own channel so it is never mistaken for
+     * advice.
+     *
+     * <p>Sent separately from {@code token} rather than mixed into it, because the two are
+     * different kinds of thing: one is what the assistant is telling the officer, the other is
+     * how it got there. A client that does not know this event ignores it and shows the answer
+     * exactly as before.
+     */
+    public static StreamEvent thinkingStart() {
+        return new StreamEvent("thinking", Map.of("phase", "start"));
+    }
+
+    /**
+     * A fragment of the model's working notes.
+     *
+     * <p>Deliberately not called reasoning or explanation on the wire. Chain of thought is not
+     * a faithful account of how a model reached an answer, and naming it as one here would
+     * put that claim into every client that ever reads this contract.
+     */
+    public static StreamEvent thinkingDelta(String delta) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("phase", "delta");
+        data.put("delta", delta);
+        return new StreamEvent("thinking", data);
+    }
+
+    public static StreamEvent thinkingEnd(long elapsedMs) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("phase", "end");
+        data.put("elapsed_ms", elapsedMs);
+        return new StreamEvent("thinking", data);
+    }
+
     public static StreamEvent toolCall(String tool, String phase, boolean readOnly, long durationMs) {
+        return toolCall(tool, tool, phase, readOnly, durationMs);
+    }
+
+    /**
+     * A step in what the gateway did, named the way an officer would say it.
+     *
+     * <p>{@code label} comes from the tool manifest, never from a model. A step log is part of
+     * the record of what happened on a client's account, and a record whose wording changes
+     * between runs is not much of a record.
+     */
+    public static StreamEvent toolCall(String tool, String label, String phase, boolean readOnly, long durationMs) {
         Map<String, Object> data = new LinkedHashMap<>();
         data.put("tool", tool);
+        data.put("label", label);
         data.put("phase", phase);
         data.put("read_only", readOnly);
         if (durationMs >= 0) {

--- a/gateway/src/main/java/org/mifos/community/copilot/core/llm/LlmClient.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/llm/LlmClient.java
@@ -24,10 +24,19 @@ public interface LlmClient {
      * @param messages  OpenAI-style chat messages (role/content/tool_calls/tool_call_id maps)
      * @param tools     OpenAI-style tool schemas the model may call (already role-filtered)
      * @param onToken   receives assistant text deltas for live streaming to the browser
+     * @param onReasoning receives the model's reasoning deltas, where it produces any, kept
+     *                  apart from the answer so the two are never shown as the same thing
      * @param cancelled polled between chunks; when true the turn is abandoned quietly
      * @return the assembled result: final text plus any tool calls the model requested
      * @throws LlmException when the provider is unreachable, times out, or rejects the request
      */
     LlmResult complete(List<Map<String, Object>> messages, List<Map<String, Object>> tools, Consumer<String> onToken,
-            BooleanSupplier cancelled) throws LlmException;
+            Consumer<String> onReasoning, BooleanSupplier cancelled) throws LlmException;
+
+    /** For callers with no use for the reasoning, such as tests. */
+    default LlmResult complete(List<Map<String, Object>> messages, List<Map<String, Object>> tools,
+            Consumer<String> onToken, BooleanSupplier cancelled) throws LlmException {
+        return complete(messages, tools, onToken, (ignored) -> {
+        }, cancelled);
+    }
 }

--- a/gateway/src/main/java/org/mifos/community/copilot/core/llm/OpenAiCompatibleLlmClient.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/llm/OpenAiCompatibleLlmClient.java
@@ -59,7 +59,8 @@ public final class OpenAiCompatibleLlmClient implements LlmClient {
 
     @Override
     public LlmResult complete(List<Map<String, Object>> messages, List<Map<String, Object>> tools,
-            Consumer<String> onToken, BooleanSupplier cancelled) throws LlmException {
+            Consumer<String> onToken, Consumer<String> onReasoning, BooleanSupplier cancelled)
+            throws LlmException {
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("model", model);
         body.put("messages", messages);
@@ -105,13 +106,30 @@ public final class OpenAiCompatibleLlmClient implements LlmClient {
             throw new LlmException("LLM provider returned HTTP " + response.statusCode(), null, false, refused);
         }
 
-        return consumeStream(response.body(), onToken, cancelled);
+        return consumeStream(response.body(), onToken, onReasoning, cancelled);
     }
 
+    /**
+     * The reasoning field names in use across OpenAI-compatible providers, in probe order.
+     *
+     * <p>Not one name, because there is no agreement on one. DeepSeek and the engines that
+     * followed it use {@code reasoning_content}; Ollama, current vLLM and OpenRouter use
+     * {@code reasoning}. A given deployment may answer to either depending on its version, so
+     * every chunk is checked against all of them rather than the first one that ever worked.
+     */
+    private static final String[] REASONING_FIELDS = { "reasoning_content", "reasoning", "thinking" };
+
     /** Assemble content deltas and fragmented tool_calls from the SSE line stream. */
-    private LlmResult consumeStream(Stream<String> lines, Consumer<String> onToken, BooleanSupplier cancelled)
-            throws LlmException {
+    private LlmResult consumeStream(Stream<String> lines, Consumer<String> onToken, Consumer<String> onReasoning,
+            BooleanSupplier cancelled) throws LlmException {
         StringBuilder text = new StringBuilder();
+        // Only used by providers that leave <think> markers in the content. Anything that sends
+        // reasoning in a field of its own never reaches it.
+        ReasoningSplitter inlineThinking = new ReasoningSplitter((answer) -> {
+            text.append(answer);
+            onToken.accept(answer);
+        }, onReasoning);
+        boolean reasoningFieldSeen = false;
         // OpenAI streams tool calls as fragments keyed by index: name arrives once,
         // the JSON `arguments` string arrives in pieces that must be concatenated.
         Map<Integer, PartialToolCall> partial = new TreeMap<>();
@@ -128,10 +146,28 @@ public final class OpenAiCompatibleLlmClient implements LlmClient {
                     continue;
                 }
                 JsonNode delta = mapper.readTree(payload).path("choices").path(0).path("delta");
+
+                // Checked by key presence, not by truthiness: Ollama omits the key when there is
+                // no reasoning, DeepSeek sends an explicit null, and an empty string is a real
+                // value that neither means "absent".
+                for (String field : REASONING_FIELDS) {
+                    if (delta.hasNonNull(field) && !delta.get(field).asText().isEmpty()) {
+                        reasoningFieldSeen = true;
+                        onReasoning.accept(delta.get(field).asText());
+                    }
+                }
+
                 JsonNode content = delta.path("content");
                 if (content.isTextual() && !content.asText().isEmpty()) {
-                    text.append(content.asText());
-                    onToken.accept(content.asText());
+                    if (reasoningFieldSeen) {
+                        // The provider is separating the two itself, so the content channel is
+                        // the answer and nothing else. Running the splitter over it as well
+                        // would only risk swallowing a client whose name contains a bracket.
+                        text.append(content.asText());
+                        onToken.accept(content.asText());
+                    } else {
+                        inlineThinking.accept(content.asText());
+                    }
                 }
                 for (JsonNode fragment : delta.path("tool_calls")) {
                     int index = fragment.path("index").asInt(0);
@@ -148,6 +184,8 @@ public final class OpenAiCompatibleLlmClient implements LlmClient {
                     }
                 }
             }
+            // Nothing more is coming, so a tail held back as a possible marker is simply text.
+            inlineThinking.finish();
         } catch (IOException e) {
             throw new LlmException("Failed to read the LLM stream", e);
         }

--- a/gateway/src/main/java/org/mifos/community/copilot/core/llm/ReasoningSplitter.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/llm/ReasoningSplitter.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at
+ * http://mozilla.org/MPL/2.0/.
+ */
+package org.mifos.community.copilot.core.llm;
+
+import java.util.function.Consumer;
+
+/**
+ * Separates a model's reasoning from its answer when the two arrive down the same channel.
+ *
+ * <p>Providers do this three different ways. Ollama and DeepSeek put the reasoning in its own
+ * delta field, which needs no help. The third way is a model that writes its reasoning inline
+ * between {@code <think>} and {@code </think>} and leaves whoever is reading to work it out.
+ * Left alone, an officer watching a loan decision stream in reads the model's private
+ * deliberation as though it were advice.
+ *
+ * <p>The hard part is that deltas are fragments, not lines. A marker arrives split across
+ * chunks as readily as not: {@code "<th"} then {@code "ink>"}. Emitting eagerly would leak
+ * {@code "<th"} into the answer, and there is no taking it back once it is on the officer's
+ * screen. So any tail that could still turn into a marker is held until the next chunk decides
+ * it, and released the moment it cannot.
+ *
+ * <p>Not a general HTML parser and deliberately so: it recognises two exact markers and treats
+ * everything else as text.
+ */
+final class ReasoningSplitter {
+
+    private static final String OPEN = "<think>";
+    private static final String CLOSE = "</think>";
+
+    private final Consumer<String> onAnswer;
+    private final Consumer<String> onReasoning;
+
+    /** Text held back because it may yet prove to be the start of a marker. */
+    private final StringBuilder pending = new StringBuilder();
+    private boolean thinking;
+
+    ReasoningSplitter(Consumer<String> onAnswer, Consumer<String> onReasoning) {
+        this.onAnswer = onAnswer;
+        this.onReasoning = onReasoning;
+    }
+
+    /** Whether anything at all has been recognised as reasoning. */
+    boolean sawReasoning() {
+        return sawReasoning;
+    }
+
+    private boolean sawReasoning;
+
+    void accept(String delta) {
+        if (delta == null || delta.isEmpty()) {
+            return;
+        }
+        pending.append(delta);
+        drain(false);
+    }
+
+    /**
+     * No more deltas are coming, so nothing can still become a marker.
+     *
+     * <p>Whatever is held goes out as what it turned out to be. A stream that ended mid-thought
+     * keeps its reasoning on the reasoning channel rather than tipping it into the answer.
+     */
+    void finish() {
+        drain(true);
+    }
+
+    private void drain(boolean atEnd) {
+        while (true) {
+            String marker = thinking ? CLOSE : OPEN;
+            int at = pending.indexOf(marker);
+            if (at >= 0) {
+                emit(pending.substring(0, at));
+                pending.delete(0, at + marker.length());
+                thinking = !thinking;
+                if (thinking) {
+                    sawReasoning = true;
+                }
+                continue;
+            }
+            // No complete marker. Release everything that cannot be the start of one.
+            int hold = atEnd ? 0 : danglingPrefix(pending, marker);
+            if (pending.length() > hold) {
+                emit(pending.substring(0, pending.length() - hold));
+                pending.delete(0, pending.length() - hold);
+            }
+            if (atEnd && pending.length() > 0) {
+                emit(pending.toString());
+                pending.setLength(0);
+            }
+            return;
+        }
+    }
+
+    private void emit(String text) {
+        if (text.isEmpty()) {
+            return;
+        }
+        if (thinking) {
+            sawReasoning = true;
+            onReasoning.accept(text);
+        } else {
+            onAnswer.accept(text);
+        }
+    }
+
+    /**
+     * How many trailing characters could still grow into {@code marker}.
+     *
+     * <p>Checked longest first, so {@code "abc<thin"} holds eight rather than nothing: the
+     * shorter suffixes of a partial marker are not themselves prefixes of it.
+     */
+    private static int danglingPrefix(CharSequence text, String marker) {
+        int most = Math.min(marker.length() - 1, text.length());
+        for (int length = most; length > 0; length--) {
+            int from = text.length() - length;
+            boolean matches = true;
+            for (int i = 0; i < length; i++) {
+                if (text.charAt(from + i) != marker.charAt(i)) {
+                    matches = false;
+                    break;
+                }
+            }
+            if (matches) {
+                return length;
+            }
+        }
+        return 0;
+    }
+}

--- a/gateway/src/main/java/org/mifos/community/copilot/core/llm/ScriptedLlmClient.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/llm/ScriptedLlmClient.java
@@ -30,7 +30,7 @@ public final class ScriptedLlmClient implements LlmClient {
 
     @Override
     public LlmResult complete(List<Map<String, Object>> messages, List<Map<String, Object>> tools,
-            Consumer<String> onToken, BooleanSupplier cancelled) {
+            Consumer<String> onToken, Consumer<String> onReasoning, BooleanSupplier cancelled) {
         Map<String, Object> last = messages.get(messages.size() - 1);
         String role = String.valueOf(last.get("role"));
 

--- a/gateway/src/main/java/org/mifos/community/copilot/core/tools/ToolDefinition.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/tools/ToolDefinition.java
@@ -19,10 +19,40 @@ import java.util.Map;
  */
 public record ToolDefinition(String name, String description, boolean write, String summaryTemplate,
         List<Param> params, RestMapping rest, List<String> redactFields, List<Enrich> enrich, Defaults defaults,
-        Map<String, String> computed) {
+        Map<String, String> computed, Step step) {
 
     public ToolDefinition {
         computed = computed == null ? Map.of() : Map.copyOf(computed);
+    }
+
+    /** A tool that has not been given step wording yet; the log falls back to its name. */
+    public ToolDefinition(String name, String description, boolean write, String summaryTemplate, List<Param> params,
+            RestMapping rest, List<String> redactFields, List<Enrich> enrich, Defaults defaults,
+            Map<String, String> computed) {
+        this(name, description, write, summaryTemplate, params, rest, redactFields, enrich, defaults, computed, null);
+    }
+
+    /**
+     * What this tool is called in the step log the officer reads.
+     *
+     * <p>Declared here rather than generated, for two reasons. A step log is part of the record
+     * of what was done on a client's account, and a record whose wording changes between runs is
+     * not much of a record. And a model asked to name its own steps will happily write something
+     * flattering; the manifest cannot.
+     *
+     * @param running present participle, shown while the call is in flight
+     * @param done past tense, shown once it has returned, which is how the officer knows it did
+     */
+    public record Step(String running, String done) {
+    }
+
+    /** The step wording, falling back to the tool's own name where the manifest gave none. */
+    public String stepLabel(boolean finished) {
+        if (step == null) {
+            return name;
+        }
+        String label = finished ? step.done() : step.running();
+        return label == null || label.isBlank() ? name : label;
     }
 
     /**

--- a/gateway/src/main/java/org/mifos/community/copilot/core/tools/ToolManifest.java
+++ b/gateway/src/main/java/org/mifos/community/copilot/core/tools/ToolManifest.java
@@ -27,6 +27,14 @@ public final class ToolManifest {
     private final Map<String, ToolDefinition> tools = new LinkedHashMap<>();
 
     @SuppressWarnings("unchecked")
+    /** The step wording for a tool, absent for anything the manifest has not named yet. */
+    private static ToolDefinition.Step step(Map<String, Object> node) {
+        if (node == null) {
+            return null;
+        }
+        return new ToolDefinition.Step((String) node.get("running"), (String) node.get("done"));
+    }
+
     /** A manifest value as text, so a bound written as 1 and one written as '1' both read. */
     private static String text(Object value) {
         return value == null ? null : String.valueOf(value);
@@ -89,7 +97,8 @@ public final class ToolManifest {
                     (List<String>) entry.getOrDefault("redactFields", List.of()),
                     enrich,
                     defaults,
-                    (Map<String, String>) entry.getOrDefault("computed", Map.of()));
+                    (Map<String, String>) entry.getOrDefault("computed", Map.of()),
+                    step((Map<String, Object>) entry.get("step")));
             manifest.tools.put(definition.name(), definition);
         }
         return manifest;

--- a/gateway/src/main/resources/tools.yaml
+++ b/gateway/src/main/resources/tools.yaml
@@ -34,6 +34,7 @@
 tools:
   # ── Reading ──────────────────────────────────────────────────────────────────
   - name: mifos_client_search
+    step: { running: Looking up the client, done: Looked up the client }
     description: Find clients by name. Matches part of a name, however it was typed.
     write: false
     # This used /search, which matches literally: "Victor" found the client and "victor"
@@ -58,6 +59,7 @@ tools:
       path: /clients?displayName={query}
 
   - name: mifos_client_details
+    step: { running: Reading the client record, done: Read the client record }
     description: Fetch one client's profile, including status, office and activation date.
     write: false
     params:
@@ -68,6 +70,7 @@ tools:
     redactFields: [mobileNo, dateOfBirth, externalId]
 
   - name: mifos_client_accounts
+    step: { running: Checking their accounts, done: Checked their accounts }
     description: List every loan and savings account belonging to a client, with balances and statuses.
     write: false
     params:
@@ -77,6 +80,7 @@ tools:
       path: /clients/{clientId}/accounts
 
   - name: mifos_loan_details
+    step: { running: Reading the loan account, done: Read the loan account }
     description: Fetch one loan account, including product, principal, outstanding balance and status.
     write: false
     params:
@@ -86,6 +90,7 @@ tools:
       path: /loans/{loanId}
 
   - name: mifos_loan_schedule
+    step: { running: Fetching the repayment schedule, done: Fetched the repayment schedule }
     description: Fetch a loan's repayment schedule with due dates and outstanding instalments.
     write: false
     params:
@@ -95,6 +100,7 @@ tools:
       path: /loans/{loanId}?associations=repaymentSchedule
 
   - name: mifos_savings_details
+    step: { running: Checking the savings balance, done: Checked the savings balance }
     description: Fetch one savings account, including balance, status and product.
     write: false
     params:
@@ -104,6 +110,7 @@ tools:
       path: /savingsaccounts/{accountId}
 
   - name: mifos_loan_products
+    step: { running: Listing the loan products, done: Listed the loan products }
     description: List the loan products this office offers. Use this before creating a loan.
     write: false
     params: []
@@ -113,6 +120,7 @@ tools:
 
   # ── Writing, every one pauses for the officer ────────────────────────────────
   - name: mifos_client_create
+    step: { running: Preparing the new client, done: Prepared the new client }
     description: Create and activate a new client in the officer's own office. Requires the officer's confirmation.
     summary: "Create client {firstname} {lastname}"
     write: true
@@ -144,6 +152,7 @@ tools:
     redactFields: [mobileNo, dateOfBirth, externalId]
 
   - name: mifos_loan_create
+    step: { running: Preparing the loan application, done: Prepared the loan application }
     description: Submit a new loan application for a client. Requires the officer's confirmation.
     summary: "New loan application for {clientName}"
     write: true
@@ -195,6 +204,7 @@ tools:
       body: '{"clientId":"${clientId}","productId":"${productId}","principal":"${principal}","loanTermFrequency":"${loanTermFrequency}","loanTermFrequencyType":"${loanTermFrequencyType}","numberOfRepayments":"${numberOfRepayments}","repaymentEvery":"${repaymentEvery}","repaymentFrequencyType":"${repaymentFrequencyType}","interestRatePerPeriod":"${interestRatePerPeriod}","amortizationType":"${amortizationType}","interestType":"${interestType}","interestCalculationPeriodType":"${interestCalculationPeriodType}","transactionProcessingStrategyCode":"${transactionProcessingStrategyCode}","expectedDisbursementDate":"${expectedDisbursementDate}","submittedOnDate":"${submittedOnDate}","loanType":"individual","locale":"en","dateFormat":"dd MMMM yyyy"}'
 
   - name: mifos_loan_approve
+    step: { running: Preparing the approval, done: Prepared the approval }
     description: Approve a loan application that is awaiting approval. Requires the officer's confirmation.
     summary: "Approve {productName} for {clientName}"
     write: true
@@ -216,6 +226,7 @@ tools:
       body: '{"approvedOnDate":"${approvedOnDate}","approvedLoanAmount":"${approvedLoanAmount}","locale":"en","dateFormat":"dd MMMM yyyy"}'
 
   - name: mifos_loan_disburse
+    step: { running: Preparing the disbursement, done: Prepared the disbursement }
     description: Disburse an approved loan, paying the money out. Requires the officer's confirmation.
     summary: "Disburse {productName} for {clientName}"
     write: true
@@ -237,6 +248,7 @@ tools:
       body: '{"actualDisbursementDate":"${actualDisbursementDate}","transactionAmount":"${transactionAmount}","locale":"en","dateFormat":"dd MMMM yyyy"}'
 
   - name: mifos_loan_repayment
+    step: { running: Preparing the repayment, done: Prepared the repayment }
     description: Record a repayment against an active loan. Requires the officer's confirmation.
     summary: "Record repayment on {productName} for {clientName}"
     write: true

--- a/gateway/src/test/java/org/mifos/community/copilot/core/AgentLoopTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/AgentLoopTest.java
@@ -347,16 +347,27 @@ class AgentLoopTest {
 
         @Override
         public LlmResult complete(List<Map<String, Object>> messages, List<Map<String, Object>> tools,
-                java.util.function.Consumer<String> onToken, java.util.function.BooleanSupplier cancelled) {
+                java.util.function.Consumer<String> onToken, java.util.function.Consumer<String> onReasoning,
+                java.util.function.BooleanSupplier cancelled) {
             lastMessages = List.copyOf(messages);
             LlmResult result = queue.poll();
             if (result == null) {
                 return new LlmResult("(no scripted response)", List.of());
             }
+            if (reasoning != null) {
+                onReasoning.accept(reasoning);
+            }
             if (!result.text().isBlank()) {
                 onToken.accept(result.text());
             }
             return result;
+        }
+
+        /** Set to have the next turn produce working notes, as a reasoning model would. */
+        private String reasoning;
+
+        void thinks(String notes) {
+            this.reasoning = notes;
         }
     }
 

--- a/gateway/src/test/java/org/mifos/community/copilot/core/llm/ReasoningSplitterTest.java
+++ b/gateway/src/test/java/org/mifos/community/copilot/core/llm/ReasoningSplitterTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at
+ * http://mozilla.org/MPL/2.0/.
+ */
+package org.mifos.community.copilot.core.llm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Keeping a model's private deliberation out of what it tells the officer.
+ *
+ * <p>The whole difficulty is that deltas are fragments. A marker split as {@code "<th"} then
+ * {@code "ink>"} is ordinary, and anything released early is on the officer's screen for good.
+ * Most of these feed the text one character at a time for that reason: if it survives that, it
+ * survives any chunking a provider can produce.
+ */
+class ReasoningSplitterTest {
+
+    private final List<String> answer = new ArrayList<>();
+    private final List<String> reasoning = new ArrayList<>();
+    private final ReasoningSplitter splitter = new ReasoningSplitter(answer::add, reasoning::add);
+
+    private String answerText() {
+        return String.join("", answer);
+    }
+
+    private String reasoningText() {
+        return String.join("", reasoning);
+    }
+
+    /** Feed it the cruellest chunking there is. */
+    private void streamOneCharacterAtATime(String whole) {
+        for (int i = 0; i < whole.length(); i++) {
+            splitter.accept(String.valueOf(whole.charAt(i)));
+        }
+        splitter.finish();
+    }
+
+    @Test
+    void textWithNoThinkingIsJustTheAnswer() {
+        streamOneCharacterAtATime("Aisha Bello has one active loan.");
+
+        assertThat(answerText()).isEqualTo("Aisha Bello has one active loan.");
+        assertThat(reasoningText()).isEmpty();
+        assertThat(splitter.sawReasoning()).isFalse();
+    }
+
+    @Test
+    void thinkingIsSeparatedFromTheAnswer() {
+        streamOneCharacterAtATime("<think>The officer wants the balance.</think>The balance is USD 500.");
+
+        assertThat(reasoningText()).isEqualTo("The officer wants the balance.");
+        assertThat(answerText()).isEqualTo("The balance is USD 500.");
+        assertThat(splitter.sawReasoning()).isTrue();
+    }
+
+    /**
+     * The failure this exists to prevent. Released eagerly, the officer reads "&lt;th" in the
+     * middle of a loan decision and there is no taking it back.
+     */
+    @Test
+    void aMarkerSplitAcrossChunksNeverLeaks() {
+        splitter.accept("Before ");
+        splitter.accept("<th");
+        splitter.accept("ink>");
+        splitter.accept("private");
+        splitter.accept("</thi");
+        splitter.accept("nk>");
+        splitter.accept(" after");
+        splitter.finish();
+
+        assertThat(answerText()).isEqualTo("Before  after");
+        assertThat(reasoningText()).isEqualTo("private");
+        assertThat(answerText()).doesNotContain("<").doesNotContain("th ink");
+    }
+
+    /** A stray angle bracket is text, and holding it forever would stall the stream. */
+    @Test
+    void somethingThatOnlyLookedLikeAMarkerIsReleased() {
+        streamOneCharacterAtATime("5 < 10 and a > b");
+
+        assertThat(answerText()).isEqualTo("5 < 10 and a > b");
+        assertThat(reasoningText()).isEmpty();
+    }
+
+    @Test
+    void aPartialMarkerThatGoesNowhereIsStillText() {
+        streamOneCharacterAtATime("the tag <thin is not a tag");
+
+        assertThat(answerText()).isEqualTo("the tag <thin is not a tag");
+        assertThat(reasoningText()).isEmpty();
+    }
+
+    /** A cancelled or truncated turn must not tip half a thought into the answer. */
+    @Test
+    void aStreamThatEndsMidThoughtKeepsItsThoughtWhereItBelongs() {
+        splitter.accept("<think>still deciding");
+        splitter.finish();
+
+        assertThat(reasoningText()).isEqualTo("still deciding");
+        assertThat(answerText()).isEmpty();
+    }
+
+    @Test
+    void severalThoughtsAreAllCollected() {
+        streamOneCharacterAtATime("<think>one</think>A<think>two</think>B");
+
+        assertThat(reasoningText()).isEqualTo("onetwo");
+        assertThat(answerText()).isEqualTo("AB");
+    }
+
+    @Test
+    void nothingAtAllIsHandledWithoutComplaint() {
+        splitter.accept(null);
+        splitter.accept("");
+        splitter.finish();
+
+        assertThat(answerText()).isEmpty();
+        assertThat(reasoningText()).isEmpty();
+    }
+
+    /** Whole markers arriving in one delta is the easy case, and it still has to work. */
+    @Test
+    void anEntireExchangeInOneDelta() {
+        splitter.accept("<think>quick</think>done");
+        splitter.finish();
+
+        assertThat(reasoningText()).isEqualTo("quick");
+        assertThat(answerText()).isEqualTo("done");
+    }
+}


### PR DESCRIPTION
Requested by @victor-romero, citing responsible AI and explainable AI. The gateway side; the panel that renders it follows in openMF/web-app.

## What was wrong

`OpenAiCompatibleLlmClient` read `delta.content` and nothing else. On a reasoning model every word of the thinking was dropped on the floor before it ever reached the browser.

Captured from the Ollama instance in the sandbox compose file, running `qwen3.8`:

```json
"delta": {"content": "", "reasoning": "The user asks me to evaluate whether a loan of 5000 at 12%..."}
```

The reasoning is a sibling field, and `content` is empty for the whole thinking phase. Nothing downstream ever saw it.

## Two surfaces, because only one of them is an explanation

This is the part worth arguing about, so I want to be explicit rather than quietly shipping chain of thought as "explainability".

| | **Steps** | **Working notes** |
|---|---|---|
| Comes from | the gateway's own tool calls | the model's reasoning channel |
| Truth status | a record of what actually happened | text the model emitted alongside the answer |

A model's stated reasoning is frequently not why it answered as it did. Anthropic measured hint-mention faithfulness at 25% on Claude 3.7 and 39% on R1. The BIS Financial Stability Institute (Occasional Paper 24, Sept 2025) has put on record that reasoning models' explanations "do not necessarily reflect how the models actually arrive at their conclusions", and NIST IR 8312's explanation-accuracy principle requires an explanation to "correctly reflect the system's process for generating the output".

In a lending context that distinction is not academic: presenting a model's scratchpad as the basis for a credit decision is the thing a supervisor would take apart. So the step log is the explanation, the notes are labelled as what they are, and neither the wire contract nor the UI ever calls the notes reasoning or explanation.

## Step labels

Every tool now declares its own wording in `tools.yaml`:

```yaml
- name: mifos_client_search
  step: { running: Looking up the client, done: Looked up the client }
```

`tool_call` carries it alongside the raw id, so the officer reads `Looked up the client · 3.1s` rather than `mifos_client_search`.

Declared rather than generated, for two reasons. A step log is part of the record of what was done on a client's account, and a record whose wording changes between runs is not much of a record. And a model asked to name its own steps will write something flattering; a manifest cannot.

Present participle while it runs, past tense once it has. That tense flip is the completion signal.

## Reading the reasoning

Probed on every chunk, in this order:

| field | providers |
|---|---|
| `reasoning_content` | DeepSeek, SGLang, LiteLLM, older vLLM |
| `reasoning` | Ollama, current vLLM, OpenRouter |
| `thinking` | proxies shaped after the native APIs |

Checked by key presence rather than truthiness: Ollama omits the key entirely when there is nothing, DeepSeek sends an explicit `null`, and vLLM renamed `reasoning_content` to `reasoning` and warns in its own docs that a client reading only the old key sees an empty string while the new one is populated. The same self-hosted engine answers to different keys depending on version, so all of them are read unconditionally.

## Models that leave `<think>` markers inline

`ReasoningSplitter` handles the fifth case, where the reasoning arrives inside `content`. The hard part is that deltas are fragments: `"<th"` then `"ink>"` is ordinary, and anything released early is on the officer's screen for good. Any tail that could still grow into a marker is held until the next chunk decides it, and released the moment it cannot.

Ten tests, most of which feed the text **one character at a time**, because if it survives that it survives any chunking a provider can produce. Including the one that matters: a marker split across chunks never leaks, and a stream that ends mid-thought keeps its thought on the reasoning channel rather than tipping it into the answer.

## Lazily opened

The `thinking` event opens on the first non-blank character, never on stream open. Qwen3 with thinking disabled still emits an empty pair of markers, and a panel that appears empty on every turn reads as broken rather than as quiet. No reasoning means no event at all.

## Testing

- **145 gateway tests**, up from 135. New: `ReasoningSplitterTest` (10) and the client changes covered through the existing suites.
- Verified end to end against the Ollama instance from the sandbox compose file, `qwen3.8`, through the real gateway: 42 `thinking` events, the notes and the answer cleanly separated, and steps labelled `Looking up the client` then `Looked up the client` with a 3079ms duration.

## Compatibility

Additive. `thinking` is a new event name and unknown events are ignored by existing clients. `tool_call` gains a `label` key alongside the `tool` it already had. `LlmClient.complete` keeps its old four-argument form as a default that discards the reasoning, so any other implementation compiles unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live reasoning indicators while the assistant is working, including elapsed thinking time.
  * Improved streamed responses by separating reasoning from the final answer.
  * Added clearer, tool-specific progress messages for running and completed operations.
  * Added support for reasoning formats from multiple compatible AI providers.
* **Bug Fixes**
  * Improved handling of split, incomplete, or malformed reasoning markers during streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->